### PR TITLE
Avoid leaking reference to partially constructed Frame instance

### DIFF
--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -61,16 +61,16 @@ namespace PuppeteerSharp
             ParentFrame = parentFrame;
             Id = frameId;
 
-            if (parentFrame != null)
-            {
-                ParentFrame.ChildFrames.Add(this);
-            }
-
             WaitTasks = new List<WaitTask>();
             LifecycleEvents = new List<string>();
 
             MainWorld = new DOMWorld(FrameManager, this, FrameManager.TimeoutSettings);
             SecondaryWorld = new DOMWorld(FrameManager, this, FrameManager.TimeoutSettings);
+
+            if (parentFrame != null)
+            {
+                ParentFrame.ChildFrames.Add(this);
+            }
         }
 
         #region Properties


### PR DESCRIPTION
The upstream counterpart for reference:
https://github.com/puppeteer/puppeteer/blob/b349c91e7df76630b7411d6645e649945c4609bd/src/common/FrameManager.ts#L593

See #1670 for context