### PR TITLE
Issue 1590 - Docfx code examples update

### DIFF
--- a/docfx_project/examples/index.md
+++ b/docfx_project/examples/index.md
@@ -7,7 +7,7 @@ Puppeteer Sharp is a .NET port of the official [Node.JS Puppeteer API](https://g
 ## Take screenshots
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
 var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 {
     Headless = true
@@ -30,7 +30,7 @@ await page.SetViewportAsync(new ViewPortOptions
 ## Generate PDF files
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
 var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 {
     Headless = true
@@ -38,6 +38,19 @@ var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.PdfAsync(outputFile);
+```
+
+## Get Inner Text of an Element
+
+```cs
+using (var page = await browser.NewPageAsync())
+{
+    await page.GoToAsync("https://www.hardkoded.com/blog/ui-testing-with-puppeteer-released");
+    var pageHeaderHandle = await page.QuerySelectorAsync("h1");
+    var innerTextHandle = await pageHeaderHandle.GetPropertyAsync("innerText");
+    var innerText = await innerTextHandle.JsonValueAsync();
+    // Inner Text: UI testing with Puppeteer book officially released!
+}
 ```
 
 ## Inject HTML


### PR DESCRIPTION
closes #1590 

Added example of getting the inner text of an element.

Updated deprecated DownloadAsync() overload usage to the newer recommended usage.