### PR TITLE
use var

### DIFF
--- a/lib/.editorconfig
+++ b/lib/.editorconfig
@@ -46,8 +46,8 @@ dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = false:error
-csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion


### PR DESCRIPTION
i was getting some VS IDE errors on the var style used. it seems, based on your code, your preference is "var always". but the editor config did not match that. so i tweaked the editor config