### PR TITLE
Discards

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/lib/PuppeteerSharp.TestServer/SimpleServer.cs
+++ b/lib/PuppeteerSharp.TestServer/SimpleServer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using System;
@@ -132,7 +132,7 @@ namespace PuppeteerSharp.TestServer
             return request;
         }
 
-        public Task WaitForRequest(string path) => WaitForRequest<bool>(path, request => true);
+        public Task WaitForRequest(string path) => WaitForRequest<bool>(path, _ => true);
 
         private static bool Authenticate(string username, string password, HttpContext context)
         {

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             var page = await context.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
             var popupTargetCompletion = new TaskCompletionSource<Target>();
-            Browser.TargetCreated += (sender, e) => popupTargetCompletion.SetResult(e.Target);
+            Browser.TargetCreated += (_, e) => popupTargetCompletion.SetResult(e.Target);
 
             await Task.WhenAll(
                 popupTargetCompletion.Task,
@@ -75,9 +75,9 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         {
             var context = await Browser.CreateIncognitoBrowserContextAsync();
             var events = new List<string>();
-            context.TargetCreated += (sender, e) => events.Add("CREATED: " + e.Target.Url);
-            context.TargetChanged += (sender, e) => events.Add("CHANGED: " + e.Target.Url);
-            context.TargetDestroyed += (sender, e) => events.Add("DESTROYED: " + e.Target.Url);
+            context.TargetCreated += (_, e) => events.Add("CREATED: " + e.Target.Url);
+            context.TargetChanged += (_, e) => events.Add("CHANGED: " + e.Target.Url);
+            context.TargetDestroyed += (_, e) => events.Add("DESTROYED: " + e.Target.Url);
             var page = await context.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
             await page.CloseAsync();

--- a/lib/PuppeteerSharp.Tests/BrowserTests/Events/TargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/Events/TargetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,9 +19,9 @@ namespace PuppeteerSharp.Tests.BrowserTests.Events
         public async Task ShouldWork()
         {
             var events = new List<string>();
-            Browser.TargetCreated += (sender, e) => events.Add("CREATED");
-            Browser.TargetChanged += (sender, e) => events.Add("CHANGED");
-            Browser.TargetDestroyed += (sender, e) => events.Add("DESTROYED");
+            Browser.TargetCreated += (_, _) => events.Add("CREATED");
+            Browser.TargetChanged += (_, _) => events.Add("CHANGED");
+            Browser.TargetDestroyed += (_, _) => events.Add("DESTROYED");
             var page = await Browser.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
             await page.CloseAsync();

--- a/lib/PuppeteerSharp.Tests/ChromiumSpecificTests/PageTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromiumSpecificTests/PageTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 using Xunit.Abstractions;
@@ -30,7 +30,7 @@ namespace PuppeteerSharp.Tests.ChromiumSpecificTests
             });
 
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/intervention");
 

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 using System.Linq;
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             // validate frameattached events
             var attachedFrames = new List<Frame>();
 
-            Page.FrameAttached += (sender, e) => attachedFrames.Add(e.Frame);
+            Page.FrameAttached += (_, e) => attachedFrames.Add(e.Frame);
 
             await FrameUtils.AttachFrameAsync(Page, "frame1", "./Assets/frame.html");
 
@@ -38,7 +38,7 @@ namespace PuppeteerSharp.Tests.FrameTests
 
             // validate framenavigated events
             var navigatedFrames = new List<Frame>();
-            Page.FrameNavigated += (sender, e) => navigatedFrames.Add(e.Frame);
+            Page.FrameNavigated += (_, e) => navigatedFrames.Add(e.Frame);
 
             await FrameUtils.NavigateFrameAsync(Page, "frame1", "./empty.html");
             Assert.Single(navigatedFrames);
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.FrameTests
 
             // validate framedetached events
             var detachedFrames = new List<Frame>();
-            Page.FrameDetached += (sender, e) => detachedFrames.Add(e.Frame);
+            Page.FrameDetached += (_, e) => detachedFrames.Add(e.Frame);
 
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             Assert.Single(navigatedFrames);
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var frameNavigated = new TaskCompletionSource<bool>();
-            Page.FrameNavigated += (sender, e) => frameNavigated.TrySetResult(true);
+            Page.FrameNavigated += (_, _) => frameNavigated.TrySetResult(true);
             await Task.WhenAll(
                 Page.GoToAsync(TestConstants.EmptyPage + "#foo"),
                 frameNavigated.Task
@@ -79,8 +79,8 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldNotSendAttachDetachEventsForMainFrame()
         {
             var hasEvents = false;
-            Page.FrameAttached += (sender, e) => hasEvents = true;
-            Page.FrameDetached += (sender, e) => hasEvents = true;
+            Page.FrameAttached += (_, _) => hasEvents = true;
+            Page.FrameDetached += (_, _) => hasEvents = true;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.False(hasEvents);
@@ -93,9 +93,9 @@ namespace PuppeteerSharp.Tests.FrameTests
             var detachedFrames = new List<Frame>();
             var navigatedFrames = new List<Frame>();
 
-            Page.FrameAttached += (sender, e) => attachedFrames.Add(e.Frame);
-            Page.FrameDetached += (sender, e) => detachedFrames.Add(e.Frame);
-            Page.FrameNavigated += (sender, e) => navigatedFrames.Add(e.Frame);
+            Page.FrameAttached += (_, e) => attachedFrames.Add(e.Frame);
+            Page.FrameDetached += (_, e) => detachedFrames.Add(e.Frame);
+            Page.FrameNavigated += (_, e) => navigatedFrames.Add(e.Frame);
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
             Assert.Equal(4, attachedFrames.Count);
@@ -164,7 +164,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             }");
             Assert.True(frame1.Detached);
             var frame2tsc = new TaskCompletionSource<Frame>();
-            Page.FrameAttached += (sender, e) => frame2tsc.TrySetResult(e.Frame);
+            Page.FrameAttached += (_, e) => frame2tsc.TrySetResult(e.Frame);
             await Page.EvaluateExpressionAsync("document.body.appendChild(window.frame)");
             var frame2 = await frame2tsc.Task;
             Assert.False(frame2.Detached);

--- a/lib/PuppeteerSharp.Tests/FrameTests/GoToTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/GoToTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldRejectWhenFrameDetaches()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
-            Server.SetRoute("/empty.html", context => Task.Delay(10000));
+            Server.SetRoute("/empty.html", _ => Task.Delay(10000));
             var waitForRequestTask = Server.WaitForRequest("/empty.html");
             var navigationTask = Page.FirstChildFrame().GoToAsync(TestConstants.EmptyPage);
             await waitForRequestTask;

--- a/lib/PuppeteerSharp.Tests/FrameTests/WaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/WaitForNavigationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
             var frame = Page.FirstChildFrame();
-            Server.SetRoute("/empty.html", context => Task.Delay(10000));
+            Server.SetRoute("/empty.html", _ => Task.Delay(10000));
             var waitForNavigationResult = frame.WaitForNavigationAsync();
             await Task.WhenAll(
                 Server.WaitForRequest("/empty.html"),

--- a/lib/PuppeteerSharp.Tests/InputTests/ClickTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/ClickTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using PuppeteerSharp.Input;
@@ -128,7 +128,7 @@ namespace PuppeteerSharp.Tests.InputTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/offscreenbuttons.html");
             var messages = new List<string>();
-            Page.Console += (sender, e) => messages.Add(e.Message.Text);
+            Page.Console += (_, e) => messages.Add(e.Message.Text);
 
             for (var i = 0; i < 11; ++i)
             {

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserAcceptTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserAcceptTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PuppeteerSharp.Mobile;
 using Xunit;
@@ -37,7 +37,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 waitForTask,
                 Page.ClickAsync("input"));
 
-            Page.Metrics += (sender, e) => metricsTcs.TrySetResult(true);
+            Page.Metrics += (_, _) => metricsTcs.TrySetResult(true);
 
             await Task.WhenAll(
                 waitForTask.Result.AcceptAsync(TestConstants.FileToUpload),

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0616.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0616.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.Issues
         public async Task ShouldBeAbleToChangeToPost()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 var payload = new Payload()
                 {

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0648.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0648.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.Issues
         public async Task ShouldWork()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             await Page.GoToAsync("https://www.google.com/search?q=firewall&oq=firewall&ie=UTF-8");
         }
     }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0764.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0764.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.Issues
         public async Task BufferAsyncShouldWorkWithBinaries()
         {
             var tcs = new TaskCompletionSource<byte[]>();
-            Page.Response += async (sender, e) =>
+            Page.Response += async (_, e) =>
             {
                 if (e.Response.Url.Contains("digits/0.png"))
                 {

--- a/lib/PuppeteerSharp.Tests/NetworkTests/NetworkEventTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/NetworkEventTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task PageEventsRequest()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) => requests.Add(e.Request);
+            Page.Request += (_, e) => requests.Add(e.Request);
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.Single(requests);
             Assert.Equal(TestConstants.EmptyPage, requests[0].Url);
@@ -37,7 +37,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task PageEventsResponse()
         {
             var responses = new List<Response>();
-            Page.Response += (sender, e) => responses.Add(e.Response);
+            Page.Response += (_, e) => responses.Add(e.Response);
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.Single(responses);
             Assert.Equal(TestConstants.EmptyPage, responses[0].Url);
@@ -56,7 +56,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task PageEventsRequestFailed()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (e.Request.Url.EndsWith("css"))
                 {
@@ -68,7 +68,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 }
             };
             var failedRequests = new List<Request>();
-            Page.RequestFailed += (sender, e) => failedRequests.Add(e.Request);
+            Page.RequestFailed += (_, e) => failedRequests.Add(e.Request);
             await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
 
             Assert.Single(failedRequests);
@@ -92,7 +92,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task PageEventsRequestFinished()
         {
             var requests = new List<Request>();
-            Page.RequestFinished += (sender, e) => requests.Add(e.Request);
+            Page.RequestFinished += (_, e) => requests.Add(e.Request);
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.Single(requests);
             Assert.Equal(TestConstants.EmptyPage, requests[0].Url);
@@ -106,9 +106,9 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldFireEventsInProperOrder()
         {
             var events = new List<string>();
-            Page.Request += (sender, e) => events.Add("request");
-            Page.Response += (sender, e) => events.Add("response");
-            Page.RequestFinished += (sender, e) => events.Add("requestfinished");
+            Page.Request += (_, _) => events.Add("request");
+            Page.Response += (_, _) => events.Add("response");
+            Page.RequestFinished += (_, _) => events.Add("requestfinished");
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.Equal(new[] { "request", "response", "requestfinished" }, events);
         }
@@ -117,10 +117,10 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldSupportRedirects()
         {
             var events = new List<string>();
-            Page.Request += (sender, e) => events.Add($"{e.Request.Method} {e.Request.Url}");
-            Page.Response += (sender, e) => events.Add($"{(int)e.Response.Status} {e.Response.Url}");
-            Page.RequestFinished += (sender, e) => events.Add($"DONE {e.Request.Url}");
-            Page.RequestFailed += (sender, e) => events.Add($"FAIL {e.Request.Url}");
+            Page.Request += (_, e) => events.Add($"{e.Request.Method} {e.Request.Url}");
+            Page.Response += (_, e) => events.Add($"{(int)e.Response.Status} {e.Response.Url}");
+            Page.RequestFinished += (_, e) => events.Add($"DONE {e.Request.Url}");
+            Page.RequestFailed += (_, e) => events.Add($"FAIL {e.Request.Url}");
             Server.SetRedirect("/foo.html", "/empty.html");
             const string FOO_URL = TestConstants.ServerUrl + "/foo.html";
             var response = await Page.GoToAsync(FOO_URL);

--- a/lib/PuppeteerSharp.Tests/NetworkTests/PageEventRequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/PageEventRequestTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldFireForNavigationRequests()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldFireForIframes()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldFireForFetches()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestContinueTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestContinueTests.cs
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             await Page.GoToAsync(TestConstants.EmptyPage);
         }
 
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldAmendHTTPHeaders()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 var headers = new Dictionary<string, string>(e.Request.Headers)
                 {
@@ -53,7 +53,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldRedirectInAWayNonObservableToPage()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 var redirectURL = e.Request.Url.Contains("/empty.html")
                     ? TestConstants.ServerUrl + "/consolelog.html" :
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 await e.Request.ContinueAsync(new Payload { Url = redirectURL });
             };
             string consoleMessage = null;
-            Page.Console += (sender, e) => consoleMessage = e.Message.Text;
+            Page.Console += (_, e) => consoleMessage = e.Message.Text;
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.Equal(TestConstants.EmptyPage, Page.Url);
             Assert.Equal("yellow", consoleMessage);
@@ -72,7 +72,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.ContinueAsync(new Payload { Method = HttpMethod.Post });
             };
@@ -91,7 +91,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldAmendPostData()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.ContinueAsync(new Payload
                 {
@@ -119,7 +119,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldAmendBothPostDataAndMethodOnNavigation()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync(new Payload
+            Page.Request += async (_, e) => await e.Request.ContinueAsync(new Payload
             {
                 Method = HttpMethod.Post,
                 PostData = "doggo"

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestFrameTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkForMainFrameNavigationRequests()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkForSubframeNavigationRequest()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkForFetchRequests()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestIsNavigationRequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestIsNavigationRequestTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             var requests = new Dictionary<string, Request>();
-            Page.Request += (sender, e) => requests[e.Request.Url.Split('/').Last()] = e.Request;
+            Page.Request += (_, e) => requests[e.Request.Url.Split('/').Last()] = e.Request;
             Server.SetRedirect("/rrredirect", "/frames/one-frame.html");
             await Page.GoToAsync(TestConstants.ServerUrl + "/rrredirect");
             Assert.True(requests["rrredirect"].IsNavigationRequest);
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkWithRequestInterception()
         {
             var requests = new Dictionary<string, Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 requests[e.Request.Url.Split('/').Last()] = e.Request;
                 await e.Request.ContinueAsync();
@@ -55,7 +55,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkWhenNavigatingToImage()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) => requests.Add(e.Request);
+            Page.Request += (_, e) => requests.Add(e.Request);
             await Page.GoToAsync(TestConstants.ServerUrl + "/pptr.png");
             Assert.True(requests[0].IsNavigationRequest);
         }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -18,9 +18,9 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Server.SetRoute("/post", context => Task.CompletedTask);
+            Server.SetRoute("/post", _ => Task.CompletedTask);
             Request request = null;
-            Page.Request += (sender, e) => request = e.Request;
+            Page.Request += (_, e) => request = e.Request;
             await Page.EvaluateExpressionHandleAsync("fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar'})})");
             Assert.NotNull(request);
             Assert.Equal("{\"foo\":\"bar\"}", request.PostData);

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestRespondTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.RespondAsync(new ResponseData
                 {
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkReturnStatusPhrases()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.RespondAsync(new ResponseData
                 {
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
 
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (!e.Request.Url.Contains("rrredirect"))
                 {
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldAllowMockingBinaryResponses()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 var imageData = File.ReadAllBytes("./Assets/pptr.png");
                 await e.Request.RespondAsync(new ResponseData
@@ -120,7 +120,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldStringifyInterceptedRequestResponseHeaders()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.RespondAsync(new ResponseData
                 {

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromCacheTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromCacheTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             var responses = new Dictionary<string, Response>();
-            Page.Response += (sender, e) => responses[e.Response.Url.Split('/').Last()] = e.Response;
+            Page.Response += (_, e) => responses[e.Response.Url.Split('/').Last()] = e.Response;
             await Page.GoToAsync(TestConstants.ServerUrl + "/cached/one-style.html");
             await Page.ReloadAsync();
 

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromServiceWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromServiceWorkerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ResponseFromServiceWorker()
         {
             var responses = new Dictionary<string, Response>();
-            Page.Response += (sender, e) => responses[e.Response.Url.Split('/').Last()] = e.Response;
+            Page.Response += (_, e) => responses[e.Response.Url.Split('/').Last()] = e.Response;
             await Page.GoToAsync(TestConstants.ServerUrl + "/serviceworkers/fetch/sw.html",
                 waitUntil: new[] { WaitUntilNavigation.Networkidle2 });
             await Page.EvaluateFunctionAsync("async () => await window.activationPromise");

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -61,13 +61,13 @@ namespace PuppeteerSharp.Tests.NetworkTests
             // Setup page to trap response.
             Response pageResponse = null;
             var requestFinished = false;
-            Page.Response += (sender, e) => pageResponse = e.Response;
-            Page.RequestFinished += (sender, e) => requestFinished = true;
+            Page.Response += (_, e) => pageResponse = e.Response;
+            Page.RequestFinished += (_, _) => requestFinished = true;
             // send request and wait for server response
             Task WaitForPageResponseEvent()
             {
                 var completion = new TaskCompletionSource<bool>();
-                Page.Response += (sender, e) =>
+                Page.Response += (_, e) =>
                 {
                     if (!TestUtils.IsFavicon(e.Response.Request))
                     {

--- a/lib/PuppeteerSharp.Tests/NetworkTests/SetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/SetRequestInterceptionTests.cs
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldIntercept()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (TestUtils.IsFavicon(e.Request))
                 {
@@ -53,7 +53,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Server.SetRedirect("/rredirect", "/empty.html");
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
 
             await Page.SetContentAsync(@"
                 <form action='/rredirect' method='post'>
@@ -72,7 +72,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Server.SetRedirect("/rredirect", "/empty.html");
             await Page.SetRequestInterceptionAsync(true);
 
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 var headers = e.Request.Headers.Clone();
                 headers["foo"] = "bar";
@@ -86,7 +86,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldBeAbleToRemoveHeaders()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 var headers = e.Request.Headers.Clone();
                 headers["foo"] = "bar";
@@ -109,7 +109,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             var requests = new List<Request>();
             var requestsReadyTcs = new TaskCompletionSource<bool>();
 
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -170,7 +170,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 ["foo"] = "bar"
             });
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 Assert.Equal("bar", e.Request.Headers["foo"]);
                 await e.Request.ContinueAsync();
@@ -185,7 +185,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             Server.SetRedirect("/logo.png", "/pptr.png");
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
 
             var status = await Page.EvaluateFunctionAsync<int>(@"async () =>
             {
@@ -205,7 +205,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 ["referer"] = TestConstants.EmptyPage
             });
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 Assert.Equal(TestConstants.EmptyPage, e.Request.Headers["referer"]);
                 await e.Request.ContinueAsync();
@@ -218,7 +218,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldBeAbortable()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (e.Request.Url.EndsWith(".css"))
                 {
@@ -230,7 +230,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 }
             };
             var failedRequests = 0;
-            Page.RequestFailed += (sender, e) => failedRequests++;
+            Page.RequestFailed += (_, _) => failedRequests++;
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
             Assert.True(response.Ok);
             Assert.Null(response.Request.Failure);
@@ -241,13 +241,13 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldBeAbortableWithCustomErrorCodes()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.AbortAsync(RequestAbortErrorCode.InternetDisconnected);
             };
             Request failedRequest = null;
-            Page.RequestFailed += (sender, e) => failedRequest = e.Request;
-            await Page.GoToAsync(TestConstants.EmptyPage).ContinueWith(e => { });
+            Page.RequestFailed += (_, e) => failedRequest = e.Request;
+            await Page.GoToAsync(TestConstants.EmptyPage).ContinueWith(_ => { });
             Assert.NotNull(failedRequest);
             Assert.Equal("net::ERR_INTERNET_DISCONNECTED", failedRequest.Failure);
         }
@@ -260,7 +260,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 ["referer"] = "http://google.com/"
             });
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var requestTask = Server.WaitForRequest("/grid.html", request => request.Headers["referer"].ToString());
             await Task.WhenAll(
                 requestTask,
@@ -273,7 +273,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldFailNavigationWhenAbortingMainResource()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.AbortAsync();
+            Page.Request += async (_, e) => await e.Request.AbortAsync();
             var exception = await Assert.ThrowsAsync<NavigationException>(
                 () => Page.GoToAsync(TestConstants.EmptyPage));
 
@@ -292,7 +292,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 await e.Request.ContinueAsync();
                 requests.Add(e.Request);
@@ -327,7 +327,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -365,7 +365,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.SetRequestInterceptionAsync(true);
             Server.SetRedirect("/non-existing.json", "/non-existing-2.json");
             Server.SetRedirect("/non-existing-2.json", "/simple.html");
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (e.Request.Url.Contains("non-existing-2"))
                 {
@@ -408,7 +408,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
 
             var spinner = false;
             // Cancel 2nd request.
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 if (TestUtils.IsFavicon(e.Request))
                 {
@@ -440,7 +440,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 requests.Add(e.Request);
                 await e.Request.ContinueAsync();
@@ -458,7 +458,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 requests.Add(e.Request);
                 await e.Request.ContinueAsync();
@@ -476,7 +476,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 requests.Add(e.Request);
                 await e.Request.ContinueAsync();
@@ -494,7 +494,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             // The requestWillBeSent will report encoded URL, whereas interception will
             // report URL as-is. @see crbug.com/759388
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/some nonexisting page");
             Assert.Equal(HttpStatusCode.NotFound, response.Status);
         }
@@ -503,8 +503,8 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWorkWithBadlyEncodedServer()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Server.SetRoute("/malformed?rnd=%911", context => Task.CompletedTask);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Server.SetRoute("/malformed?rnd=%911", _ => Task.CompletedTask);
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/malformed?rnd=%911");
             Assert.Equal(HttpStatusCode.OK, response.Status);
         }
@@ -516,7 +516,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             // report encoded URL for stylesheet. @see crbug.com/759388
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 requests.Add(e.Request);
                 await e.Request.ContinueAsync();
@@ -534,7 +534,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.SetRequestInterceptionAsync(true);
             Request request = null;
             var requestIntercepted = new TaskCompletionSource<bool>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 request = e.Request;
                 requestIntercepted.SetResult(true);
@@ -552,7 +552,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldThrowIfInterceptionIsNotEnabled()
         {
             Exception exception = null;
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 try
                 {
@@ -572,7 +572,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
             var urls = new List<string>();
-            Page.Request += async (sender, e) =>
+            Page.Request += async (_, e) =>
             {
                 urls.Add(e.Request.Url.Split('/').Last());
                 await e.Request.ContinueAsync();

--- a/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/beforeunload.html");
 
             var dialogTask = new TaskCompletionSource<bool>();
-            Page.Dialog += async (sender, e) =>
+            Page.Dialog += async (_, e) =>
             {
                 Assert.Equal(DialogType.BeforeUnload, e.Dialog.DialogType);
                 Assert.Equal(string.Empty, e.Dialog.DefaultValue);
@@ -67,7 +67,7 @@ namespace PuppeteerSharp.Tests.PageTests
             };
 
             var closeTask = new TaskCompletionSource<bool>();
-            Page.Close += (sender, e) => closeTask.TrySetResult(true);
+            Page.Close += (_, _) => closeTask.TrySetResult(true);
 
             // We have to interact with a page so that 'beforeunload' handlers
             // fire.

--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -98,7 +98,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             Task<int> frameEvaluation = null;
 
-            Page.FrameNavigated += (sender, e) =>
+            Page.FrameNavigated += (_, e) =>
             {
                 frameEvaluation = e.Frame.EvaluateFunctionAsync<int>("() => 6 * 7");
             };

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/CloseTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,13 +15,13 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldWorkWithWindowClose()
         {
             var newPageTaskSource = new TaskCompletionSource<Page>();
-            Context.TargetCreated += async (sender, e) => newPageTaskSource.TrySetResult(await e.Target.PageAsync());
+            Context.TargetCreated += async (_, e) => newPageTaskSource.TrySetResult(await e.Target.PageAsync());
 
             await Page.EvaluateExpressionAsync("window['newPage'] = window.open('about:blank');");
             var newPage = await newPageTaskSource.Task;
 
             var closeTaskSource = new TaskCompletionSource<bool>();
-            newPage.Close += (sender, e) => closeTaskSource.SetResult(true);
+            newPage.Close += (_, _) => closeTaskSource.SetResult(true);
             await Page.EvaluateExpressionAsync("window['newPage'].close();");
             await closeTaskSource.Task;
         }
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         {
             var newPage = await Context.NewPageAsync();
             var closeTaskSource = new TaskCompletionSource<bool>();
-            newPage.Close += (sender, e) => closeTaskSource.SetResult(true);
+            newPage.Close += (_, _) => closeTaskSource.SetResult(true);
             await newPage.CloseAsync();
             await closeTaskSource.Task;
         }

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/ConsoleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/ConsoleTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         {
             var messages = new List<ConsoleMessage>();
 
-            Page.Console += (sender, e) => messages.Add(e.Message);
+            Page.Console += (_, e) => messages.Add(e.Message);
 
             await Page.EvaluateFunctionAsync(@"() => {
               // A pair of time/timeEnd generates only one Console API call.
@@ -111,7 +111,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.GoToAsync(TestConstants.AboutBlank);
             var messageTask = new TaskCompletionSource<ConsoleMessage>();
 
-            Page.Console += (sender, e) => messageTask.TrySetResult(e.Message);
+            Page.Console += (_, e) => messageTask.TrySetResult(e.Message);
 
             await Page.EvaluateFunctionAsync("async url => fetch(url).catch(e => {})", TestConstants.EmptyPage);
             var message = await messageTask.Task;
@@ -132,7 +132,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var consoleTask = new TaskCompletionSource<ConsoleEventArgs>();
-            Page.Console += (sender, e) => consoleTask.TrySetResult(e);
+            Page.Console += (_, e) => consoleTask.TrySetResult(e);
 
             await Task.WhenAll(
                 consoleTask.Task,
@@ -152,7 +152,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var consoleTask = new TaskCompletionSource<ConsoleEventArgs>();
-            Page.Console += (sender, e) => consoleTask.TrySetResult(e);
+            Page.Console += (_, e) => consoleTask.TrySetResult(e);
 
             await Task.WhenAll(
                 consoleTask.Task,

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/DOMContentLoadedTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/DOMContentLoadedTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,7 +16,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         {
             var _ = Page.GoToAsync(TestConstants.AboutBlank);
             var completion = new TaskCompletionSource<bool>();
-            Page.DOMContentLoaded += (sender, e) => completion.SetResult(true);
+            Page.DOMContentLoaded += (_, _) => completion.SetResult(true);
             await completion.Task;
         }
     }

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/DialogTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/DialogTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [Fact]
         public async Task ShouldFire()
         {
-            Page.Dialog += async (sender, e) =>
+            Page.Dialog += async (_, e) =>
             {
                 Assert.Equal(DialogType.Alert, e.Dialog.DialogType);
                 Assert.Equal(string.Empty, e.Dialog.DefaultValue);
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [Fact]
         public async Task ShouldAllowAcceptingPrompts()
         {
-            Page.Dialog += async (sender, e) =>
+            Page.Dialog += async (_, e) =>
             {
                 Assert.Equal(DialogType.Prompt, e.Dialog.DialogType);
                 Assert.Equal("yes.", e.Dialog.DefaultValue);
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [Fact]
         public async Task ShouldDismissThePrompt()
         {
-            Page.Dialog += async (sender, e) =>
+            Page.Dialog += async (_, e) =>
             {
                 await e.Dialog.Dismiss();
             };

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/ErrorTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/ErrorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldThrowWhenPageCrashes()
         {
             string error = null;
-            Page.Error += (sender, e) => error = e.Error;
+            Page.Error += (_, e) => error = e.Error;
             var gotoTask = Page.GoToAsync("chrome://crash");
 
             await WaitForError();

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/PopupTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/PopupTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldWork()
         {
             var popupTaskSource = new TaskCompletionSource<Page>();
-            Page.Popup += (sender, e) => popupTaskSource.TrySetResult(e.PopupPage);
+            Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
                 popupTaskSource.Task,
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldWorkWithNoopener()
         {
             var popupTaskSource = new TaskCompletionSource<Page>();
-            Page.Popup += (sender, e) => popupTaskSource.TrySetResult(e.PopupPage);
+            Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
                 popupTaskSource.Task,
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.SetContentAsync("<a target=_blank href='/one-style.html'>yo</a>");
 
             var popupTaskSource = new TaskCompletionSource<Page>();
-            Page.Popup += (sender, e) => popupTaskSource.TrySetResult(e.PopupPage);
+            Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
                 popupTaskSource.Task,
@@ -63,7 +63,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.SetContentAsync("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
 
             var popupTaskSource = new TaskCompletionSource<Page>();
-            Page.Popup += (sender, e) => popupTaskSource.TrySetResult(e.PopupPage);
+            Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
                 popupTaskSource.Task,
@@ -80,7 +80,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.SetContentAsync("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
 
             var popupTaskSource = new TaskCompletionSource<Page>();
-            Page.Popup += (sender, e) => popupTaskSource.TrySetResult(e.PopupPage);
+            Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
                 popupTaskSource.Task,

--- a/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -140,9 +140,9 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldFailWhenNavigatingToBadSSL()
         {
-            Page.Request += (sender, e) => Assert.NotNull(e.Request);
-            Page.RequestFinished += (sender, e) => Assert.NotNull(e.Request);
-            Page.RequestFailed += (sender, e) => Assert.NotNull(e.Request);
+            Page.Request += (_, e) => Assert.NotNull(e.Request);
+            Page.RequestFinished += (_, e) => Assert.NotNull(e.Request);
+            Page.RequestFailed += (_, e) => Assert.NotNull(e.Request);
 
             var exception = await Assert.ThrowsAnyAsync<Exception>(async () => await Page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html"));
 
@@ -189,7 +189,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldFailWhenExceedingMaximumNavigationTimeout()
         {
-            Server.SetRoute("/empty.html", context => Task.Delay(-1));
+            Server.SetRoute("/empty.html", _ => Task.Delay(-1));
 
             var exception = await Assert.ThrowsAnyAsync<Exception>(async ()
                 => await Page.GoToAsync(TestConstants.EmptyPage, new NavigationOptions { Timeout = 1 }));
@@ -199,7 +199,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldFailWhenExceedingDefaultMaximumNavigationTimeout()
         {
-            Server.SetRoute("/empty.html", context => Task.Delay(-1));
+            Server.SetRoute("/empty.html", _ => Task.Delay(-1));
 
             Page.DefaultNavigationTimeout = 1;
             var exception = await Assert.ThrowsAnyAsync<Exception>(async () => await Page.GoToAsync(TestConstants.EmptyPage));
@@ -210,7 +210,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldFailWhenExceedingDefaultMaximumTimeout()
         {
             // Hang for request to the empty.html
-            Server.SetRoute("/empty.html", context => Task.Delay(-1));
+            Server.SetRoute("/empty.html", _ => Task.Delay(-1));
             Page.DefaultTimeout = 1;
             var exception = await Assert.ThrowsAnyAsync<Exception>(async () => await Page.GoToAsync(TestConstants.EmptyPage));
             Assert.Contains("Timeout of 1 ms exceeded", exception.Message);
@@ -220,7 +220,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldPrioritizeDefaultNavigationTimeoutOverDefaultTimeout()
         {
             // Hang for request to the empty.html
-            Server.SetRoute("/empty.html", context => Task.Delay(-1));
+            Server.SetRoute("/empty.html", _ => Task.Delay(-1));
             Page.DefaultTimeout = 0;
             Page.DefaultNavigationTimeout = 1;
             var exception = await Assert.ThrowsAnyAsync<Exception>(async () => await Page.GoToAsync(TestConstants.EmptyPage));
@@ -368,7 +368,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldNavigateToDataURLAndFireDataURLRequests()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -386,7 +386,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldNavigateToURLWithHashAndFireRequestsWithoutHash()
         {
             var requests = new List<Request>();
-            Page.Request += (sender, e) =>
+            Page.Request += (_, e) =>
             {
                 if (!TestUtils.IsFavicon(e.Request))
                 {
@@ -431,7 +431,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldSendReferer()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             string referer1 = null;
             string referer2 = null;
 

--- a/lib/PuppeteerSharp.Tests/PageTests/MetricsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/MetricsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task MetricsEventFiredOnConsoleTimespan()
         {
             var metricsTaskWrapper = new TaskCompletionSource<MetricEventArgs>();
-            Page.Metrics += (sender, e) => metricsTaskWrapper.SetResult(e);
+            Page.Metrics += (_, e) => metricsTaskWrapper.SetResult(e);
 
             await Page.EvaluateExpressionAsync("console.timeStamp('test42')");
             var result = await metricsTaskWrapper.Task;

--- a/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldRespectTimeout()
         {
             const string imgPath = "/img.png";
-            Server.SetRoute(imgPath, context => Task.Delay(-1));
+            Server.SetRoute(imgPath, _ => Task.Delay(-1));
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldRespectDefaultTimeout()
         {
             const string imgPath = "/img.png";
-            Server.SetRoute(imgPath, context => Task.Delay(-1));
+            Server.SetRoute(imgPath, _ => Task.Delay(-1));
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             Page.DefaultTimeout = 1;
@@ -81,7 +81,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var imgPath = "/img.png";
             var imgResponse = new TaskCompletionSource<bool>();
-            Server.SetRoute(imgPath, context => imgResponse.Task);
+            Server.SetRoute(imgPath, _ => imgResponse.Task);
             var loaded = false;
             var waitTask = Server.WaitForRequest(imgPath);
             var contentTask = Page.SetContentAsync($"<img src=\"{TestConstants.ServerUrl + imgPath}\"></img>")

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNavigationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldWorkWithBothDomcontentloadedAndLoad()
         {
             var responseCompleted = new TaskCompletionSource<bool>();
-            Server.SetRoute("/one-style.css", context =>
+            Server.SetRoute("/one-style.css", _ =>
             {
                 return responseCompleted.Task;
             });
@@ -147,17 +147,17 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldWorkWhenSubframeIssuesWindowStop()
         {
-            Server.SetRoute("/frames/style.css", (context) => Task.CompletedTask);
+            Server.SetRoute("/frames/style.css", _ => Task.CompletedTask);
             var navigationTask = Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
             var frameAttachedTaskSource = new TaskCompletionSource<Frame>();
-            Page.FrameAttached += (sender, e) =>
+            Page.FrameAttached += (_, e) =>
             {
                 frameAttachedTaskSource.SetResult(e.Frame);
             };
 
             var frame = await frameAttachedTaskSource.Task;
             var frameNavigatedTaskSource = new TaskCompletionSource<bool>();
-            Page.FrameNavigated += (sender, e) =>
+            Page.FrameNavigated += (_, e) =>
             {
                 if (e.Frame == frame)
                 {

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForRequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForRequestTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
-                await Page.WaitForRequestAsync(request => false, new WaitForOptions
+                await Page.WaitForRequestAsync(_ => false, new WaitForOptions
                 {
                     Timeout = 1
                 }));
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             Page.DefaultTimeout = 1;
             var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
-                await Page.WaitForRequestAsync(request => false));
+                await Page.WaitForRequestAsync(_ => false));
 
             Assert.Contains("Timeout of 1 ms exceeded", exception.Message);
         }

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForResponseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForResponseTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
-                await Page.WaitForResponseAsync(request => false, new WaitForOptions
+                await Page.WaitForResponseAsync(_ => false, new WaitForOptions
                 {
                     Timeout = 1
                 }));
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             Page.DefaultTimeout = 1;
             var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
-                await Page.WaitForResponseAsync(request => false));
+                await Page.WaitForResponseAsync(_ => false));
 
             Assert.Contains("Timeout of 1 ms exceeded", exception.Message);
         }

--- a/lib/PuppeteerSharp.Tests/PuppeteerBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerBaseTest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using PuppeteerSharp.TestServer;
 using System.IO;
 using System.Threading.Tasks;
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests
         protected static Task WaitForBrowserDisconnect(Browser browser)
         {
             var disconnectedTask = new TaskCompletionSource<bool>();
-            browser.Disconnected += (sender, e) => disconnectedTask.TrySetResult(true);
+            browser.Disconnected += (_, _) => disconnectedTask.TrySetResult(true);
             return disconnectedTask.Task;
         }
     }

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/BrowserDisconnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/BrowserDisconnectTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,9 +22,9 @@ namespace PuppeteerSharp.Tests.BrowserTests.Events
             var disconnectedOriginal = 0;
             var disconnectedRemote1 = 0;
             var disconnectedRemote2 = 0;
-            originalBrowser.Disconnected += (sender, e) => ++disconnectedOriginal;
-            remoteBrowser1.Disconnected += (sender, e) => ++disconnectedRemote1;
-            remoteBrowser2.Disconnected += (sender, e) => ++disconnectedRemote2;
+            originalBrowser.Disconnected += (_, _) => ++disconnectedOriginal;
+            remoteBrowser1.Disconnected += (_, _) => ++disconnectedRemote1;
+            remoteBrowser2.Disconnected += (_, _) => ++disconnectedRemote2;
 
             var remoteBrowser2Disconnected = WaitForBrowserDisconnect(remoteBrowser2);
             remoteBrowser2.Disconnect();
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Tests.BrowserTests.Events
         [Fact]
         public async Task ShouldRejectNavigationWhenBrowserCloses()
         {
-            Server.SetRoute("/one-style.css", context => Task.Delay(10000));
+            Server.SetRoute("/one-style.css", _ => Task.Delay(10000));
 
             using (var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions()))
             {
@@ -74,7 +74,7 @@ namespace PuppeteerSharp.Tests.BrowserTests.Events
         [Fact]
         public async Task ShouldRejectWaitForSelectorWhenBrowserCloses()
         {
-            Server.SetRoute("/empty.html", context => Task.Delay(10000));
+            Server.SetRoute("/empty.html", _ => Task.Delay(10000));
 
             using (var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions()))
             {

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/FixturesTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
                 "PuppeteerSharp.Tests.DumpIO",
                 $"\"{new BrowserFetcher().RevisionInfo(BrowserFetcher.DefaultRevision).ExecutablePath}\"");
 
-            process.ErrorDataReceived += (sender, e) =>
+            process.ErrorDataReceived += (_, e) =>
             {
                 success |= e.Data != null && e.Data.Contains("DevTools listening on ws://");
             };
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
                 BrowserWSEndpoint = ChromiumLauncher.EndPoint
             });
 
-            browser.Disconnected += (sender, e) =>
+            browser.Disconnected += (_, _) =>
             {
                 browserClosedTaskWrapper.SetResult(true);
             };
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             var browserClosedTaskWrapper = new TaskCompletionSource<bool>();
             var browser = await Puppeteer.LaunchAsync(new LaunchOptions { Headless = true }, TestConstants.LoggerFactory);
 
-            browser.Disconnected += (sender, e) =>
+            browser.Disconnected += (_, _) =>
             {
                 browserClosedTaskWrapper.SetResult(true);
             };

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/HeadfulTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/HeadfulTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using PuppeteerSharp.Helpers;
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             {
                 await page.GoToAsync(TestConstants.EmptyPage);
                 await page.SetRequestInterceptionAsync(true);
-                page.Request += async (sender, e) => await e.Request.RespondAsync(
+                page.Request += async (_, e) => await e.Request.RespondAsync(
                     new ResponseData { Body = "{ body: 'YO, GOOGLE.COM'}" });
                 await page.EvaluateFunctionHandleAsync(@"() => {
                     const frame = document.createElement('iframe');

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/IgnoreHttpsErrorsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/IgnoreHttpsErrorsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             var responses = new List<Response>();
             HttpsServer.SetRedirect("/plzredirect", "/empty.html");
 
-            Page.Response += (sender, e) => responses.Add(e.Response);
+            Page.Response += (_, e) => responses.Add(e.Response);
 
             var requestTask = HttpsServer.WaitForRequest(
                 "/empty.html",
@@ -68,7 +68,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         public async Task ShouldWorkWithRequestInterception()
         {
             await Page.SetRequestInterceptionAsync(true);
-            Page.Request += async (sender, e) => await e.Request.ContinueAsync();
+            Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.Equal(HttpStatusCode.OK, response.Status);
         }

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections.Features;
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             });
             var tcsDisconnected = new TaskCompletionSource<bool>();
 
-            originalBrowser.Disconnected += (sender, e) => tcsDisconnected.TrySetResult(true);
+            originalBrowser.Disconnected += (_, _) => tcsDisconnected.TrySetResult(true);
             await Task.WhenAll(
               tcsDisconnected.Task,
               remoteBrowser.CloseAsync());

--- a/lib/PuppeteerSharp.Tests/TargetTests/CreateCDPSessionTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetTests/CreateCDPSessionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             await client.SendAsync("Network.enable");
             var events = new List<object>();
 
-            client.MessageReceived += (sender, e) =>
+            client.MessageReceived += (_, e) =>
             {
                 if (e.MessageID == "Network.requestWillBeSent")
                 {

--- a/lib/PuppeteerSharp.Tests/TargetTests/TargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetTests/TargetTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -220,7 +220,7 @@ namespace PuppeteerSharp.Tests.TargetTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var targetCreatedCompletion = new TaskCompletionSource<Target>();
-            Browser.TargetCreated += (sender, e) => targetCreatedCompletion.TrySetResult(e.Target);
+            Browser.TargetCreated += (_, e) => targetCreatedCompletion.TrySetResult(e.Target);
             await Page.GoToAsync(TestConstants.ServerUrl + "/popup/window-open.html");
             var createdTarget = await targetCreatedCompletion.Task;
 

--- a/lib/PuppeteerSharp.Tests/WorkerTests/WorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/WorkerTests.cs
@@ -18,8 +18,8 @@ namespace PuppeteerSharp.Tests.WorkerTests
             var workerCreatedTcs = new TaskCompletionSource<bool>();
             var workerDestroyedTcs = new TaskCompletionSource<bool>();
 
-            Page.WorkerCreated += (sender, e) => workerCreatedTcs.TrySetResult(true);
-            Page.WorkerDestroyed += (sender, e) => workerDestroyedTcs.TrySetResult(true);
+            Page.WorkerCreated += (_, _) => workerCreatedTcs.TrySetResult(true);
+            Page.WorkerDestroyed += (_, _) => workerDestroyedTcs.TrySetResult(true);
 
             await Task.WhenAll(
                 workerCreatedTcs.Task,
@@ -38,12 +38,12 @@ namespace PuppeteerSharp.Tests.WorkerTests
         public async Task ShouldEmitCreatedAndDestroyedEvents()
         {
             var workerCreatedTcs = new TaskCompletionSource<Worker>();
-            Page.WorkerCreated += (sender, e) => workerCreatedTcs.TrySetResult(e.Worker);
+            Page.WorkerCreated += (_, e) => workerCreatedTcs.TrySetResult(e.Worker);
 
             var workerObj = await Page.EvaluateFunctionHandleAsync("() => new Worker('data:text/javascript,1')");
             var worker = await workerCreatedTcs.Task;
             var workerDestroyedTcs = new TaskCompletionSource<Worker>();
-            Page.WorkerDestroyed += (sender, e) => workerDestroyedTcs.TrySetResult(e.Worker);
+            Page.WorkerDestroyed += (_, e) => workerDestroyedTcs.TrySetResult(e.Worker);
             await Page.EvaluateFunctionAsync("workerObj => workerObj.terminate()", workerObj);
             Assert.Same(worker, await workerDestroyedTcs.Task);
         }
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         public async Task ShouldReportConsoleLogs()
         {
             var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
-            Page.Console += (sender, e) => consoleTcs.TrySetResult(e.Message);
+            Page.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1)`)");
 
@@ -70,7 +70,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         public async Task ShouldHaveJSHandlesForConsoleLogs()
         {
             var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
-            Page.Console += (sender, e) =>
+            Page.Console += (_, e) =>
             {
                 consoleTcs.TrySetResult(e.Message);
             };
@@ -86,7 +86,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         public async Task ShouldHaveAnExecutionContext()
         {
             var workerCreatedTcs = new TaskCompletionSource<Worker>();
-            Page.WorkerCreated += (sender, e) => workerCreatedTcs.TrySetResult(e.Worker);
+            Page.WorkerCreated += (_, e) => workerCreatedTcs.TrySetResult(e.Worker);
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1)`)");
             var worker = await workerCreatedTcs.Task;
@@ -97,7 +97,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         public async Task ShouldReportErrors()
         {
             var errorTcs = new TaskCompletionSource<string>();
-            Page.PageError += (sender, e) => errorTcs.TrySetResult(e.Message);
+            Page.PageError += (_, e) => errorTcs.TrySetResult(e.Message);
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript, throw new Error('this is my error');`)");
             var errorLog = await errorTcs.Task;

--- a/lib/PuppeteerSharp/Helpers/MultiMap.cs
+++ b/lib/PuppeteerSharp/Helpers/MultiMap.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,7 +9,7 @@ namespace PuppeteerSharp.Helpers
         private readonly ConcurrentDictionary<TKey, List<TValue>> _map = new ConcurrentDictionary<TKey, List<TValue>>();
 
         internal void Add(TKey key, TValue value)
-            => _map.GetOrAdd(key, k => new List<TValue>()).Add(value);
+            => _map.GetOrAdd(key, _ => new List<TValue>()).Add(value);
 
         internal List<TValue> Get(TKey key)
             => _map.TryGetValue(key, out var set) ? set : new List<TValue>();

--- a/lib/PuppeteerSharp/LauncherBase.cs
+++ b/lib/PuppeteerSharp/LauncherBase.cs
@@ -61,7 +61,7 @@ namespace PuppeteerSharp
 
             if (options.DumpIO)
             {
-                Process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine(e.Data);
+                Process.ErrorDataReceived += (_, e) => Console.Error.WriteLine(e.Data);
             }
         }
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -81,7 +81,7 @@ namespace PuppeteerSharp
 
             _screenshotTaskQueue = screenshotTaskQueue;
 
-            _ = target.CloseTask.ContinueWith((arg) =>
+            _ = target.CloseTask.ContinueWith(_ =>
             {
                 try
                 {
@@ -1835,14 +1835,14 @@ namespace PuppeteerSharp
             var networkManager = FrameManager.NetworkManager;
 
             Client.MessageReceived += Client_MessageReceived;
-            FrameManager.FrameAttached += (sender, e) => FrameAttached?.Invoke(this, e);
-            FrameManager.FrameDetached += (sender, e) => FrameDetached?.Invoke(this, e);
-            FrameManager.FrameNavigated += (sender, e) => FrameNavigated?.Invoke(this, e);
+            FrameManager.FrameAttached += (_, e) => FrameAttached?.Invoke(this, e);
+            FrameManager.FrameDetached += (_, e) => FrameDetached?.Invoke(this, e);
+            FrameManager.FrameNavigated += (_, e) => FrameNavigated?.Invoke(this, e);
 
-            networkManager.Request += (sender, e) => Request?.Invoke(this, e);
-            networkManager.RequestFailed += (sender, e) => RequestFailed?.Invoke(this, e);
-            networkManager.Response += (sender, e) => Response?.Invoke(this, e);
-            networkManager.RequestFinished += (sender, e) => RequestFinished?.Invoke(this, e);
+            networkManager.Request += (_, e) => Request?.Invoke(this, e);
+            networkManager.RequestFailed += (_, e) => RequestFailed?.Invoke(this, e);
+            networkManager.Response += (_, e) => Response?.Invoke(this, e);
+            networkManager.RequestFinished += (_, e) => RequestFinished?.Invoke(this, e);
 
             await Task.WhenAll(
                Client.SendAsync("Target.setAutoAttach", new TargetSetAutoAttachRequest

--- a/lib/PuppeteerSharp/Target.cs
+++ b/lib/PuppeteerSharp/Target.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using PuppeteerSharp.Helpers;
@@ -149,8 +149,8 @@ namespace PuppeteerSharp
             return new Worker(
                 client,
                 TargetInfo.Url,
-                (consoleType, handles, stackTrace) => Task.CompletedTask,
-                (e) => { });
+                (_, _, _) => Task.CompletedTask,
+                _ => { });
         }
 
         private async Task<Page> CreatePageAsync()


### PR DESCRIPTION
requires c#9 branch to be merged first https://github.com/hardkoded/puppeteer-sharp/pull/1634

https://docs.microsoft.com/en-us/dotnet/csharp/discards

> Because there's only a single discard variable, that variable may not even be allocated storage. Discards can reduce memory allocations. Discards make the intent of your code clear. They enhance its readability and maintainability.