### PR TITLE
Fixed negative index error

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/GoBackTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GoBackTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -45,6 +45,26 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.Equal(TestConstants.EmptyPage, Page.Url);
             await Page.GoForwardAsync();
             Assert.Equal(TestConstants.ServerUrl + "/first.html", Page.Url);
+        }
+        
+        [Fact]
+        public async Task GoBackToAboutBlank()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var response = await Page.GoBackAsync();
+            Assert.Null(response);
+            Assert.Equal(TestConstants.AboutBlank, Page.Url);
+
+            // Trying to go back from the root about:blank page should do nothing.
+            response = await Page.GoBackAsync();
+            Assert.Null(response);
+            Assert.Equal(TestConstants.AboutBlank, Page.Url);
+
+            // Try going forward again to the empty page
+            response = await Page.GoForwardAsync();
+            Assert.True(response.Ok);
+            Assert.Equal(TestConstants.EmptyPage, response.Url);
         }
     }
 }

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1871,7 +1871,7 @@ namespace PuppeteerSharp
         {
             var history = await Client.SendAsync<PageGetNavigationHistoryResponse>("Page.getNavigationHistory").ConfigureAwait(false);
 
-            if (history.Entries.Count <= history.CurrentIndex + delta)
+            if (history.Entries.Count <= history.CurrentIndex + delta || history.CurrentIndex + delta < 0)
             {
                 return null;
             }


### PR DESCRIPTION
This fixes a negative index error that can be reproduced by the new test in this PR: `GoBackTests.GoBackToAboutBlank`.

Exception being thrown was:

```
System.ArgumentOutOfRangeException
Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
   at System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at PuppeteerSharp.Page.<GoAsync>d__224.MoveNext() in D:\dev\github\jpeirson\puppeteer-sharp\lib\PuppeteerSharp\Page.cs:line 1878
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PuppeteerSharp.Tests.PageTests.GoBackTests.<GoBackToAboutBlank>d__3.MoveNext() in D:\dev\github\jpeirson\puppeteer-sharp\lib\PuppeteerSharp.Tests\PageTests\GoBackTests.cs:line 60
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass48_1.<<InvokeTestMethodAsync>b__1>d.MoveNext() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 264
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.ExecutionTimer.<AggregateAsync>d__4.MoveNext() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\ExecutionTimer.cs:line 48
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.ExceptionAggregator.<RunAsync>d__9.MoveNext() in C:\Dev\xunit\xunit\src\xunit.core\Sdk\ExceptionAggregator.cs:line 90
```