### PR TITLE
Add missing `TaskCreationOptions.RunContinuationsAsynchronously` (tests)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/SimpleServer.cs
+++ b/lib/PuppeteerSharp.TestServer/SimpleServer.cs
@@ -120,7 +120,7 @@ namespace PuppeteerSharp.TestServer
 
         public async Task<T> WaitForRequest<T>(string path, Func<HttpRequest, T> selector)
         {
-            var taskCompletion = new TaskCompletionSource<T>();
+            var taskCompletion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
             _requestSubscribers.Add(path, (httpRequest) =>
             {
                 taskCompletion.SetResult(selector(httpRequest));

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -63,7 +63,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             var context = await Browser.CreateIncognitoBrowserContextAsync();
             var page = await context.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
-            var popupTargetCompletion = new TaskCompletionSource<Target>();
+            var popupTargetCompletion = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             Browser.TargetCreated += (_, e) => popupTargetCompletion.SetResult(e.Target);
 
             await Task.WhenAll(

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldSendFrameNavigatedWhenNavigatingOnAnchorURLs()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var frameNavigated = new TaskCompletionSource<bool>();
+            var frameNavigated = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.FrameNavigated += (_, _) => frameNavigated.TrySetResult(true);
             await Task.WhenAll(
                 Page.GoToAsync(TestConstants.EmptyPage + "#foo"),
@@ -164,7 +164,7 @@ namespace PuppeteerSharp.Tests.FrameTests
                 window.frame.remove();
             }");
             Assert.True(frame1.Detached);
-            var frame2tsc = new TaskCompletionSource<Frame>();
+            var frame2tsc = new TaskCompletionSource<Frame>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.FrameAttached += (_, e) => frame2tsc.TrySetResult(e.Frame);
             await Page.EvaluateExpressionAsync("document.body.appendChild(window.frame)");
             var frame2 = await frame2tsc.Task;

--- a/lib/PuppeteerSharp.Tests/FrameTests/GoToTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/GoToTests.cs
@@ -90,7 +90,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         private class MatchingResponseData
         {
             public Task<Frame> FrameTask { get; internal set; }
-            public TaskCompletionSource<string> ServerResponseTcs { get; internal set; } = new TaskCompletionSource<string>();
+            public TaskCompletionSource<string> ServerResponseTcs { get; internal set; } = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             public Task<Response> NavigationTask { get; internal set; }
         }
     }

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserAcceptTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserAcceptTests.cs
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.InputTests
         {
             await Page.SetContentAsync("<input type=file oninput='javascript:console.timeStamp()'>");
             var waitForTask = Page.WaitForFileChooserAsync();
-            var metricsTcs = new TaskCompletionSource<bool>();
+            var metricsTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await Task.WhenAll(
                 waitForTask,

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0764.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0764.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.Issues
         [SkipBrowserFact(skipFirefox: true)]
         public async Task BufferAsyncShouldWorkWithBinaries()
         {
-            var tcs = new TaskCompletionSource<byte[]>();
+            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Response += async (_, e) =>
             {
                 if (e.Response.Url.Contains("digits/0.png"))

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             // Setup server to trap request.
-            var serverResponseCompletion = new TaskCompletionSource<bool>();
+            var serverResponseCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             HttpResponse serverResponse = null;
             Server.SetRoute("/get", context =>
             {
@@ -67,7 +67,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             // send request and wait for server response
             Task WaitForPageResponseEvent()
             {
-                var completion = new TaskCompletionSource<bool>();
+                var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 Page.Response += (_, e) =>
                 {
                     if (!TestUtils.IsFavicon(e.Response.Request))

--- a/lib/PuppeteerSharp.Tests/NetworkTests/SetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/SetRequestInterceptionTests.cs
@@ -108,7 +108,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             await Page.SetRequestInterceptionAsync(true);
             var requests = new List<Request>();
-            var requestsReadyTcs = new TaskCompletionSource<bool>();
+            var requestsReadyTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Page.Request += async (_, e) =>
             {
@@ -534,7 +534,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.SetContentAsync("<iframe></iframe>");
             await Page.SetRequestInterceptionAsync(true);
             Request request = null;
-            var requestIntercepted = new TaskCompletionSource<bool>();
+            var requestIntercepted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Request += (_, e) =>
             {
                 request = e.Request;

--- a/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/beforeunload.html");
 
-            var dialogTask = new TaskCompletionSource<bool>();
+            var dialogTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Dialog += async (_, e) =>
             {
                 Assert.Equal(DialogType.BeforeUnload, e.Dialog.DialogType);
@@ -67,7 +67,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 dialogTask.TrySetResult(true);
             };
 
-            var closeTask = new TaskCompletionSource<bool>();
+            var closeTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Close += (_, _) => closeTask.TrySetResult(true);
 
             // We have to interact with a page so that 'beforeunload' handlers

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/CloseTests.cs
@@ -15,13 +15,13 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldWorkWithWindowClose()
         {
-            var newPageTaskSource = new TaskCompletionSource<Page>();
+            var newPageTaskSource = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             Context.TargetCreated += async (_, e) => newPageTaskSource.TrySetResult(await e.Target.PageAsync());
 
             await Page.EvaluateExpressionAsync("window['newPage'] = window.open('about:blank');");
             var newPage = await newPageTaskSource.Task;
 
-            var closeTaskSource = new TaskCompletionSource<bool>();
+            var closeTaskSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             newPage.Close += (_, _) => closeTaskSource.SetResult(true);
             await Page.EvaluateExpressionAsync("window['newPage'].close();");
             await closeTaskSource.Task;
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldWorkWithPageClose()
         {
             var newPage = await Context.NewPageAsync();
-            var closeTaskSource = new TaskCompletionSource<bool>();
+            var closeTaskSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             newPage.Close += (_, _) => closeTaskSource.SetResult(true);
             await newPage.CloseAsync();
             await closeTaskSource.Task;

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/ConsoleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/ConsoleTests.cs
@@ -88,7 +88,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldNotFailForWindowObject()
         {
-            var consoleTcs = new TaskCompletionSource<string>();
+            var consoleTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             void EventHandler(object sender, ConsoleEventArgs e)
             {
@@ -110,7 +110,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldTriggerCorrectLog()
         {
             await Page.GoToAsync(TestConstants.AboutBlank);
-            var messageTask = new TaskCompletionSource<ConsoleMessage>();
+            var messageTask = new TaskCompletionSource<ConsoleMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Page.Console += (_, e) => messageTask.TrySetResult(e.Message);
 
@@ -132,7 +132,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldHaveLocationWhenFetchFails()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var consoleTask = new TaskCompletionSource<ConsoleEventArgs>();
+            var consoleTask = new TaskCompletionSource<ConsoleEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Console += (_, e) => consoleTask.TrySetResult(e);
 
             await Task.WhenAll(
@@ -152,7 +152,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldHaveLocationForConsoleAPICalls()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var consoleTask = new TaskCompletionSource<ConsoleEventArgs>();
+            var consoleTask = new TaskCompletionSource<ConsoleEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Console += (_, e) => consoleTask.TrySetResult(e);
 
             await Task.WhenAll(

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/DOMContentLoadedTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/DOMContentLoadedTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         public async Task ShouldFireWhenExpected()
         {
             var _ = Page.GoToAsync(TestConstants.AboutBlank);
-            var completion = new TaskCompletionSource<bool>();
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.DOMContentLoaded += (_, _) => completion.SetResult(true);
             await completion.Task;
         }

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/PopupTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/PopupTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldWork()
         {
-            var popupTaskSource = new TaskCompletionSource<Page>();
+            var popupTaskSource = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldWorkWithNoopener()
         {
-            var popupTaskSource = new TaskCompletionSource<Page>();
+            var popupTaskSource = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetContentAsync("<a target=_blank href='/one-style.html'>yo</a>");
 
-            var popupTaskSource = new TaskCompletionSource<Page>();
+            var popupTaskSource = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
@@ -63,7 +63,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetContentAsync("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
 
-            var popupTaskSource = new TaskCompletionSource<Page>();
+            var popupTaskSource = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(
@@ -80,7 +80,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetContentAsync("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
 
-            var popupTaskSource = new TaskCompletionSource<Page>();
+            var popupTaskSource = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
 
             await Task.WhenAll(

--- a/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
@@ -293,10 +293,10 @@ namespace PuppeteerSharp.Tests.PageTests
                 "/fetch-request-c.js",
                 "/fetch-request-d.js" })
             {
-                fetches[url] = new TaskCompletionSource<bool>();
+                fetches[url] = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 Server.SetRoute(url, async context =>
                 {
-                    var taskCompletion = new TaskCompletionSource<Func<HttpResponse, Task>>();
+                    var taskCompletion = new TaskCompletionSource<Func<HttpResponse, Task>>(TaskCreationOptions.RunContinuationsAsynchronously);
                     responses.Add(taskCompletion);
                     fetches[context.Request.Path].SetResult(true);
                     var actionResponse = await taskCompletion.Task;
@@ -311,7 +311,7 @@ namespace PuppeteerSharp.Tests.PageTests
             );
             var secondFetchResourceRequested = Server.WaitForRequest("/fetch-request-d.js");
 
-            var pageLoaded = new TaskCompletionSource<bool>();
+            var pageLoaded = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             void WaitPageLoad(object sender, EventArgs e)
             {
                 pageLoaded.SetResult(true);

--- a/lib/PuppeteerSharp.Tests/PageTests/MetricsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/MetricsTests.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task MetricsEventFiredOnConsoleTimespan()
         {
-            var metricsTaskWrapper = new TaskCompletionSource<MetricEventArgs>();
+            var metricsTaskWrapper = new TaskCompletionSource<MetricEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Metrics += (_, e) => metricsTaskWrapper.SetResult(e);
 
             await Page.EvaluateExpressionAsync("console.timeStamp('test42')");

--- a/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
@@ -91,7 +91,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldAwaitResourcesToLoad()
         {
             var imgPath = "/img.png";
-            var imgResponse = new TaskCompletionSource<bool>();
+            var imgResponse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Server.SetRoute(imgPath, _ => imgResponse.Task);
             var loaded = false;
             var waitTask = Server.WaitForRequest(imgPath);

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNavigationTests.cs
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkWithBothDomcontentloadedAndLoad()
         {
-            var responseCompleted = new TaskCompletionSource<bool>();
+            var responseCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Server.SetRoute("/one-style.css", _ =>
             {
                 return responseCompleted.Task;
@@ -150,14 +150,14 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             Server.SetRoute("/frames/style.css", _ => Task.CompletedTask);
             var navigationTask = Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
-            var frameAttachedTaskSource = new TaskCompletionSource<Frame>();
+            var frameAttachedTaskSource = new TaskCompletionSource<Frame>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.FrameAttached += (_, e) =>
             {
                 frameAttachedTaskSource.SetResult(e.Frame);
             };
 
             var frame = await frameAttachedTaskSource.Task;
-            var frameNavigatedTaskSource = new TaskCompletionSource<bool>();
+            var frameNavigatedTaskSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.FrameNavigated += (_, e) =>
             {
                 if (e.Frame == frame)

--- a/lib/PuppeteerSharp.Tests/PuppeteerBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerBaseTest.cs
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests
 
         protected static Task<JToken> WaitEvent(CDPSession emitter, string eventName)
         {
-            var completion = new TaskCompletionSource<JToken>();
+            var completion = new TaskCompletionSource<JToken>(TaskCreationOptions.RunContinuationsAsynchronously);
             void handler(object sender, MessageEventArgs e)
             {
                 if (e.MessageID != eventName)
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Tests
 
         protected static Task WaitForBrowserDisconnect(Browser browser)
         {
-            var disconnectedTask = new TaskCompletionSource<bool>();
+            var disconnectedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             browser.Disconnected += (_, _) => disconnectedTask.TrySetResult(true);
             return disconnectedTask.Task;
         }

--- a/lib/PuppeteerSharp.Tests/PuppeteerPageBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerPageBaseTest.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests
 
         protected Task WaitForError()
         {
-            var wrapper = new TaskCompletionSource<bool>();
+            var wrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             void errorEvent(object sender, ErrorEventArgs e)
             {

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/FixturesTests.cs
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldCloseTheBrowserWhenTheConnectedProcessCloses()
         {
-            var browserClosedTaskWrapper = new TaskCompletionSource<bool>();
+            var browserClosedTaskWrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var ChromiumLauncher = new ChromiumLauncher(
                 new BrowserFetcher(Product.Chrome).RevisionInfo().ExecutablePath,
                 new LaunchOptions { Headless = true });
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldCloseTheBrowserWhenTheLaunchedProcessCloses()
         {
-            var browserClosedTaskWrapper = new TaskCompletionSource<bool>();
+            var browserClosedTaskWrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var browser = await Puppeteer.LaunchAsync(new LaunchOptions { Headless = true }, TestConstants.LoggerFactory);
 
             browser.Disconnected += (_, _) =>

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             {
                 BrowserWSEndpoint = originalBrowser.WebSocketEndpoint
             });
-            var tcsDisconnected = new TaskCompletionSource<bool>();
+            var tcsDisconnected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             originalBrowser.Disconnected += (_, _) => tcsDisconnected.TrySetResult(true);
             await Task.WhenAll(
@@ -117,7 +117,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             {
                 BrowserWSEndpoint = browserOne.WebSocketEndpoint
             });
-            var tcs = new TaskCompletionSource<Page>();
+            var tcs = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             async void TargetCreated(object sender, TargetChangedArgs e)
             {
                 tcs.TrySetResult(await e.Target.PageAsync());

--- a/lib/PuppeteerSharp.Tests/TargetTests/TargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetTests/TargetTests.cs
@@ -74,7 +74,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             Assert.Contains(Page, allPages);
             Assert.Contains(otherPage, allPages);
 
-            var closePageTaskCompletion = new TaskCompletionSource<Page>();
+            var closePageTaskCompletion = new TaskCompletionSource<Page>(TaskCreationOptions.RunContinuationsAsynchronously);
             async void TargetDestroyedEventHandler(object sender, TargetChangedArgs e)
             {
                 closePageTaskCompletion.SetResult(await e.Target.PageAsync());
@@ -93,7 +93,7 @@ namespace PuppeteerSharp.Tests.TargetTests
         public async Task ShouldReportWhenAServiceWorkerIsCreatedAndDestroyed()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var createdTargetTaskCompletion = new TaskCompletionSource<Target>();
+            var createdTargetTaskCompletion = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             void TargetCreatedEventHandler(object sender, TargetChangedArgs e)
             {
                 createdTargetTaskCompletion.SetResult(e.Target);
@@ -106,7 +106,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             Assert.Equal(TargetType.ServiceWorker, createdTarget.Type);
             Assert.Equal(TestConstants.ServerUrl + "/serviceworkers/empty/sw.js", createdTarget.Url);
 
-            var targetDestroyedTaskCompletion = new TaskCompletionSource<Target>();
+            var targetDestroyedTaskCompletion = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             void TargetDestroyedEventHandler(object sender, TargetChangedArgs e)
             {
                 targetDestroyedTaskCompletion.SetResult(e.Target);
@@ -145,7 +145,7 @@ namespace PuppeteerSharp.Tests.TargetTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
 
-            var changedTargetTaskCompletion = new TaskCompletionSource<Target>();
+            var changedTargetTaskCompletion = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             void ChangedTargetEventHandler(object sender, TargetChangedArgs e)
             {
                 changedTargetTaskCompletion.SetResult(e.Target);
@@ -157,7 +157,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             var changedTarget = await changedTargetTaskCompletion.Task;
             Assert.Equal(TestConstants.CrossProcessUrl + "/", changedTarget.Url);
 
-            changedTargetTaskCompletion = new TaskCompletionSource<Target>();
+            changedTargetTaskCompletion = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             Context.TargetChanged += ChangedTargetEventHandler;
             await Page.GoToAsync(TestConstants.EmptyPage);
             changedTarget = await changedTargetTaskCompletion.Task;
@@ -170,7 +170,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             var targetChanged = false;
             void listener(object sender, TargetChangedArgs e) => targetChanged = true;
             Context.TargetChanged += listener;
-            var targetCompletionTask = new TaskCompletionSource<Target>();
+            var targetCompletionTask = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             void TargetCreatedEventHandler(object sender, TargetChangedArgs e)
             {
                 targetCompletionTask.SetResult(e.Target);
@@ -182,7 +182,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             Assert.Equal(TestConstants.AboutBlank, target.Url);
 
             var newPage = await newPageTask;
-            targetCompletionTask = new TaskCompletionSource<Target>();
+            targetCompletionTask = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             Context.TargetCreated += TargetCreatedEventHandler;
             var evaluateTask = newPage.EvaluateExpressionHandleAsync("window.open('about:blank')");
             var target2 = await targetCompletionTask.Task;
@@ -196,7 +196,7 @@ namespace PuppeteerSharp.Tests.TargetTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldNotCrashWhileRedirectingIfOriginalRequestWasMissed()
         {
-            var serverResponseEnd = new TaskCompletionSource<bool>();
+            var serverResponseEnd = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var serverResponse = (HttpResponse)null;
             Server.SetRoute("/one-style.css", context => { serverResponse = context.Response; return serverResponseEnd.Task; });
             // Open a new page. Use window.open to connect to the page later.
@@ -220,7 +220,7 @@ namespace PuppeteerSharp.Tests.TargetTests
         public async Task ShouldHaveAnOpener()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var targetCreatedCompletion = new TaskCompletionSource<Target>();
+            var targetCreatedCompletion = new TaskCompletionSource<Target>(TaskCreationOptions.RunContinuationsAsynchronously);
             Browser.TargetCreated += (_, e) => targetCreatedCompletion.TrySetResult(e.Target);
             await Page.GoToAsync(TestConstants.ServerUrl + "/popup/window-open.html");
             var createdTarget = await targetCreatedCompletion.Task;

--- a/lib/PuppeteerSharp.Tests/WorkerTests/WorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/WorkerTests.cs
@@ -16,8 +16,8 @@ namespace PuppeteerSharp.Tests.WorkerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task PageWorkers()
         {
-            var workerCreatedTcs = new TaskCompletionSource<bool>();
-            var workerDestroyedTcs = new TaskCompletionSource<bool>();
+            var workerCreatedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var workerDestroyedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Page.WorkerCreated += (_, _) => workerCreatedTcs.TrySetResult(true);
             Page.WorkerDestroyed += (_, _) => workerDestroyedTcs.TrySetResult(true);
@@ -38,12 +38,12 @@ namespace PuppeteerSharp.Tests.WorkerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldEmitCreatedAndDestroyedEvents()
         {
-            var workerCreatedTcs = new TaskCompletionSource<Worker>();
+            var workerCreatedTcs = new TaskCompletionSource<Worker>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.WorkerCreated += (_, e) => workerCreatedTcs.TrySetResult(e.Worker);
 
             var workerObj = await Page.EvaluateFunctionHandleAsync("() => new Worker('data:text/javascript,1')");
             var worker = await workerCreatedTcs.Task;
-            var workerDestroyedTcs = new TaskCompletionSource<Worker>();
+            var workerDestroyedTcs = new TaskCompletionSource<Worker>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.WorkerDestroyed += (_, e) => workerDestroyedTcs.TrySetResult(e.Worker);
             await Page.EvaluateFunctionAsync("workerObj => workerObj.terminate()", workerObj);
             Assert.Same(worker, await workerDestroyedTcs.Task);
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldReportConsoleLogs()
         {
-            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1)`)");
@@ -70,7 +70,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldHaveJSHandlesForConsoleLogs()
         {
-            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.Console += (_, e) =>
             {
                 consoleTcs.TrySetResult(e.Message);
@@ -86,7 +86,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldHaveAnExecutionContext()
         {
-            var workerCreatedTcs = new TaskCompletionSource<Worker>();
+            var workerCreatedTcs = new TaskCompletionSource<Worker>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.WorkerCreated += (_, e) => workerCreatedTcs.TrySetResult(e.Worker);
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1)`)");
@@ -97,7 +97,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldReportErrors()
         {
-            var errorTcs = new TaskCompletionSource<string>();
+            var errorTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             Page.PageError += (_, e) => errorTcs.TrySetResult(e.Message);
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript, throw new Error('this is my error');`)");


### PR DESCRIPTION
See #1672, which covered only the `PuppeteerSharp` package.
This PR covers the `PuppeteerSharp.Tests` and `PuppeteerSharp.TestServer` packages.