### PR TITLE
[WIP] New EnqueueNewPages Launch option

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/ScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/ScreenshotTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using PuppeteerSharp.Media;
 using Xunit;
 using Xunit.Abstractions;
+using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.Tests.PageTests
 {

--- a/lib/PuppeteerSharp.Tests/PageTests/ScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/ScreenshotTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using PuppeteerSharp.Media;
 using Xunit;
 using Xunit.Abstractions;
-using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.Tests.PageTests
 {

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -29,7 +29,7 @@ namespace PuppeteerSharp
         /// Use interchangeably with `browserWSEndpoint` to let Puppeteer fetch it from <see href="https://chromedevtools.github.io/devtools-protocol/#how-do-i-access-the-browser-target">metadata endpoin</see>.
         /// </summary>
         public string BrowserURL { get; set; }
-        
+
         /// <summary>
         /// Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
         /// </summary>
@@ -72,5 +72,13 @@ namespace PuppeteerSharp
         /// Setting this to <c>false</c> proved to work in .NET Core but it tends to fail on .NET Framework.
         /// </remarks>
         public bool EnqueueTransportMessages { get; set; } = true;
+
+        /// <summary>
+        /// If `true`, the browser will enqueue all <seealso cref="Browser.NewPageAsync"/> calls in the <seealso cref="Browser.ScreenshotTaskQueue"/>.
+        /// So new pages call won't interfere with the <seealso cref="Page.ScreenshotBase64Async(ScreenshotOptions)"/> method call.
+        /// EnqueueNewPages might be needed when using Chromium with <seealso cref="LaunchOptions.Headless"/> in false and making calls in parallel.
+        /// It is false by default because enqueuing <seealso cref="Browser.NewPageAsync"/> it's not necesarry all the time and it's a performance hit.
+        /// </summary>
+        public bool EnqueueNewPages { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/IBrowserOptions.cs
+++ b/lib/PuppeteerSharp/IBrowserOptions.cs
@@ -8,12 +8,20 @@
         /// <summary>
         /// Whether to ignore HTTPS errors during navigation. Defaults to false.
         /// </summary>
-        bool IgnoreHTTPSErrors { get; }
+        bool IgnoreHTTPSErrors { get; set; }
 
         /// <summary>
         /// Gets or sets the default Viewport.
         /// </summary>
         /// <value>The default Viewport.</value>
         ViewPortOptions DefaultViewport { get; set; }
+
+        /// <summary>
+        /// If `true`, the browser will enqueue all <seealso cref="Browser.NewPageAsync"/> calls in the <seealso cref="Browser.ScreenshotTaskQueue"/>.
+        /// So new pages call won't interfere with the <seealso cref="Page.ScreenshotBase64Async(ScreenshotOptions)"/> method call.
+        /// EnqueueNewPages might be needed when using Chromium with <seealso cref="LaunchOptions.Headless"/> in false and making calls in parallel.
+        /// It is false by default because enqueuing <seealso cref="Browser.NewPageAsync"/> it's not necesarry all the time and it's a performance hit.
+        /// </summary>
+        bool EnqueueNewPages { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -135,5 +135,13 @@ namespace PuppeteerSharp
         /// Setting this to <c>false</c> proved to work in .NET Core but it tends to fail on .NET Framework.
         /// </remarks>
         public bool EnqueueTransportMessages { get; set; } = true;
+
+        /// <summary>
+        /// If `true`, the browser will enqueue all <seealso cref="Browser.NewPageAsync"/> calls in the <seealso cref="Browser.ScreenshotTaskQueue"/>.
+        /// So new pages call won't interfere with the <seealso cref="Page.ScreenshotBase64Async(ScreenshotOptions)"/> method call.
+        /// EnqueueNewPages might be needed when using Chromium with <seealso cref="LaunchOptions.Headless"/> in false and making calls in parallel.
+        /// It is false by default because enqueuing <seealso cref="Browser.NewPageAsync"/> it's not necesarry all the time and it's a performance hit.
+        /// </summary>
+        public bool EnqueueNewPages { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -61,7 +61,7 @@ namespace PuppeteerSharp
                         .ConfigureAwait(false);
 
                     var browser = await Browser
-                        .CreateAsync(connection, Array.Empty<string>(), options.IgnoreHTTPSErrors, options.DefaultViewport, Process)
+                        .CreateAsync(connection, Array.Empty<string>(), options, Process)
                         .ConfigureAwait(false);
 
                     await browser.WaitForTargetAsync(t => t.Type == TargetType.Page).ConfigureAwait(false);
@@ -102,7 +102,7 @@ namespace PuppeteerSharp
                 var connection = await Connection.Create(browserWSEndpoint, options, _loggerFactory).ConfigureAwait(false);
                 var response = await connection.SendAsync<GetBrowserContextsResponse>("Target.getBrowserContexts");
                 return await Browser
-                    .CreateAsync(connection, response.BrowserContextIds, options.IgnoreHTTPSErrors, options.DefaultViewport, null)
+                    .CreateAsync(connection, response.BrowserContextIds, options, null)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
When Chrome is launched with `headless` in `false` new page creation might interfere with screenshot tasks.

To solve that we are adding a new LaunchOption called `EnqueueNewPages` (`false` by default). If set to true. We will use the same Queue we use for taking screenshots to create new pages.

As this is a performance hit, the default value will be `false`. 

closes #1076 