### PR TITLE
Fixed issue with disposing shared screenshot task queue

### DIFF
--- a/lib/PuppeteerSharp.Tests/Issues/Issue1878.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue1878.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using PuppeteerSharp.Tests.Attributes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PuppeteerSharp.Tests.Issues
+{
+    [Collection(TestConstants.TestFixtureCollectionName)]
+    public class Issue1878 : PuppeteerBrowserContextBaseTest
+    {
+        public Issue1878(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [PuppeteerFact]
+        public async Task MultiplePagesShouldNotShareSameScreenshotTaskQueue()
+        {
+            // 1st page
+            using (Page page = await Context.NewPageAsync())
+            {
+                var html = "...some html..";
+                await page.GoToAsync($"data:text/html,{html}", new NavigationOptions
+                {
+                    WaitUntil = new[]
+                    {
+                        WaitUntilNavigation.DOMContentLoaded,
+                        WaitUntilNavigation.Load,
+                        WaitUntilNavigation.Networkidle0,
+                        WaitUntilNavigation.Networkidle2
+                    }
+                });
+
+                await page.ScreenshotAsync("...some path...");
+            }
+
+            //2nd page
+            using (Page page = await Context.NewPageAsync())
+            {
+                var html = "...some html...";
+                await page.GoToAsync($"data:text/html,{html}", new NavigationOptions
+                {
+                    WaitUntil = new[]
+                    {
+                        WaitUntilNavigation.DOMContentLoaded,
+                        WaitUntilNavigation.Load,
+                        WaitUntilNavigation.Networkidle0,
+                        WaitUntilNavigation.Networkidle2
+                    }
+                });
+
+                await page.ScreenshotAsync("...some path..."); //<- will throw because Browser TaskQueue is disposed when 1st Page is disposed
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -2586,9 +2586,6 @@ namespace PuppeteerSharp
         /// calling <see cref="DisposeAsync"/>, you must release all references to the <see cref="Page"/> so
         /// the garbage collector can reclaim the memory that the <see cref="Page"/> was occupying.</remarks>
         /// <returns>ValueTask</returns>
-        public ValueTask DisposeAsync() => new ValueTask(CloseAsync()
-            .ContinueWith(
-                _ => _screenshotTaskQueue.DisposeAsync(),
-                TaskScheduler.Default));
+        public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
     }
 }


### PR DESCRIPTION
This fixes #1878 .

Note that the `TaskQueue` is indeed already disposed as expected when the `Browser` [is disposed](https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp/Browser.cs#L554-L557).