### PR TITLE
Added GitHub-Repo to Useful links

### DIFF
--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -21,6 +21,7 @@ Puppeteer Sharp is a .NET port of the official [Node.JS Puppeteer API](https://g
 
 # Useful links
 
+* [GitHub-Repo](https://github.com/hardkoded/puppeteer-sharp)
 * Slack channel [#puppeteer-sharp](https://puppeteer.slack.com/join/shared_invite/enQtMzU4MjIyMDA5NTM4LWI0YTE0MjM0NWQzYmE2MTRmNjM1ZTBkN2MxNmJmNTIwNTJjMmFhOWFjMGExMDViYjk2YjU2ZmYzMmE1NmExYzc)
 * [StackOverflow](https://stackoverflow.com/search?q=puppeteer-sharp)
 * [Issues](https://github.com/kblok/puppeteer-sharp/issues?utf8=%E2%9C%93&q=is%3Aissue)

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -22,6 +22,6 @@ Puppeteer Sharp is a .NET port of the official [Node.JS Puppeteer API](https://g
 # Useful links
 
 * [GitHub-Repo](https://github.com/hardkoded/puppeteer-sharp)
-* Slack channel [#puppeteer-sharp](https://puppeteer.slack.com/join/shared_invite/enQtMzU4MjIyMDA5NTM4LWI0YTE0MjM0NWQzYmE2MTRmNjM1ZTBkN2MxNmJmNTIwNTJjMmFhOWFjMGExMDViYjk2YjU2ZmYzMmE1NmExYzc)
+* Slack channel [#puppeteer-sharp](https://www.hardkoded.com/goto/pptr-slack)
 * [StackOverflow](https://stackoverflow.com/search?q=puppeteer-sharp)
 * [Issues](https://github.com/kblok/puppeteer-sharp/issues?utf8=%E2%9C%93&q=is%3Aissue)


### PR DESCRIPTION
I really missed that link ;)
additionally: the link for the slack channel doesn't work anymore. it says it is expired.