### PR TITLE
Add an option to include/specify a custom delegate to download the browser.

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -52,6 +52,7 @@ namespace PuppeteerSharp
         };
 
         private readonly WebClient _webClient = new WebClient();
+        private readonly CustomFileDownloadAction _customFileDownload;
         private bool _isDisposed;
 
         /// <summary>
@@ -91,11 +92,6 @@ namespace PuppeteerSharp
         public Product Product { get; }
 
         /// <summary>
-        /// Gets the default or a custom download delegate
-        /// </summary>
-        public GetBrowserAsync GetBrowserTaskAsync { get; }
-
-        /// <summary>
         /// Proxy used by the WebClient in <see cref="DownloadAsync(int)"/> and <see cref="CanDownloadAsync(int)"/>
         /// </summary>
         public IWebProxy WebProxy
@@ -118,7 +114,7 @@ namespace PuppeteerSharp
             DownloadHost = _hosts[Product.Chrome];
             Platform = GetCurrentPlatform();
             Product = Product.Chrome;
-            GetBrowserTaskAsync = _webClient.DownloadFileTaskAsync;
+            _customFileDownload = _webClient.DownloadFileTaskAsync;
         }
 
         /// <summary>
@@ -146,7 +142,7 @@ namespace PuppeteerSharp
             DownloadHost = string.IsNullOrEmpty(options.Host) ? _hosts[options.Product] : options.Host;
             Platform = options.Platform ?? GetCurrentPlatform();
             Product = options.Product;
-            GetBrowserTaskAsync = options.GetBrowserTaskAsync ?? _webClient.DownloadFileTaskAsync;
+            _customFileDownload = options.CustomFileDownload ?? _webClient.DownloadFileTaskAsync;
         }
 
         /// <summary>
@@ -299,7 +295,7 @@ namespace PuppeteerSharp
                 _webClient.DownloadProgressChanged += DownloadProgressChanged;
             }
 
-            await GetBrowserTaskAsync(url, filePath).ConfigureAwait(false);
+            await _customFileDownload(url, filePath).ConfigureAwait(false);
 
             if (filePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
             {

--- a/lib/PuppeteerSharp/BrowserFetcherOptions.cs
+++ b/lib/PuppeteerSharp/BrowserFetcherOptions.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp
         /// <param name="address">address</param>
         /// <param name="fileName">fileName</param>
         /// <returns></returns>
-        public delegate Task GetBrowserAsync(string address, string fileName);
+        public delegate Task CustomFileDownloadAction(string address, string fileName);
 
         /// <summary>
         /// Product. Defaults to Chrome.
@@ -39,6 +39,6 @@ namespace PuppeteerSharp
         /// <summary>
         /// Gets the default or a custom download delegate
         /// </summary>
-        public GetBrowserAsync GetBrowserTaskAsync { get; set; }
+        public CustomFileDownloadAction CustomFileDownload { get; set; }
     }
 }


### PR DESCRIPTION
To Support using a cache browser location.

Scenario: Azure function runs for a limited amount of time (10 mins  - Consumption plan), and one has to download the browser each time the app starts!

> Azure Functions/Apps with *Headless Chromium*
>  -  [Headless Chromium ONLY works in the Linux Consumption plan](https://anthonychu.ca/post/azure-functions-headless-chromium-puppeteer-playwright/)
>  -  [Linux consumption apps ONLY Run-From-Package.](https://stackoverflow.com/a/56035713/3563013)
>  -  [You can ONLY use "shared mounted storage" or `Path.GetTempPath()`.](https://anthonychu.ca/post/azure-functions-puppeteer-pdf-razor-template/)

https://github.com/hardkoded/puppeteer-sharp/discussions/1845