### PR TITLE
Add Page.WaitForNetworkIdleAsync

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
-                await Page.WaitForNetworkIdleAsync(timeout:1));
+                await Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { Timeout = 1 }));
 
             Assert.Contains("Timeout of 1 ms exceeded", exception.Message);
         }
@@ -63,7 +63,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var t2 = DateTime.Now;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var task = Page.WaitForNetworkIdleAsync(idleTime: 10).ContinueWith(x => t1 = DateTime.Now);
+            var task = Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { IdleTime = 10 }).ContinueWith(x => t1 = DateTime.Now);
 
             await Task.WhenAll(
                 task,
@@ -96,7 +96,7 @@ namespace PuppeteerSharp.Tests.PageTests
             };
 
             await Task.WhenAll(
-                Page.WaitForNetworkIdleAsync(timeout: 0),
+                Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { Timeout = 0 }),
                 Page.EvaluateFunctionAsync(@"() => setTimeout(() => {
                         fetch('/digits/1.png');
                         fetch('/digits/2.png');

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PuppeteerSharp.Tests.Attributes;
+using PuppeteerSharp.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PuppeteerSharp.Tests.PageTests
+{
+    [Collection(TestConstants.TestFixtureCollectionName)]
+    public class WaitForNetworkIdleTests : PuppeteerPageBaseTest
+    {
+        public WaitForNetworkIdleTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [PuppeteerTest("page.spec.ts", "Page.waitForNetworkIdle", "should work")]
+        [PuppeteerFact]
+        public async Task ShouldWork()
+        {
+            var t1 = DateTime.Now;
+            var t2 = DateTime.Now;
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var task = Page.WaitForNetworkIdleAsync().ContinueWith(x => t1 = DateTime.Now);
+
+            await Task.WhenAll(
+                task,
+                Page.EvaluateFunctionAsync(@"
+                    (async () => {
+                        await Promise.all([
+                                fetch('/digits/1.png'),
+                                fetch('/digits/2.png'),
+                            ]);
+                        await new Promise((resolve) => setTimeout(resolve, 200));
+                        await fetch('/digits/3.png');
+                        await new Promise((resolve) => setTimeout(resolve, 200));
+                        await fetch('/digits/4.png');
+                    })();").ContinueWith(x => t2 = DateTime.Now)
+            );
+
+            Assert.True(t1 > t2);
+            Assert.True((t1 - t2).TotalMilliseconds >= 400);
+        }
+
+        [PuppeteerTest("page.spec.ts", "Page.waitForNetworkIdle", "should respect timeout")]
+        [PuppeteerFact]
+        public async Task ShouldRespectTimeout()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var exception = await Assert.ThrowsAnyAsync<TimeoutException>(async () =>
+                await Page.WaitForNetworkIdleAsync(timeout:1));
+
+            Assert.Contains("Timeout of 1 ms exceeded", exception.Message);
+        }
+
+        [PuppeteerTest("page.spec.ts", "Page.waitForNetworkIdle", "should respect idleTime")]
+        [PuppeteerFact]
+        public async Task ShouldRespectIdleTimeout()
+        {
+            var t1 = DateTime.Now;
+            var t2 = DateTime.Now;
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var task = Page.WaitForNetworkIdleAsync(idleTime: 10).ContinueWith(x => t1 = DateTime.Now);
+
+            await Task.WhenAll(
+                task,
+                Page.EvaluateFunctionAsync(@"
+                    (async () => {
+                        await Promise.all([
+                            fetch('/digits/1.png'),
+                            fetch('/digits/2.png'),
+                        ]);
+                        await new Promise((resolve) => setTimeout(resolve, 250));
+                    })();").ContinueWith(x => t2 = DateTime.Now)
+            );
+
+            Assert.True(t1 > t2);
+        }
+
+        [PuppeteerTest("page.spec.ts", "Page.waitForNetworkIdle", "should work with no timeout")]
+        [PuppeteerFact]
+        public async Task ShouldWorkWithNoTimeout()
+        {
+            var responseCount = 0;
+            var responseUrls = new List<string>(3);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            Page.FrameManager.NetworkManager.Response += (sender, args) =>
+            {
+                responseCount++;
+                responseUrls.Add(args.Response.Url);
+            };
+
+            await Task.WhenAll(
+                Page.WaitForNetworkIdleAsync(timeout: 0),
+                Page.EvaluateFunctionAsync(@"() => setTimeout(() => {
+                        fetch('/digits/1.png');
+                        fetch('/digits/2.png');
+                        fetch('/digits/3.png');
+                    }, 50)")
+            );
+
+            Assert.Equal(3, responseCount);
+            Assert.All(responseUrls, x =>
+            {
+                Assert.StartsWith(TestConstants.ServerUrl + "/digits", x);
+                Assert.EndsWith(".png", x);
+            });
+        }
+    }
+}

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
@@ -223,6 +224,11 @@ namespace PuppeteerSharp
                     Request = request
                 });
             }
