### PR TITLE
use a static local func

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -2409,7 +2409,7 @@ namespace PuppeteerSharp
         {
             return $"({fun})({string.Join(",", args.Select(SerializeArgument))})";
 
-            string SerializeArgument(object arg)
+            static string SerializeArgument(object arg)
             {
                 return arg == null
                     ? "undefined"


### PR DESCRIPTION
https://www.c-sharpcorner.com/article/c-sharp-8-0-static-local-functions/

> In C# 8.0, we addressed this issue by declaring the local functions as static since we are aware that static methods won’t be allocating separate memory in each object and the same in its variables scoped to it.