### PR TITLE
Set CA1001 to "Error" and resolved issues

### DIFF
--- a/demos/PuppeteerSharpPdfDemo/Program.cs
+++ b/demos/PuppeteerSharpPdfDemo/Program.cs
@@ -16,7 +16,8 @@ namespace PuppeteerSharpPdfDemo
             };
 
             Console.WriteLine("Downloading chromium");
-            await new BrowserFetcher().DownloadAsync();
+            using var browserFetcher = new BrowserFetcher();
+            await browserFetcher.DownloadAsync();
 
             Console.WriteLine("Navigating google");
             using (var browser = await Puppeteer.LaunchAsync(options))

--- a/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo-Local.csproj
+++ b/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo-Local.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net471</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net471'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>

--- a/docfx_project/api/index.md
+++ b/docfx_project/api/index.md
@@ -7,7 +7,8 @@ Puppeteer Sharp is a .NET port of the official [Node.JS Puppeteer API](https://g
 ## Take screenshots
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+using var browserFetcher = new BrowserFetcher();
+await browserFetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
 var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 {
     Headless = true
@@ -45,7 +46,8 @@ await page.PdfAsync(outputFile);
 ### Generate PDF files with custom options
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+using var browserFetcher = new BrowserFetcher();
+await browserFetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
 var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 {
     Headless = true

--- a/docfx_project/examples/ChromeExtension.md
+++ b/docfx_project/examples/ChromeExtension.md
@@ -10,10 +10,11 @@ You need to test a chrome extension
 Use `Puppeteer.LaunchAsync` passing arguments specifying to load your extension.
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+using var browserFetcher = new BrowserFetcher();
+await browserFetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
 
 var pathToExtension = "path/to/extension";
-var launhcOptions = new LaunhcOptions()
+var launchOptions = new LaunchOptions()
 {
     Headless = false,
     Args = new []

--- a/docfx_project/examples/Page.ScreenshotAsync.md
+++ b/docfx_project/examples/Page.ScreenshotAsync.md
@@ -10,7 +10,8 @@ You need to take an screenshot of a page.
 Use `Page.ScreenshotAsync` passing a file path as an argument.
 
 ```cs
-new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+using var browserFetcher = new BrowserFetcher();
+await browserFetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
 
 var url = "https://www.somepage.com";
 var file = ".\\somepage.jpg";

--- a/docfx_project/examples/ReuseChrome.md
+++ b/docfx_project/examples/ReuseChrome.md
@@ -13,7 +13,7 @@ Use `BrowserFetcherOptions` to specify the full path for where to download Chrom
 
 ```
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
-var browserFetcher = new BrowserFetcher(browserFetcherOptions);
+using var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 await browserFetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
 ```
 

--- a/docfx_project/examples/index.md
+++ b/docfx_project/examples/index.md
@@ -7,7 +7,8 @@ Puppeteer Sharp is a .NET port of the official [Node.JS Puppeteer API](https://g
 ## Take screenshots
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
+using var browserFetcher = new BrowserFetcher();
+await browserFetcher.DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
 var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 {
     Headless = true
@@ -30,7 +31,8 @@ await page.SetViewportAsync(new ViewPortOptions
 ## Generate PDF files
 
 ```cs
-await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
+using var browserFetcher = new BrowserFetcher();
+await browserFetcher.DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
 var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 {
     Headless = true

--- a/lib/PuppeteerSharp.DevicesFetcher/Program.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Program.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.DevicesFetcher
             }
 
             string chromeVersion = null;
-            var fetcher = new BrowserFetcher();
+            using var fetcher = new BrowserFetcher();
 
             await fetcher.DownloadAsync();
             await using (var browser = await Puppeteer.LaunchAsync(new LaunchOptions()))

--- a/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
@@ -19,9 +19,10 @@ namespace PuppeteerSharp.Tests.FixturesTests
         public async Task ShouldDumpBrowserProcessStderr()
         {
             var success = false;
+            using var browserFetcher = new BrowserFetcher(Product.Chrome);
             var process = GetTestAppProcess(
                 "PuppeteerSharp.Tests.DumpIO",
-                $"\"{(await new BrowserFetcher(Product.Chrome).GetRevisionInfoAsync()).ExecutablePath}\"");
+                $"\"{(await browserFetcher.GetRevisionInfoAsync().ConfigureAwait(false)).ExecutablePath}\"");
 
             process.ErrorDataReceived += (_, e) =>
             {
@@ -38,8 +39,9 @@ namespace PuppeteerSharp.Tests.FixturesTests
         public async Task ShouldCloseTheBrowserWhenTheConnectedProcessCloses()
         {
             var browserClosedTaskWrapper = new TaskCompletionSource<bool>();
+            using var browserFetcher = new BrowserFetcher(Product.Chrome);
             var ChromiumLauncher = new ChromiumLauncher(
-                (await new BrowserFetcher(Product.Chrome).GetRevisionInfoAsync()).ExecutablePath,
+                (await browserFetcher.GetRevisionInfoAsync()).ExecutablePath,
                 new LaunchOptions { Headless = true });
 
             await ChromiumLauncher.StartAsync().ConfigureAwait(false);

--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserFetcherTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserFetcherTests.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldDownloadAndExtractLinuxBinary()
         {
-            var browserFetcher = Puppeteer.CreateBrowserFetcher(new BrowserFetcherOptions
+            using var browserFetcher = Puppeteer.CreateBrowserFetcher(new BrowserFetcherOptions
             {
                 Platform = Platform.Linux,
                 Path = _downloadsFolder,
@@ -76,7 +76,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldDownloadAndExtractFirefoxLinuxBinary()
         {
-            var browserFetcher = Puppeteer.CreateBrowserFetcher(new BrowserFetcherOptions
+            using var browserFetcher = Puppeteer.CreateBrowserFetcher(new BrowserFetcherOptions
             {
                 Platform = Platform.Linux,
                 Path = _downloadsFolder,

--- a/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
             #region PdfAsync
 
-            var browserFetcher = new BrowserFetcher();
+            using var browserFetcher = new BrowserFetcher();
             await browserFetcher.DownloadAsync();
             await using var browser = await Puppeteer.LaunchAsync(new LaunchOptions {Headless = true});
             await using var page = await browser.NewPageAsync();

--- a/lib/PuppeteerSharp.Tests/PuppeteerLoaderFixture.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerLoaderFixture.cs
@@ -21,7 +21,8 @@ namespace PuppeteerSharp.Tests
 
         private async Task SetupAsync()
         {
-            var downloaderTask = new BrowserFetcher(TestConstants.IsChrome ? Product.Chrome : Product.Firefox).DownloadAsync();
+            using var browserFetcher = new BrowserFetcher(TestConstants.IsChrome ? Product.Chrome : Product.Firefox);
+            var downloaderTask = browserFetcher.DownloadAsync();
 
             Server = SimpleServer.Create(TestConstants.Port, TestUtils.FindParentDirectory("PuppeteerSharp.TestServer"));
             HttpsServer = SimpleServer.CreateHttps(TestConstants.HttpsPort, TestUtils.FindParentDirectory("PuppeteerSharp.TestServer"));

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                 fileInfo.Delete();
             }
             #region ScreenshotAsync
-            var browserFetcher = new BrowserFetcher();
+            using var browserFetcher = new BrowserFetcher();
             await browserFetcher.DownloadAsync();
             await using var browser = await Puppeteer.LaunchAsync(
                 new LaunchOptions { Headless = true });

--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -68,7 +68,7 @@
     <Rule Id="CA1062" Action="Error" /> <!-- Error CA1031: Modify 'DeleteAsync' to catch a more specific allowed exception type, or rethrow the exception. (CA1031)-->
     <Rule Id="CA1063" Action="Error" /> <!-- Error CA1063: Provide an overridable implementation of Dispose(bool) -->
     <Rule Id="CA1064" Action="Error" /> <!-- Error CA1064: Exceptions should be public (CA1064)-->
-    <Rule Id="CA1001" Action="None" /> <!-- Error CA1001: A class owns a disposable -->
+    <Rule Id="CA1001" Action="Error" /> <!-- Error CA1001: A class owns a disposable -->
     <Rule Id="CA1304" Action="Error" /> <!-- Error CA1304: The behavior of 'string.ToLower()' could vary based on the current user's locale settings. Replace this call in 'JSHandle.ToString()' with a call to 'string.ToLower(CultureInfo)'. (CA1304) -->
     <Rule Id="CA1305" Action="Error" /> <!-- String.Format with culture-->
     <Rule Id="CA1720" Action="Error" /> <!-- Error SA1720: Name contains type-->

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -547,7 +547,11 @@ namespace PuppeteerSharp
         /// created by Puppeteer.
         /// </summary>
         /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
-        protected virtual void Dispose(bool disposing) => _ = CloseAsync();
+        protected virtual void Dispose(bool disposing) => _ = CloseAsync()
+            .ContinueWith(_ =>
+            {
+                ScreenshotTaskQueue.Dispose();
+            }, TaskScheduler.Default);
 
         #endregion
 

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -548,10 +548,9 @@ namespace PuppeteerSharp
         /// </summary>
         /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
         protected virtual void Dispose(bool disposing) => _ = CloseAsync()
-            .ContinueWith(_ =>
-            {
-                ScreenshotTaskQueue.Dispose();
-            }, TaskScheduler.Default);
+            .ContinueWith(
+                _ => ScreenshotTaskQueue.DisposeAsync(),
+                TaskScheduler.Default);
 
         #endregion
 

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -30,7 +30,7 @@ namespace PuppeteerSharp
     /// var browser = await await Puppeteer.LaunchAsync(new LaunchOptions { ExecutablePath = revisionInfo.ExecutablePath});
     /// </code>
     /// </example>
-    public class BrowserFetcher
+    public class BrowserFetcher : IDisposable
     {
         private static readonly Dictionary<Product, string> _hosts = new Dictionary<Product, string>
         {
@@ -51,6 +51,7 @@ namespace PuppeteerSharp
         };
 
         private readonly WebClient _webClient = new WebClient();
+        private bool _isDisposed;
 
         /// <summary>
         /// Default Chromium revision.
@@ -626,5 +627,33 @@ namespace PuppeteerSharp
 
         private static string GetDownloadURL(Product product, Platform platform, string host, string revision)
             => string.Format(CultureInfo.CurrentCulture, _downloadUrls[(product, platform)], host, revision, GetArchiveName(product, platform, revision));
+
+        /// <summary>
+        /// Disposes of any disposable members in <see cref="BrowserFetcher" />.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of any disposable members in <see cref="BrowserFetcher" />.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _webClient.Dispose();
+            }
+
+            _isDisposed = true;
+        }
     }
 }

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -331,6 +331,7 @@ namespace PuppeteerSharp
         {
             Close("Connection disposed");
             Transport.Dispose();
+            _callbackQueue.Dispose();
         }
         #endregion
     }

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -330,6 +330,8 @@ namespace PuppeteerSharp
         protected virtual void Dispose(bool disposing)
         {
             Close("Connection disposed");
+            Transport.MessageReceived -= Transport_MessageReceived;
+            Transport.Closed -= Transport_Closed;
             Transport.Dispose();
             _callbackQueue.Dispose();
         }

--- a/lib/PuppeteerSharp/Helpers/TaskQueue.cs
+++ b/lib/PuppeteerSharp/Helpers/TaskQueue.cs
@@ -4,9 +4,10 @@ using System.Threading.Tasks;
 
 namespace PuppeteerSharp.Helpers
 {
-    internal class TaskQueue
+    internal class TaskQueue : IDisposable
     {
         private readonly SemaphoreSlim _semaphore;
+        private bool _isDisposed;
 
         internal TaskQueue() => _semaphore = new SemaphoreSlim(1);
 
@@ -34,6 +35,27 @@ namespace PuppeteerSharp.Helpers
             {
                 _semaphore.Release();
             }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool dispose)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (dispose)
+            {
+                _semaphore.Dispose();
+            }
+
+            _isDisposed = true;
         }
     }
 }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -208,7 +208,7 @@ namespace PuppeteerSharp
             }
 
             var revision = Environment.GetEnvironmentVariable("PUPPETEER_CHROMIUM_REVISION");
-            var browserFetcher = new BrowserFetcher(_product);
+            using var browserFetcher = new BrowserFetcher(_product);
             RevisionInfo revisionInfo;
 
             if (!string.IsNullOrEmpty(revision))

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -2528,7 +2528,7 @@ namespace PuppeteerSharp
         /// calling <see cref="Dispose()"/>, you must release all references to the <see cref="Page"/> so
         /// the garbage collector can reclaim the memory that the <see cref="Page"/> was occupying.</remarks>
         /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
-        protected virtual void Dispose(bool disposing) => _ = CloseAsync();
+        protected virtual void Dispose(bool disposing) => _ = DisposeAsync();
         #endregion
 
         #region IAsyncDisposable
@@ -2540,7 +2540,10 @@ namespace PuppeteerSharp
         /// calling <see cref="DisposeAsync"/>, you must release all references to the <see cref="Page"/> so
         /// the garbage collector can reclaim the memory that the <see cref="Page"/> was occupying.</remarks>
         /// <returns>ValueTask</returns>
-        public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
+        public ValueTask DisposeAsync() => new ValueTask(CloseAsync()
+            .ContinueWith(
+                _ => _screenshotTaskQueue.DisposeAsync(),
+                TaskScheduler.Default));
         #endregion
     }
 }

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -158,6 +158,7 @@ namespace PuppeteerSharp.Transport
             // Make sure any outstanding asynchronous read operation is cancelled.
             StopReading();
             _client?.Dispose();
+            _socketQueue.Dispose();
         }
 
         #endregion

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace PuppeteerSharp
 {
-    internal class WaitTask
+    internal class WaitTask : IDisposable
     {
         private readonly DOMWorld _world;
         private readonly string _predicateBody;
@@ -21,6 +21,7 @@ namespace PuppeteerSharp
 
         private int _runCount;
         private bool _terminated;
+        private bool _isDisposing;
 
         private const string WaitForPredicatePageFunction = @"
 async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...args) {
@@ -232,8 +233,26 @@ async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...
             {
                 _cts.Cancel();
             }
-            _cts?.Dispose();
             _world.WaitTasks.Remove(this);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool dispose)
+        {
+            if (_isDisposing)
+            {
+                return;
+            }
+
+            _cts.Dispose();
+            _timeoutTimer?.Dispose();
+
+            _isDisposing = true;
         }
     }
 }

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -250,7 +250,6 @@ async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...
             }
 
             _cts.Dispose();
-            _timeoutTimer?.Dispose();
 
             _isDisposing = true;
         }

--- a/samples/PupppeterSharpAspNetFrameworkSample/PupppeterSharpAspNetFrameworkSample/Services/BrowserClient.cs
+++ b/samples/PupppeterSharpAspNetFrameworkSample/PupppeterSharpAspNetFrameworkSample/Services/BrowserClient.cs
@@ -11,7 +11,7 @@ namespace PupppeterSharpAspNetFrameworkSample.Services
 
         public static async Task<string> GetTextAsync(string url)
         {
-            var browserFetcher = new BrowserFetcher(new BrowserFetcherOptions()
+            using var browserFetcher = new BrowserFetcher(new BrowserFetcherOptions()
             {
                 Path = HostPath
             });
@@ -23,7 +23,7 @@ namespace PupppeterSharpAspNetFrameworkSample.Services
                 TransportFactory = AspNetWebSocketTransport.AspNetTransportFactory,
                 ExecutablePath = browserFetcher.GetExecutablePath(BrowserFetcher.DefaultRevision)
             }).ConfigureAwait(false))
-            using(var page = await browser.NewPageAsync().ConfigureAwait(false))
+            using (var page = await browser.NewPageAsync().ConfigureAwait(false))
             {
                 var response = await page.GoToAsync(url).ConfigureAwait(false);
                 return await response.TextAsync().ConfigureAwait(false);


### PR DESCRIPTION
closes #1423 

For classes with disposable members, made those classes implement IDisposable, using the recommended Dispose() methods.

This created a ripple effect where the newly disposable classes needed to be disposed of wherever used.

Updated documentation, examples, sample code, and demos where `BrowserFetcher` is used and could be disposed.

@kblok sorry, this one has got a lot of changes. Documentation aside, the rest was necessary to satisfy the analyzer.