### PR TITLE
remove ToObject<ConnectionResponseParams

### DIFF
--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
@@ -191,8 +191,6 @@ namespace PuppeteerSharp
             else
             {
                 var method = obj.Method;
-                var param = obj.Params?.ToObject<ConnectionResponseParams>();
-
                 MessageReceived?.Invoke(this, new MessageEventArgs
                 {
                     MessageID = method,


### PR DESCRIPTION
I assume this is redundant? but technically it could be breaking behavior change