### PR TITLE
Don’t disable BlinkGenPropertyTrees anymore

### DIFF
--- a/lib/PuppeteerSharp/ChromiumProcess.cs
+++ b/lib/PuppeteerSharp/ChromiumProcess.cs
@@ -31,7 +31,7 @@ namespace PuppeteerSharp
             "--disable-default-apps",
             "--disable-dev-shm-usage",
             "--disable-extensions",
-            "--disable-features=TranslateUI,BlinkGenPropertyTrees",
+            "--disable-features=TranslateUI",
             "--disable-hang-monitor",
             "--disable-ipc-flooding-protection",
             "--disable-popup-blocking",


### PR DESCRIPTION
closes #1474