### PR TITLE
Bump Default Firefox Revision

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -63,9 +63,9 @@ namespace PuppeteerSharp
         public const string DefaultChromiumRevision = "884014";
 
         /// <summary>
-        /// Default Chromium revision.
+        /// Default Firefox revision.
         /// </summary>
-        public const string DefaultFirefoxRevision = "90.0a1";
+        public const string DefaultFirefoxRevision = "91.0a1";
 
         /// <summary>
         /// Gets the downloads folder.


### PR DESCRIPTION
Revision `90.0a1` is no longer available under [`nightly/latest-mozilla-central`](https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/), but revision `91.0a1` is.
Note that revision `90.0a1` is still available under [`nightly/2021/05/2021-05-31-11-57-11-mozilla-central`](https://archive.mozilla.org/pub/firefox/nightly/2021/05/2021-05-31-11-57-11-mozilla-central/).

Fixes the current CI failures.