### PR TITLE
Fixes bug #1016: Unhandled TargetClosedException

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
@@ -133,6 +133,9 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldWorkWithoutThrowingUnhandledTaskExceptions()
         {
+            // Using this technique to test finalizers:
+            // https://www.inversionofcontrol.co.uk/unit-testing-finalizers-in-csharp/
+
             TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
             WeakReference<Page> weak = null;

--- a/lib/PuppeteerSharp/DOMWorld.cs
+++ b/lib/PuppeteerSharp/DOMWorld.cs
@@ -145,12 +145,14 @@ namespace PuppeteerSharp
                 document.close();
             }", html).ConfigureAwait(false);
 
-            var watcher = new LifecycleWatcher(_frameManager, Frame, waitUntil, timeout);
-            var watcherTask = await Task.WhenAny(
-                watcher.TimeoutOrTerminationTask,
-                watcher.LifecycleTask).ConfigureAwait(false);
+            using (var watcher = new LifecycleWatcher(_frameManager, Frame, waitUntil, timeout))
+            {
+                var watcherTask = await Task.WhenAny(
+                    watcher.TimeoutOrTerminationTask,
+                    watcher.LifecycleTask).ConfigureAwait(false);
 
-            await watcherTask.ConfigureAwait(false);
+                await watcherTask.ConfigureAwait(false);
+            }
         }
 
         internal async Task<ElementHandle> AddScriptTagAsync(AddTagOptions options)

--- a/lib/PuppeteerSharp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/LifecycleWatcher.cs
@@ -180,29 +180,12 @@ namespace PuppeteerSharp
 
             if (_terminationTaskWrapper.Task.Status == TaskStatus.Faulted)
             {
-                try
-                {
-                    _terminationTaskWrapper.Task.GetAwaiter().GetResult();
-                }
-                catch
-                {
-                    // We try and catch so that the task isn't flagged as unhandled
-                }
+                _terminationTaskWrapper.Task.ContinueWith(_ => true, TaskContinuationOptions.OnlyOnFaulted);
             }
 
             foreach (var task in _issuedTimeoutOrTerminationTasks)
             {
-                if (task.Status == TaskStatus.Faulted)
-                {
-                    try
-                    {
-                        task.GetAwaiter().GetResult();
-                    }
-                    catch
-                    {
-                        // We try and catch so that the task isn't flagged as unhandled
-                    }
-                }
+                task.ContinueWith(_ => true, TaskContinuationOptions.OnlyOnFaulted);
             }
         }
 

--- a/lib/PuppeteerSharp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/LifecycleWatcher.cs
@@ -172,21 +172,18 @@ namespace PuppeteerSharp
 
         public void Dispose(bool disposing)
         {
+            var exception = _terminationTaskWrapper.Task.Exception;
+
+            foreach (var task in _issuedTimeoutOrTerminationTasks)
+            {
+                exception = task.Exception;
+            }
+
             _frameManager.LifecycleEvent -= FrameManager_LifecycleEvent;
             _frameManager.FrameNavigatedWithinDocument -= NavigatedWithinDocument;
             _frameManager.FrameDetached -= OnFrameDetached;
             _frameManager.NetworkManager.Request -= OnRequest;
             _frameManager.Client.Disconnected -= OnClientDisconnected;
-
-            if (_terminationTaskWrapper.Task.Status == TaskStatus.Faulted)
-            {
-                _terminationTaskWrapper.Task.ContinueWith(_ => true, TaskContinuationOptions.OnlyOnFaulted);
-            }
-
-            foreach (var task in _issuedTimeoutOrTerminationTasks)
-            {
-                task.ContinueWith(_ => true, TaskContinuationOptions.OnlyOnFaulted);
-            }
         }
 
         #endregion

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -342,8 +342,7 @@ namespace PuppeteerSharp
 
             request.Response = response;
             request.RedirectChainList.Add(request);
-            response.BodyLoadedTaskWrapper.TrySetException(
-                new PuppeteerException("Response body is unavailable for redirect responses"));
+            response.BodyLoadedTaskWrapper.TrySetResult(false);
 
             if (request.RequestId != null)
             {

--- a/lib/PuppeteerSharp/Response.cs
+++ b/lib/PuppeteerSharp/Response.cs
@@ -117,7 +117,12 @@ namespace PuppeteerSharp
         {
             if (_buffer == null)
             {
-                await BodyLoadedTaskWrapper.Task.ConfigureAwait(false);
+                var success = await BodyLoadedTaskWrapper.Task.ConfigureAwait(false);
+
+                if (!success)
+                {
+                    throw new PuppeteerException("Response body is unavailable for redirect responses");
+                }
 
                 try
                 {


### PR DESCRIPTION
It solves the issue by collecting the lingering tasks, and manually making them throw so that the UnobservedTaskException event doesn't see them anymore.