### PR TITLE
Add missing `-f $framework`

### DIFF
--- a/appveyor-linux.yml
+++ b/appveyor-linux.yml
@@ -28,7 +28,7 @@ build_script:
 
     dotnet build -f $framework ./lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
 
-    dotnet build ./lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
+    dotnet build -f $framework ./lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
 
     dotnet build -f $framework ./lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
 


### PR DESCRIPTION
```
$ export framework=netcoreapp2.2
```
```
$ dotnet build ./lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
Microsoft (R) Build Engine version 16.7.2+b60ddb6f4 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored /home/androbin/data/git/puppeteer-sharp/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj (in 365 ms).
  PuppeteerSharp.TestServer -> /home/androbin/data/git/puppeteer-sharp/lib/PuppeteerSharp.TestServer/bin/Debug/netcoreapp2.2/PuppeteerSharp.TestServer.dll
/usr/share/dotnet/sdk/3.1.407/Microsoft.Common.CurrentVersion.targets(1177,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.8 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [/home/androbin/data/git/puppeteer-sharp/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj]

Build FAILED.

/usr/share/dotnet/sdk/3.1.407/Microsoft.Common.CurrentVersion.targets(1177,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.8 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [/home/androbin/data/git/puppeteer-sharp/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:01.55
```
```
$ dotnet build -f $framework ./lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
Microsoft (R) Build Engine version 16.7.2+b60ddb6f4 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  PuppeteerSharp.TestServer -> /home/androbin/data/git/puppeteer-sharp/lib/PuppeteerSharp.TestServer/bin/Debug/netcoreapp2.2/PuppeteerSharp.TestServer.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:00.47
```