### PR TITLE
Prevent ThrowKeyNullException

### DIFF
--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -303,8 +303,9 @@ namespace PuppeteerSharp
                     redirectChain = request.RedirectChainList;
                 }
             }
-            if (!_requestIdToRequest.TryGetValue(e.RequestId, out var currentRequest) ||
-              currentRequest.Frame == null)
+            if (interceptionId != null &&
+                (!_requestIdToRequest.TryGetValue(e.RequestId, out var currentRequest) ||
+                currentRequest.Frame == null))
             {
                 var frame = await FrameManager.TryGetFrameAsync(e.FrameId).ConfigureAwait(false);
 


### PR DESCRIPTION
I noticed this error when opening `open.spotify.com/` as a logged in user with chrome installed
```
NetworkManager failed to process Network.requestWillBeSent. Value cannot be null. (Parameter 'key').    at System.Collections.Concurrent.ConcurrentDictionary`2.ThrowKeyNullException()
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at PuppeteerSharp.Helpers.MultiMap`2.Add(TKey key, TValue value) in D:\GitHub\Projects\puppeteer-sharp\lib\PuppeteerSharp\Helpers\MultiMap.cs:line 12
   at PuppeteerSharp.Helpers.AsyncDictionaryHelper`2.TryGetItemAsync(TKey key) in D:\GitHub\Projects\puppeteer-sharp\lib\PuppeteerSharp\Helpers\AsyncDictionaryHelper.cs:line 38
   at PuppeteerSharp.NetworkManager.OnRequestAsync(RequestWillBeSentPayload e, String interceptionId) in D:\GitHub\Projects\puppeteer-sharp\lib\PuppeteerSharp\NetworkManager.cs:line 309
   at PuppeteerSharp.NetworkManager.OnRequestWillBeSentAsync(RequestWillBeSentPayload e) in D:\GitHub\Projects\puppeteer-sharp\lib\PuppeteerSharp\NetworkManager.cs:line 385
   at PuppeteerSharp.NetworkManager.Client_MessageReceived(Object sender, MessageEventArgs e) in D:\GitHub\Projects\puppeteer-sharp\lib\PuppeteerSharp\NetworkManager.cs:line 141
```