### PR TITLE
Fix Page._workers concurrency issues

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -40,7 +40,7 @@ namespace PuppeteerSharp
         private readonly TaskQueue _screenshotTaskQueue;
         private readonly EmulationManager _emulationManager;
         private readonly Dictionary<string, Delegate> _pageBindings;
-        private readonly Dictionary<string, Worker> _workers;
+        private readonly IDictionary<string, Worker> _workers;
         private readonly ILogger _logger;
         private PageGetLayoutMetricsResponse _burstModeMetrics;
         private bool _screenshotBurstModeOn;
@@ -74,7 +74,7 @@ namespace PuppeteerSharp
             _timeoutSettings = new TimeoutSettings();
             _emulationManager = new EmulationManager(client);
             _pageBindings = new Dictionary<string, Delegate>();
-            _workers = new Dictionary<string, Worker>();
+            _workers = new ConcurrentDictionary<string, Worker>();
             _logger = Client.Connection.LoggerFactory.CreateLogger<Page>();
             Accessibility = new Accessibility(client);
 


### PR DESCRIPTION
I have prepared a test project to demonstrate the errors that can occur with the current version: [Test.zip](https://github.com/hardkoded/puppeteer-sharp/files/6289319/Test.zip)

- `Object reference not set to an instance of an object.`
- `Index was outside the bounds of the array.`
- `Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.`
- `TryGetValue` returns wrong value

Fixes #1681