### PR TITLE
Allow ResponseData.Headers to support multiple values for the same key

### DIFF
--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -238,13 +238,11 @@ namespace PuppeteerSharp
             {
                 foreach (var keyValuePair in response.Headers)
                 {
-                    // Skip headers with null values
                     if (keyValuePair.Value == null)
                     {
                         continue;
                     }
 
-                    // Use ICollection instead of IEnumerable as string implements IEnumerable
                     if (keyValuePair.Value is ICollection values)
                     {
                         foreach (var val in values)

--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -231,24 +232,41 @@ namespace PuppeteerSharp
 
             _interceptionHandled = true;
 
-            var responseHeaders = new Dictionary<string, string>();
+            var responseHeaders = new List<Header>();
 
             if (response.Headers != null)
             {
-                foreach (var keyValue in response.Headers)
+                foreach (var keyValuePair in response.Headers)
                 {
-                    responseHeaders[keyValue.Key] = keyValue.Value.ToString();
+                    // Skip headers with null values
+                    if (keyValuePair.Value == null)
+                    {
+                        continue;
+                    }
+
+                    // Use ICollection instead of IEnumerable as string implements IEnumerable
+                    if (keyValuePair.Value is ICollection values)
+                    {
+                        foreach (var val in values)
+                        {
+                            responseHeaders.Add(new Header { Name = keyValuePair.Key, Value = val.ToString() });
+                        }
+                    }
+                    else
+                    {
+                        responseHeaders.Add(new Header { Name = keyValuePair.Key, Value = keyValuePair.Value.ToString() });
+                    }
+                }
+
+                if (!response.Headers.ContainsKey("content-length") && response.BodyData != null)
+                {
+                    responseHeaders.Add(new Header { Name = "content-length", Value = response.BodyData.Length.ToString(CultureInfo.CurrentCulture) });
                 }
             }
 
             if (response.ContentType != null)
             {
-                responseHeaders["content-type"] = response.ContentType;
-            }
-
-            if (!responseHeaders.ContainsKey("content-length") && response.BodyData != null)
-            {
-                responseHeaders["content-length"] = response.BodyData.Length.ToString(CultureInfo.CurrentCulture);
+                responseHeaders.Add(new Header { Name = "content-type", Value = response.ContentType });
             }
 
             try
@@ -257,7 +275,7 @@ namespace PuppeteerSharp
                 {
                     RequestId = InterceptionId,
                     ResponseCode = response.Status != null ? (int)response.Status : 200,
-                    ResponseHeaders = HeadersArray(responseHeaders),
+                    ResponseHeaders = responseHeaders.ToArray(),
                     Body = response.BodyData != null ? Convert.ToBase64String(response.BodyData) : null
                 }).ConfigureAwait(false);
             }

--- a/lib/PuppeteerSharp/ResponseData.cs
+++ b/lib/PuppeteerSharp/ResponseData.cs
@@ -25,7 +25,9 @@ namespace PuppeteerSharp
         /// <value>The body as binary.</value>
         public byte[] BodyData { get; set; }
         /// <summary>
-        /// Response headers. Header values will be converted to a string.
+        /// Response headers. Header values will be converted to strings. Headers with null values will be
+        /// ignored. When multiple headers values are required use an <see cref="System.Collections.ICollection"/>
+        /// to add multiple values for the Header key.
         /// </summary>
         /// <value>Headers.</value>
         public Dictionary<string, object> Headers { get; set; }


### PR DESCRIPTION
- Without breaking the current API this change allows for arrays of values
  (Anything that implements ICollection and can be iterated over).
- The Headers with null values will be ignored, previously an exception
  would have occurred with the Value.ToString() call so this is unlikely
  a breaking change in behaviour.
- New test case added

Resolves https://github.com/hardkoded/puppeteer-sharp/issues/1542
Replaces #1607

