### PR TITLE
`chmod +x crashpad_handler`

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -308,8 +308,14 @@ namespace PuppeteerSharp
                 var executables = new string[]
                 {
                     "chrome",
+                    "chrome_sandbox", // setuid
                     "crashpad_handler",
+                    "google-chrome",
                     "nacl_helper",
+                    "nacl_helper_bootstrap",
+                    "xdg-mime",
+                    "xdg-settings",
+                    "cron/google-chrome",
                 };
 
                 foreach (var executable in executables)


### PR DESCRIPTION
Fixes `PuppeteerSharp.Tests.LauncherTests.PuppeteerLaunchTests.ShouldWorkWithNoDefaultArguments` on Linux
See #1643