+        }
+
+        internal int NumRequestsInProgress()
+        {
+            return _requestIdToRequest.Count(x => x.Value.Response == null);
         }
 
         private void ForgetRequest(Request request, bool events)

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -226,10 +226,8 @@ namespace PuppeteerSharp
             }
         }
 
-        internal int NumRequestsInProgress()
-        {
-            return _requestIdToRequest.Count(x => x.Value.Response == null);
-        }
+        internal int NumRequestsInProgress
+            => _requestIdToRequest.Count(x => x.Value.Response == null);
 
         private void ForgetRequest(Request request, bool events)
         {

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1695,9 +1695,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Waits for Network Idle
         /// </summary>
-        /// <param name="timeout">Maximum wait time in milliseconds, defaults to 30 seconds, pass 0 to disable the timeout.
-        /// The default value can be changed by using the <see cref="Page.DefaultTimeout"/> property.</param>
-        /// <param name="idleTime">How long to wait for no network requests in milliseconds, defaults to 500 milliseconds.</param>
+        /// <param name="options">Optional waiting parameters</param>
         /// <returns>returns Task which resolves when network is idle</returns>
         /// <example>
         /// <code>
@@ -1707,12 +1705,10 @@ namespace PuppeteerSharp
         /// ]]>
         /// </code>
         /// </example>
-        public async Task WaitForNetworkIdleAsync(int? timeout = null, int idleTime = 500)
+        public async Task WaitForNetworkIdleAsync(WaitForNetworkIdleOptions options = null)
         {
-            if (timeout == null)
-            {
-                timeout = _timeoutSettings.Timeout;
-            }
+            var timeout = options?.Timeout ?? DefaultTimeout;
+            var idleTime = options?.IdleTime ?? 500;
 
             var networkIdleTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1732,7 +1728,7 @@ namespace PuppeteerSharp
             {
                 idleTimer.Stop();
 
-                if (networkManager.NumRequestsInProgress() == 0)
+                if (networkManager.NumRequestsInProgress == 0)
                 {
                     idleTimer.Start();
                 }
@@ -1755,7 +1751,7 @@ namespace PuppeteerSharp
 
             Evaluate();
 
-            await Task.WhenAny(networkIdleTcs.Task, SessionClosedTask).WithTimeout(timeout.Value, t =>
+            await Task.WhenAny(networkIdleTcs.Task, SessionClosedTask).WithTimeout(timeout, t =>
             {
                 Cleanup();
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1738,15 +1738,8 @@ namespace PuppeteerSharp
                 }
             }
 
-            void RequestEventListener(object sender, RequestEventArgs e)
-            {
-                Evaluate();
-            }
-
-            void ResponseEventListener(object sender, ResponseCreatedEventArgs e)
-            {
-                Evaluate();
-            }
+            void RequestEventListener(object sender, RequestEventArgs e) => Evaluate();
+            void ResponseEventListener(object sender, ResponseCreatedEventArgs e) => Evaluate();
 
             void Cleanup()
             {

--- a/lib/PuppeteerSharp/WaitForNetworkIdleOptions.cs
+++ b/lib/PuppeteerSharp/WaitForNetworkIdleOptions.cs
@@ -1,0 +1,20 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Optional waiting parameters.
+    /// </summary>
+    /// <seealso cref="Page.WaitForNetworkIdleAsync"/>
+    public class WaitForNetworkIdleOptions
+    {
+        /// <summary>
+        /// Maximum time to wait for in milliseconds. Defaults to 30000 (30 seconds). Pass 0 to disable timeout.
+        /// The default value can be changed by setting the <see cref="Page.DefaultTimeout"/> property.
+        /// </summary>
+        public int? Timeout { get; set; }
+
+        /// <summary>
+        /// How long to wait for no network requests in milliseconds, defaults to 500 milliseconds.
+        /// </summary>
+        public int? IdleTime { get; set; }
+    }
+}


### PR DESCRIPTION
Adds new `Page.WaitForNetworkIdleAsync` method ported from [page.waitForNetworkIdle](https://github.com/puppeteer/puppeteer/blob/8ff9d598bf4afd10cbc61ca9579b7bd38edb8026/src/common/Page.ts#L1942)

The current method signature looks like the following:

```c#
public async Task WaitForNetworkIdleAsync(int? timeout = null, int idleTime = 500)
```

The other `WaitFor` methods use `WaitForOptions` which only has a `Timeout` property. Happy to add a new `WaitForNetworkIdleOptions` class if required, though seems overkill for two optional params.

I've expanded the `ShouldWorkWithNoTimeout` test a little, I would have liked to see the responses validated to confirm that not only did the requests complete, that the expected number completed. So I've done that in `ShouldWorkWithNoTimeout`

Tests passing locally, be great to have a second pair of eyes on this.

Resolves #1911