### PR TITLE
Fix WaitTasks concurrency issues

### DIFF
--- a/lib/PuppeteerSharp/DOMWorld.cs
+++ b/lib/PuppeteerSharp/DOMWorld.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -16,7 +17,7 @@ namespace PuppeteerSharp
         private TaskCompletionSource<ExecutionContext> _contextResolveTaskWrapper;
         private TaskCompletionSource<ElementHandle> _documentCompletionSource;
 
-        internal List<WaitTask> WaitTasks { get; set; }
+        internal ICollection<WaitTask> WaitTasks { get; set; }
 
         internal Frame Frame { get; }
 
@@ -28,7 +29,7 @@ namespace PuppeteerSharp
 
             SetContext(null);
 
-            WaitTasks = new List<WaitTask>();
+            WaitTasks = new ConcurrentSet<WaitTask>();
             _detached = false;
         }
 
@@ -56,7 +57,7 @@ namespace PuppeteerSharp
             _detached = true;
             while (WaitTasks.Count > 0)
             {
-                WaitTasks[0].Terminate(new Exception("waitForFunction failed: frame got detached."));
+                WaitTasks.First().Terminate(new Exception("waitForFunction failed: frame got detached."));
             }
         }
 

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -40,8 +40,6 @@ namespace PuppeteerSharp
     {
         private readonly CDPSession _client;
 
-        internal List<WaitTask> WaitTasks { get; }
-
         internal string Id { get; set; }
 
         internal string LoaderId { get; set; }
@@ -61,7 +59,6 @@ namespace PuppeteerSharp
             ParentFrame = parentFrame;
             Id = frameId;
 
-            WaitTasks = new List<WaitTask>();
             LifecycleEvents = new List<string>();
 
             MainWorld = new DOMWorld(FrameManager, this, FrameManager.TimeoutSettings);


### PR DESCRIPTION
I have prepared a test project to demonstrate the errors that can occur with the current version:  [Test.zip](https://github.com/hardkoded/puppeteer-sharp/files/6289374/Test.zip)

- `Index was out of range. Must be non-negative and less than the size of the collection. Parameter name: index`
- `Index was outside the bounds of the array.`
- `Contains` returns wrong value

See #1680 