### PR TITLE
Set CA1816 to error

### DIFF
--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="CA1721" Action="None" /> <!-- Error CA1721: The property name 'DefaultArgs' is confusing given the existence of method 'GetDefaultArgs'. Rename or remove one of these members. (CA1721)-->
     <Rule Id="CA1724" Action="None" /> <!-- Error CA1724: The type name Extensions conflicts in whole or in part with the namespace name 'Microsoft.Extensions'. Change either name to eliminate the conflict. (CA1724) -->
     <Rule Id="CA1806" Action="None" /> <!-- Error CA1806: DownloadAsync calls Chmod but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method. (CA1806)-->
-    <Rule Id="CA1816" Action="None" /> <!-- Error CA1816: Change Connection.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it. (CA1816) -->
+    <Rule Id="CA1816" Action="Error" /> <!-- Error CA1816: Change Connection.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it. (CA1816) -->
     <Rule Id="CA2000" Action="Error" /> <!-- Error CA2000: Call System.IDisposable.Dispose on object created by 'new Process()' before all references to it are out of scope. (CA2000) -->
     <Rule Id="CA2008" Action="None" /> <!-- Error ca2008: Pass TaskScheduler-->
     <Rule Id="CA2200" Action="None" /> <!-- Error CA2200: Re-throwing caught exception changes stack information. (CA2200)  -->

--- a/lib/PuppeteerSharp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/LifecycleWatcher.cs
@@ -164,7 +164,11 @@ namespace PuppeteerSharp
             return true;
         }
 
-        public void Dispose() => Dispose(true);
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
         ~LifecycleWatcher() => Dispose(false);
 

--- a/lib/PuppeteerSharp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/LifecycleWatcher.cs
@@ -166,14 +166,6 @@ namespace PuppeteerSharp
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        ~LifecycleWatcher() => Dispose(false);
-
-        public void Dispose(bool disposing)
-        {
             _frameManager.LifecycleEvent -= FrameManager_LifecycleEvent;
             _frameManager.FrameNavigatedWithinDocument -= NavigatedWithinDocument;
             _frameManager.FrameDetached -= OnFrameDetached;


### PR DESCRIPTION
When I had a look at the class, i saw that it did not need a finalizer. LifecycleWatcher does not contain any unmanaged members. See [implementing dispose](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose) for reference: "It is possible for a base class to only reference managed objects, and implement the dispose pattern. In these cases, a finalizer is unnecessary. A finalizer is only required if you directly reference unmanaged resources."

In a second commit I removed the second dispose(bool) method and the finalizer.

I am uncertain about the SuppressMessage for CA2213:DisposableFieldsShouldBeDisposed in line 36 of the same file. The _terminationCancellationToken is only canceled in our dispose-method but never actually disposed. Can you elaborate on that?