### PR TITLE
Configure SA1201 action as error

### DIFF
--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -14,7 +14,7 @@
     <Rule Id="SA1516" Action="Error" /> <!-- Error SA1516: Elements should be separated by blank line (SA1516)-->
     <Rule Id="SA1629" Action="None" /> <!-- Error SA1629: Documentation text should end with a period (SA1629)-->
     <Rule Id="SA1514" Action="None" /> <!-- Error SA1514: Element documentation header should be preceded by blank line (SA1514)-->
-    <Rule Id="SA1201" Action="Error" /> <!-- Error SA1201: A constructor should not follow a property (SA1201)-->
+    <Rule Id="SA1201" Action="Error" /> <!-- Error SA1201: Elements must appear in the correct order (SA1201)-->
     <Rule Id="SA1202" Action="None" /> <!-- Error SA1202: 'public' members should come before 'internal' members (SA1202)-->
     <Rule Id="SA1210" Action="Error" /> <!-- Error SA1210: Using directives should be ordered alphabetically by the namespaces. (SA1210)-->
     <Rule Id="SA1208" Action="Error" /> <!-- Error SA1208: Order usings-->

--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -14,7 +14,7 @@
     <Rule Id="SA1516" Action="Error" /> <!-- Error SA1516: Elements should be separated by blank line (SA1516)-->
     <Rule Id="SA1629" Action="None" /> <!-- Error SA1629: Documentation text should end with a period (SA1629)-->
     <Rule Id="SA1514" Action="None" /> <!-- Error SA1514: Element documentation header should be preceded by blank line (SA1514)-->
-    <Rule Id="SA1201" Action="None" /> <!-- Error SA1201: A constructor should not follow a property (SA1201)-->
+    <Rule Id="SA1201" Action="Error" /> <!-- Error SA1201: A constructor should not follow a property (SA1201)-->
     <Rule Id="SA1202" Action="None" /> <!-- Error SA1202: 'public' members should come before 'internal' members (SA1202)-->
     <Rule Id="SA1210" Action="Error" /> <!-- Error SA1210: Using directives should be ordered alphabetically by the namespaces. (SA1210)-->
     <Rule Id="SA1208" Action="Error" /> <!-- Error SA1208: Order usings-->

--- a/lib/PuppeteerSharp/BoundingBox.cs
+++ b/lib/PuppeteerSharp/BoundingBox.cs
@@ -10,27 +10,6 @@ namespace PuppeteerSharp
     public class BoundingBox : IEquatable<BoundingBox>
     {
         /// <summary>
-        /// The x coordinate of the element in pixels.
-        /// </summary>
-        /// <value>The x.</value>
-        public decimal X { get; set; }
-        /// <summary>
-        /// The y coordinate of the element in pixels.
-        /// </summary>
-        /// <value>The y.</value>
-        public decimal Y { get; set; }
-        /// <summary>
-        /// The width of the element in pixels.
-        /// </summary>
-        /// <value>The width.</value>
-        public decimal Width { get; set; }
-        /// <summary>
-        /// The height of the element in pixels.
-        /// </summary>
-        /// <value>The height.</value>
-        public decimal Height { get; set; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="T:PuppeteerSharp.BoundingBox"/> class.
         /// </summary>
         public BoundingBox()
@@ -51,6 +30,27 @@ namespace PuppeteerSharp
             Width = width;
             Height = height;
         }
+
+        /// <summary>
+        /// The x coordinate of the element in pixels.
+        /// </summary>
+        /// <value>The x.</value>
+        public decimal X { get; set; }
+        /// <summary>
+        /// The y coordinate of the element in pixels.
+        /// </summary>
+        /// <value>The y.</value>
+        public decimal Y { get; set; }
+        /// <summary>
+        /// The width of the element in pixels.
+        /// </summary>
+        /// <value>The width.</value>
+        public decimal Width { get; set; }
+        /// <summary>
+        /// The height of the element in pixels.
+        /// </summary>
+        /// <value>The height.</value>
+        public decimal Height { get; set; }
 
         internal Clip ToClip()
         {

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -42,14 +42,10 @@ namespace PuppeteerSharp
         /// </summary>
         private const int CloseTimeout = 5000;
 
-        #region Private members
-
         private readonly ConcurrentDictionary<string, BrowserContext> _contexts;
         private readonly ILogger<Browser> _logger;
         private readonly Func<TargetInfo, bool> _targetFilterCallback;
         private Task _closeTask;
-
-        #endregion
 
         internal Browser(
             Connection connection,
@@ -75,8 +71,6 @@ namespace PuppeteerSharp
             _logger = Connection.LoggerFactory.CreateLogger<Browser>();
             _targetFilterCallback = targetFilter ?? ((TargetInfo _) => true);
         }
-
-        #region Events
 
         /// <summary>
         /// Raised when the <see cref="Browser"/> gets closed.
@@ -104,10 +98,6 @@ namespace PuppeteerSharp
         /// Raised when a target is destroyed, for example when a page is closed
         /// </summary>
         public event EventHandler<TargetChangedArgs> TargetDestroyed;
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         /// Gets the Browser websocket url
@@ -176,9 +166,6 @@ namespace PuppeteerSharp
         internal LauncherBase Launcher { get; set; }
 
         internal IDictionary<string, Target> TargetsMap { get; }
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         /// Creates a new page
@@ -370,10 +357,6 @@ namespace PuppeteerSharp
             Closed?.Invoke(this, new EventArgs());
         }
 
-        #endregion
-
-        #region Private Methods
-
         internal void ChangeTarget(Target target)
         {
             var args = new TargetChangedArgs { Target = target };
@@ -538,9 +521,6 @@ namespace PuppeteerSharp
 
             return browser;
         }
-        #endregion
-
-        #region IDisposable
 
         /// <inheritdoc />
         public void Dispose()
@@ -559,17 +539,11 @@ namespace PuppeteerSharp
                 _ => ScreenshotTaskQueue.DisposeAsync(),
                 TaskScheduler.Default);
 
-        #endregion
-
-        #region IAsyncDisposable
-
         /// <summary>
         /// Closes <see cref="Connection"/> and any Chromium <see cref="Process"/> that was
         /// created by Puppeteer.
         /// </summary>
         /// <returns>ValueTask</returns>
         public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -56,52 +56,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Default Chromium revision.
         /// </summary>
-        [Obsolete("Use DefaultChromiumRevision instead")]
-        public static int DefaultRevision { get; } = int.Parse(DefaultChromiumRevision, CultureInfo.CurrentCulture.NumberFormat);
-
-        /// <summary>
-        /// Default Chromium revision.
-        /// </summary>
         public const string DefaultChromiumRevision = "970485";
-
-        /// <summary>
-        /// Default Firefox revision.
-        /// </summary>
-        public string DefaultFirefoxRevision { get; private set; } = "latest";
-
-        /// <summary>
-        /// Gets the downloads folder.
-        /// </summary>
-        public string DownloadsFolder { get; }
-
-        /// <summary>
-        /// A download host to be used. Defaults to https://storage.googleapis.com.
-        /// </summary>
-        public string DownloadHost { get; }
-
-        /// <summary>
-        /// Gets the platform.
-        /// </summary>
-        public Platform Platform { get; }
-
-        /// <summary>
-        /// Gets the product.
-        /// </summary>
-        public Product Product { get; }
-
-        /// <summary>
-        /// Proxy used by the WebClient in <see cref="DownloadAsync(int)"/> and <see cref="CanDownloadAsync(int)"/>
-        /// </summary>
-        public IWebProxy WebProxy
-        {
-            get => _webClient.Proxy;
-            set => _webClient.Proxy = value;
-        }
-
-        /// <summary>
-        /// Occurs when download progress in <see cref="DownloadAsync(int)"/> changes.
-        /// </summary>
-        public event DownloadProgressChangedEventHandler DownloadProgressChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BrowserFetcher"/> class.
@@ -141,6 +96,51 @@ namespace PuppeteerSharp
             Platform = options.Platform ?? GetCurrentPlatform();
             Product = options.Product;
             _customFileDownload = options.CustomFileDownload ?? _webClient.DownloadFileTaskAsync;
+        }
+
+        /// <summary>
+        /// Occurs when download progress in <see cref="DownloadAsync(int)"/> changes.
+        /// </summary>
+        public event DownloadProgressChangedEventHandler DownloadProgressChanged;
+
+        /// <summary>
+        /// Default Chromium revision.
+        /// </summary>
+        [Obsolete("Use DefaultChromiumRevision instead")]
+        public static int DefaultRevision { get; } = int.Parse(DefaultChromiumRevision, CultureInfo.CurrentCulture.NumberFormat);
+
+        /// <summary>
+        /// Default Firefox revision.
+        /// </summary>
+        public string DefaultFirefoxRevision { get; private set; } = "latest";
+
+        /// <summary>
+        /// Gets the downloads folder.
+        /// </summary>
+        public string DownloadsFolder { get; }
+
+        /// <summary>
+        /// A download host to be used. Defaults to https://storage.googleapis.com.
+        /// </summary>
+        public string DownloadHost { get; }
+
+        /// <summary>
+        /// Gets the platform.
+        /// </summary>
+        public Platform Platform { get; }
+
+        /// <summary>
+        /// Gets the product.
+        /// </summary>
+        public Product Product { get; }
+
+        /// <summary>
+        /// Proxy used by the WebClient in <see cref="DownloadAsync(int)"/> and <see cref="CanDownloadAsync(int)"/>
+        /// </summary>
+        public IWebProxy WebProxy
+        {
+            get => _webClient.Proxy;
+            set => _webClient.Proxy = value;
         }
 
         /// <summary>

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -37,6 +37,10 @@ namespace PuppeteerSharp
     /// </summary>
     public class CDPSession
     {
+        #region Private Members
+        private readonly ConcurrentDictionary<int, MessageTask> _callbacks;
+        #endregion
+
         internal CDPSession(Connection connection, TargetType targetType, string sessionId)
         {
             Connection = connection;
@@ -46,9 +50,17 @@ namespace PuppeteerSharp
             _callbacks = new ConcurrentDictionary<int, MessageTask>();
         }
 
-        #region Private Members
-        private readonly ConcurrentDictionary<int, MessageTask> _callbacks;
-        #endregion
+        /// <summary>
+        /// Occurs when message received from Chromium.
+        /// </summary>
+        public event EventHandler<MessageEventArgs> MessageReceived;
+
+        /// <summary>
+        /// Occurs when the connection is closed.
+        /// </summary>
+        public event EventHandler Disconnected;
+
+        internal event EventHandler<SessionAttachedEventArgs> SessionAttached;
 
         #region Properties
         /// <summary>
@@ -68,18 +80,6 @@ namespace PuppeteerSharp
         /// </summary>
         /// <value>The connection.</value>
         internal Connection Connection { get; private set; }
-
-        /// <summary>
-        /// Occurs when message received from Chromium.
-        /// </summary>
-        public event EventHandler<MessageEventArgs> MessageReceived;
-
-        /// <summary>
-        /// Occurs when the connection is closed.
-        /// </summary>
-        public event EventHandler Disconnected;
-
-        internal event EventHandler<SessionAttachedEventArgs> SessionAttached;
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="CDPSession"/> is closed.

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -37,9 +37,7 @@ namespace PuppeteerSharp
     /// </summary>
     public class CDPSession
     {
-        #region Private Members
         private readonly ConcurrentDictionary<int, MessageTask> _callbacks;
-        #endregion
 
         internal CDPSession(Connection connection, TargetType targetType, string sessionId)
         {
@@ -62,7 +60,6 @@ namespace PuppeteerSharp
 
         internal event EventHandler<SessionAttachedEventArgs> SessionAttached;
 
-        #region Properties
         /// <summary>
         /// Gets the target type.
         /// </summary>
@@ -97,9 +94,6 @@ namespace PuppeteerSharp
         /// </summary>
         /// <value>The logger factory.</value>
         public ILoggerFactory LoggerFactory => Connection.LoggerFactory;
-        #endregion
-
-        #region Public Methods
 
         internal void Send(string method, object args = null)
             => _ = SendAsync(method, args, false);
@@ -185,10 +179,6 @@ namespace PuppeteerSharp
 
         internal bool HasPendingCallbacks() => _callbacks.Count != 0;
 
-        #endregion
-
-        #region Private Methods
-
         internal void OnMessage(ConnectionResponse obj)
         {
             var id = obj.Id;
@@ -232,7 +222,5 @@ namespace PuppeteerSharp
 
         internal void OnSessionAttached(CDPSession session)
             => SessionAttached?.Invoke(this, new SessionAttachedEventArgs { Session = session });
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -18,8 +18,6 @@ namespace PuppeteerSharp
     /// </summary>
     public class Connection : IDisposable
     {
-        #region Private Members
-
         private readonly ILogger _logger;
         private readonly TaskQueue _callbackQueue = new TaskQueue();
 
@@ -27,8 +25,6 @@ namespace PuppeteerSharp
         private readonly ConcurrentDictionary<string, CDPSession> _sessions;
         private readonly AsyncDictionaryHelper<string, CDPSession> _asyncSessions;
         private int _lastId;
-
-        #endregion
 
         /// <summary>
         /// Gets default web socket factory implementation.
@@ -65,7 +61,6 @@ namespace PuppeteerSharp
 
         internal event EventHandler<SessionAttachedEventArgs> SessionAttached;
 
-        #region Properties
         /// <summary>
         /// Gets the WebSocket URL.
         /// </summary>
@@ -102,10 +97,6 @@ namespace PuppeteerSharp
         public ILoggerFactory LoggerFactory { get; }
 
         internal AsyncMessageQueue MessageQueue { get; }
-
-        #endregion
-
-        #region Public Methods
 
         internal int GetMessageID() => Interlocked.Increment(ref _lastId);
 
@@ -160,7 +151,6 @@ namespace PuppeteerSharp
         }
 
         internal bool HasPendingCallbacks() => _callbacks.Count != 0;
-        #endregion
 
         internal void Close(string closeReason)
         {
@@ -198,8 +188,6 @@ namespace PuppeteerSharp
         internal CDPSession GetSession(string sessionId) => _sessions.GetValueOrDefault(sessionId);
 
         internal Task<CDPSession> GetSessionAsync(string sessionId) => _asyncSessions.GetItemAsync(sessionId);
-
-        #region Private Methods
 
         private async void Transport_MessageReceived(object sender, MessageReceivedEventArgs e)
             => await _callbackQueue.Enqueue(() => ProcessMessage(e)).ConfigureAwait(false);
@@ -290,10 +278,6 @@ namespace PuppeteerSharp
 
         private void Transport_Closed(object sender, TransportClosedEventArgs e) => Close(e.CloseReason);
 
-        #endregion
-
-        #region Static Methods
-
         internal static async Task<Connection> Create(string url, IConnectionOptions connectionOptions, ILoggerFactory loggerFactory = null, CancellationToken cancellationToken = default)
         {
 #pragma warning disable 618
@@ -333,6 +317,5 @@ namespace PuppeteerSharp
             Transport.Dispose();
             _callbackQueue.Dispose();
         }
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/DOMWorld.cs
+++ b/lib/PuppeteerSharp/DOMWorld.cs
@@ -17,10 +17,6 @@ namespace PuppeteerSharp
         private TaskCompletionSource<ExecutionContext> _contextResolveTaskWrapper;
         private TaskCompletionSource<ElementHandle> _documentCompletionSource;
 
-        internal ICollection<WaitTask> WaitTasks { get; set; }
-
-        internal Frame Frame { get; }
-
         public DOMWorld(FrameManager frameManager, Frame frame, TimeoutSettings timeoutSettings)
         {
             _frameManager = frameManager;
@@ -32,6 +28,12 @@ namespace PuppeteerSharp
             WaitTasks = new ConcurrentSet<WaitTask>();
             _detached = false;
         }
+
+        internal ICollection<WaitTask> WaitTasks { get; set; }
+
+        internal Frame Frame { get; }
+
+        internal bool HasContext => _contextResolveTaskWrapper?.Task.IsCompleted == true;
 
         internal void SetContext(ExecutionContext context)
         {
@@ -49,8 +51,6 @@ namespace PuppeteerSharp
                 _contextResolveTaskWrapper = new TaskCompletionSource<ExecutionContext>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }
-
-        internal bool HasContext => _contextResolveTaskWrapper?.Task.IsCompleted == true;
 
         internal void Detach()
         {

--- a/lib/PuppeteerSharp/Dialog.cs
+++ b/lib/PuppeteerSharp/Dialog.cs
@@ -24,6 +24,21 @@ namespace PuppeteerSharp
         private readonly CDPSession _client;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Dialog"/> class.
+        /// </summary>
+        /// <param name="client">Client.</param>
+        /// <param name="type">Type.</param>
+        /// <param name="message">Message.</param>
+        /// <param name="defaultValue">Default value.</param>
+        public Dialog(CDPSession client, DialogType type, string message, string defaultValue)
+        {
+            _client = client;
+            DialogType = type;
+            Message = message;
+            DefaultValue = defaultValue;
+        }
+
+        /// <summary>
         /// Dialog's type, can be one of alert, beforeunload, confirm or prompt.
         /// </summary>
         /// <value>The type of the dialog.</value>
@@ -38,21 +53,6 @@ namespace PuppeteerSharp
         /// </summary>
         /// <value>The message.</value>
         public string Message { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Dialog"/> class.
-        /// </summary>
-        /// <param name="client">Client.</param>
-        /// <param name="type">Type.</param>
-        /// <param name="message">Message.</param>
-        /// <param name="defaultValue">Default value.</param>
-        public Dialog(CDPSession client, DialogType type, string message, string defaultValue)
-        {
-            _client = client;
-            DialogType = type;
-            Message = message;
-            DefaultValue = defaultValue;
-        }
 
         /// <summary>
         /// Accept the Dialog.

--- a/lib/PuppeteerSharp/DialogEventArgs.cs
+++ b/lib/PuppeteerSharp/DialogEventArgs.cs
@@ -9,14 +9,14 @@ namespace PuppeteerSharp
     public class DialogEventArgs : EventArgs
     {
         /// <summary>
-        /// Dialog data.
-        /// </summary>
-        public Dialog Dialog { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="DialogEventArgs"/> class.
         /// </summary>
         /// <param name="dialog">Dialog.</param>
         public DialogEventArgs(Dialog dialog) => Dialog = dialog;
+
+        /// <summary>
+        /// Dialog data.
+        /// </summary>
+        public Dialog Dialog { get; }
     }
 }

--- a/lib/PuppeteerSharp/ErrorEventArgs.cs
+++ b/lib/PuppeteerSharp/ErrorEventArgs.cs
@@ -8,12 +8,6 @@ namespace PuppeteerSharp
     public class ErrorEventArgs : EventArgs
     {
         /// <summary>
-        /// Gets the error.
-        /// </summary>
-        /// <value>The error.</value>
-        public string Error { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ErrorEventArgs"/> class.
         /// </summary>
         /// <param name="error">Error.</param>
@@ -21,5 +15,11 @@ namespace PuppeteerSharp
         {
             Error = error;
         }
+
+        /// <summary>
+        /// Gets the error.
+        /// </summary>
+        /// <value>The error.</value>
+        public string Error { get; }
     }
 }

--- a/lib/PuppeteerSharp/ExecutionContext.cs
+++ b/lib/PuppeteerSharp/ExecutionContext.cs
@@ -24,8 +24,6 @@ namespace PuppeteerSharp
         private readonly CDPSession _client;
         private readonly int _contextId;
 
-        internal DOMWorld World { get; }
-
         internal ExecutionContext(
             CDPSession client,
             ContextPayload contextPayload,
@@ -35,6 +33,8 @@ namespace PuppeteerSharp
             _contextId = contextPayload.Id;
             World = world;
         }
+
+        internal DOMWorld World { get; }
 
         /// <summary>
         /// Frame associated with this execution context.

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -41,18 +41,6 @@ namespace PuppeteerSharp
     {
         private readonly List<Frame> _childFrames = new();
 
-        internal string Id { get; set; }
-
-        internal string LoaderId { get; set; }
-
-        internal List<string> LifecycleEvents { get; }
-
-        internal string NavigationURL { get; private set; }
-
-        internal DOMWorld MainWorld { get; }
-
-        internal DOMWorld SecondaryWorld { get; }
-
         internal Frame(FrameManager frameManager, Frame parentFrame, string frameId)
         {
             FrameManager = frameManager;
@@ -107,6 +95,18 @@ namespace PuppeteerSharp
         public Frame ParentFrame { get; private set; }
 
         internal FrameManager FrameManager { get; }
+
+        internal string Id { get; set; }
+
+        internal string LoaderId { get; set; }
+
+        internal List<string> LifecycleEvents { get; }
+
+        internal string NavigationURL { get; private set; }
+
+        internal DOMWorld MainWorld { get; }
+
+        internal DOMWorld SecondaryWorld { get; }
         #endregion
 
         #region Public Methods

--- a/lib/PuppeteerSharp/FrameEventArgs.cs
+++ b/lib/PuppeteerSharp/FrameEventArgs.cs
@@ -6,12 +6,6 @@ namespace PuppeteerSharp
     public class FrameEventArgs
     {
         /// <summary>
-        /// Gets or sets the frame.
-        /// </summary>
-        /// <value>The frame.</value>
-        public Frame Frame { get; set; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="FrameEventArgs"/> class.
         /// </summary>
         /// <param name="frame">Frame.</param>
@@ -19,5 +13,11 @@ namespace PuppeteerSharp
         {
             Frame = frame;
         }
+
+        /// <summary>
+        /// Gets or sets the frame.
+        /// </summary>
+        /// <value>The frame.</value>
+        public Frame Frame { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Helpers/ConcurrentSet.cs
+++ b/lib/PuppeteerSharp/Helpers/ConcurrentSet.cs
@@ -116,28 +116,6 @@ namespace PuppeteerSharp.Helpers
             _dictionary.Clear();
         }
 
-        public struct KeyEnumerator
-        {
-            private readonly IEnumerator<KeyValuePair<T, byte>> _kvpEnumerator;
-
-            internal KeyEnumerator(IEnumerable<KeyValuePair<T, byte>> data)
-            {
-                _kvpEnumerator = data.GetEnumerator();
-            }
-
-            public T Current => _kvpEnumerator.Current.Key;
-
-            public bool MoveNext()
-            {
-                return _kvpEnumerator.MoveNext();
-            }
-
-            public void Reset()
-            {
-                _kvpEnumerator.Reset();
-            }
-        }
-
         /// <summary>
         /// Obtain an enumerator that iterates through the elements in the set.
         /// </summary>
@@ -184,6 +162,28 @@ namespace PuppeteerSharp.Helpers
             foreach (var element in this)
             {
                 array[arrayIndex++] = element;
+            }
+        }
+
+        public struct KeyEnumerator
+        {
+            private readonly IEnumerator<KeyValuePair<T, byte>> _kvpEnumerator;
+
+            internal KeyEnumerator(IEnumerable<KeyValuePair<T, byte>> data)
+            {
+                _kvpEnumerator = data.GetEnumerator();
+            }
+
+            public T Current => _kvpEnumerator.Current.Key;
+
+            public bool MoveNext()
+            {
+                return _kvpEnumerator.MoveNext();
+            }
+
+            public void Reset()
+            {
+                _kvpEnumerator.Reset();
             }
         }
     }

--- a/lib/PuppeteerSharp/Input/Key.cs
+++ b/lib/PuppeteerSharp/Input/Key.cs
@@ -7,7 +7,6 @@ namespace PuppeteerSharp.Input
     {
         private readonly string _value;
 
-        private Key(string value) => _value = value;
         /// <summary>
         /// Cancel key.
         /// </summary>
@@ -413,8 +412,7 @@ namespace PuppeteerSharp.Input
         /// </summary>
         public static readonly Key ZoomOut = new Key("ZoomOut");
 
-        /// <inheritdoc />
-        public override string ToString() => _value;
+        private Key(string value) => _value = value;
 
         /// <summary>
         /// Converts the <paramref name="key"/> to its underlining string value
@@ -425,5 +423,8 @@ namespace PuppeteerSharp.Input
         {
             return key._value;
         }
+
+        /// <inheritdoc />
+        public override string ToString() => _value;
     }
 }

--- a/lib/PuppeteerSharp/Input/Keyboard.cs
+++ b/lib/PuppeteerSharp/Input/Keyboard.cs
@@ -15,12 +15,12 @@ namespace PuppeteerSharp.Input
         private readonly CDPSession _client;
         private readonly HashSet<string> _pressedKeys = new HashSet<string>();
 
-        internal int Modifiers { get; set; }
-
         internal Keyboard(CDPSession client)
         {
             _client = client;
         }
+
+        internal int Modifiers { get; set; }
 
         /// <summary>
         /// Dispatches a <c>keydown</c> event

--- a/lib/PuppeteerSharp/LauncherBase.cs
+++ b/lib/PuppeteerSharp/LauncherBase.cs
@@ -57,19 +57,6 @@ namespace PuppeteerSharp
             Dispose(false);
         }
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Disposes Base process and any temporary user directory.
-        /// </summary>
-        /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
-        protected virtual void Dispose(bool disposing) => _stateManager.CurrentState.Dispose(this);
-
         internal TaskCompletionSource<bool> ExitCompletionSource { get; } = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         internal TaskCompletionSource<string> StartCompletionSource { get; } = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -104,6 +91,19 @@ namespace PuppeteerSharp
         /// Gets Base process current state.
         /// </summary>
         internal State CurrentState => _stateManager.CurrentState;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes Base process and any temporary user directory.
+        /// </summary>
+        /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
+        protected virtual void Dispose(bool disposing) => _stateManager.CurrentState.Dispose(this);
 
         /// <summary>
         /// Asynchronously starts Base process.

--- a/lib/PuppeteerSharp/Media/MarginOptions.cs
+++ b/lib/PuppeteerSharp/Media/MarginOptions.cs
@@ -36,6 +36,13 @@ namespace PuppeteerSharp.Media
         public string Right { get; set; }
 
         /// <inheritdoc/>
+        public static bool operator ==(MarginOptions left, MarginOptions right)
+            => EqualityComparer<MarginOptions>.Default.Equals(left, right);
+
+        /// <inheritdoc/>
+        public static bool operator !=(MarginOptions left, MarginOptions right) => !(left == right);
+
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (obj == null || GetType() != obj.GetType())
@@ -61,11 +68,5 @@ namespace PuppeteerSharp.Media
                 ^ EqualityComparer<string>.Default.GetHashCode(Left)
                 ^ EqualityComparer<string>.Default.GetHashCode(Bottom)
                 ^ EqualityComparer<string>.Default.GetHashCode(Right);
-
-        /// <inheritdoc/>
-        public static bool operator ==(MarginOptions left, MarginOptions right)
-            => EqualityComparer<MarginOptions>.Default.Equals(left, right);
-        /// <inheritdoc/>
-        public static bool operator !=(MarginOptions left, MarginOptions right) => !(left == right);
     }
 }

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -88,6 +88,13 @@ namespace PuppeteerSharp.Media
         public static PaperFormat A6 => new PaperFormat(4.13m, 5.83m);
 
         /// <inheritdoc/>
+        public static bool operator ==(PaperFormat left, PaperFormat right)
+            => EqualityComparer<PaperFormat>.Default.Equals(left, right);
+
+        /// <inheritdoc/>
+        public static bool operator !=(PaperFormat left, PaperFormat right) => !(left == right);
+
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (obj == null || GetType() != obj.GetType())
@@ -109,12 +116,5 @@ namespace PuppeteerSharp.Media
             => 859600377
                 ^ Width.GetHashCode()
                 ^ Height.GetHashCode();
-
-        /// <inheritdoc/>
-        public static bool operator ==(PaperFormat left, PaperFormat right)
-            => EqualityComparer<PaperFormat>.Default.Equals(left, right);
-
-        /// <inheritdoc/>
-        public static bool operator !=(PaperFormat left, PaperFormat right) => !(left == right);
     }
 }

--- a/lib/PuppeteerSharp/MetricEventArgs.cs
+++ b/lib/PuppeteerSharp/MetricEventArgs.cs
@@ -9,16 +9,6 @@ namespace PuppeteerSharp
     public class MetricEventArgs : EventArgs
     {
         /// <summary>
-        /// Gets the title.
-        /// </summary>
-        /// <value>The title.</value>
-        public string Title { get; }
-        /// <summary>
-        /// Gets the metrics.
-        /// </summary>
-        /// <value>The metrics.</value>
-        public Dictionary<string, decimal> Metrics { get; }
-        /// <summary>
         /// Initializes a new instance of the <see cref="MetricEventArgs"/> class.
         /// </summary>
         /// <param name="title">Title.</param>
@@ -28,5 +18,15 @@ namespace PuppeteerSharp
             Title = title;
             Metrics = metrics;
         }
+        /// <summary>
+        /// Gets the title.
+        /// </summary>
+        /// <value>The title.</value>
+        public string Title { get; }
+        /// <summary>
+        /// Gets the metrics.
+        /// </summary>
+        /// <value>The metrics.</value>
+        public Dictionary<string, decimal> Metrics { get; }
     }
 }

--- a/lib/PuppeteerSharp/NavigationException.cs
+++ b/lib/PuppeteerSharp/NavigationException.cs
@@ -10,12 +10,6 @@ namespace PuppeteerSharp
     public class NavigationException : PuppeteerException
     {
         /// <summary>
-        /// Url that caused the exception
-        /// </summary>
-        /// <value>The URL.</value>
-        public string Url { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="NavigationException"/> class.
         /// </summary>
         public NavigationException()
@@ -70,5 +64,11 @@ namespace PuppeteerSharp
                 return $"{base.Message} at {Url}";
             }
         }
+
+        /// <summary>
+        /// Url that caused the exception
+        /// </summary>
+        /// <value>The URL.</value>
+        public string Url { get; }
     }
 }

--- a/lib/PuppeteerSharp/NetworkEventManager.cs
+++ b/lib/PuppeteerSharp/NetworkEventManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -14,6 +14,9 @@ namespace PuppeteerSharp
         private readonly ConcurrentDictionary<string, QueuedEventGroup> _queuedEventGroupMap = new();
         private readonly ConcurrentDictionary<string, List<RedirectInfo>> _queuedRedirectInfoMap = new();
         private readonly ConcurrentDictionary<string, List<ResponseReceivedExtraInfoResponse>> _responseReceivedExtraInfoMap = new();
+
+        public int NumRequestsInProgress
+            => _httpRequestsMap.Values.Count(r => r.Response == null);
 
         internal void Forget(string requestId)
         {
@@ -62,9 +65,6 @@ namespace PuppeteerSharp
 
             return result;
         }
-
-        public int NumRequestsInProgress
-            => _httpRequestsMap.Values.Count(r => r.Response == null);
 
         internal ResponseReceivedExtraInfoResponse ShiftResponseExtraInfo(string networkRequestId)
         {

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -40,8 +40,6 @@ namespace PuppeteerSharp
             _logger = _client.Connection.LoggerFactory.CreateLogger<NetworkManager>();
         }
 
-        internal Dictionary<string, string> ExtraHTTPHeaders => _extraHTTPHeaders?.Clone();
-
         internal event EventHandler<ResponseCreatedEventArgs> Response;
 
         internal event EventHandler<RequestEventArgs> Request;
@@ -51,6 +49,8 @@ namespace PuppeteerSharp
         internal event EventHandler<RequestEventArgs> RequestFailed;
 
         internal event EventHandler<RequestEventArgs> RequestServedFromCache;
+
+        internal Dictionary<string, string> ExtraHTTPHeaders => _extraHTTPHeaders?.Clone();
 
         internal FrameManager FrameManager { get; set; }
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -61,6 +61,26 @@ namespace PuppeteerSharp
             { "mm", 3.78m }
         };
 
+        /// <summary>
+        /// List of supported metrics provided by the <see cref="Metrics"/> event.
+        /// </summary>
+        public static readonly IEnumerable<string> SupportedMetrics = new List<string>
+        {
+            "Timestamp",
+            "Documents",
+            "Frames",
+            "JSEventListeners",
+            "Nodes",
+            "LayoutCount",
+            "RecalcStyleCount",
+            "LayoutDuration",
+            "RecalcStyleDuration",
+            "ScriptDuration",
+            "TaskDuration",
+            "JSHeapUsedSize",
+            "JSHeapTotalSize"
+        };
+
         private Page(
             CDPSession client,
             Target target,
@@ -99,11 +119,6 @@ namespace PuppeteerSharp
                 },
                 TaskScheduler.Default);
         }
-
-        /// <summary>
-        /// Chrome DevTools Protocol session.
-        /// </summary>
-        public CDPSession Client { get; }
 
         /// <summary>
         /// Raised when the JavaScript <c>load</c> <see href="https://developer.mozilla.org/en-US/docs/Web/Events/load"/> event is dispatched.
@@ -237,6 +252,11 @@ namespace PuppeteerSharp
         public event EventHandler<PopupEventArgs> Popup;
 
         /// <summary>
+        /// Chrome DevTools Protocol session.
+        /// </summary>
+        public CDPSession Client { get; }
+
+        /// <summary>
         /// This setting will change the default maximum time for the following methods:
         /// - <see cref="GoToAsync(string, NavigationOptions)"/>
         /// - <see cref="GoBackAsync(NavigationOptions)"/>
@@ -331,26 +351,6 @@ namespace PuppeteerSharp
         /// Gets this page's viewport
         /// </summary>
         public ViewPortOptions Viewport { get; private set; }
-
-        /// <summary>
-        /// List of supported metrics provided by the <see cref="Metrics"/> event.
-        /// </summary>
-        public static readonly IEnumerable<string> SupportedMetrics = new List<string>
-        {
-            "Timestamp",
-            "Documents",
-            "Frames",
-            "JSEventListeners",
-            "Nodes",
-            "LayoutCount",
-            "RecalcStyleCount",
-            "LayoutDuration",
-            "RecalcStyleDuration",
-            "ScriptDuration",
-            "TaskDuration",
-            "JSHeapUsedSize",
-            "JSHeapTotalSize"
-        };
 
         /// <summary>
         /// Get the browser the page belongs to.

--- a/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
@@ -10,12 +10,6 @@ namespace PuppeteerSharp.PageAccessibility
 {
     internal class AXNode
     {
-        internal AccessibilityGetFullAXTreeResponse.AXTreeNode Payload { get; }
-
-        public List<AXNode> Children { get; }
-
-        public bool Focusable { get; set; }
-
         private readonly string _name;
         private readonly bool _richlyEditable;
         private readonly bool _editable;
@@ -36,6 +30,12 @@ namespace PuppeteerSharp.PageAccessibility
             _hidden = payload.Properties?.FirstOrDefault(p => p.Name == "hidden")?.Value.Value.ToObject<bool>() == true;
             Focusable = payload.Properties?.FirstOrDefault(p => p.Name == "focusable")?.Value.Value.ToObject<bool>() == true;
         }
+
+        public List<AXNode> Children { get; }
+
+        public bool Focusable { get; set; }
+
+        internal AccessibilityGetFullAXTreeResponse.AXTreeNode Payload { get; }
 
         internal static AXNode CreateTree(IEnumerable<AccessibilityGetFullAXTreeResponse.AXTreeNode> payloads)
         {

--- a/lib/PuppeteerSharp/PageErrorEventArgs.cs
+++ b/lib/PuppeteerSharp/PageErrorEventArgs.cs
@@ -8,14 +8,15 @@ namespace PuppeteerSharp
     public class PageErrorEventArgs : EventArgs
     {
         /// <summary>
-        /// Error Message
-        /// </summary>
-        /// <value>The message.</value>
-        public string Message { get; set; }
-        /// <summary>
         /// Initializes a new instance of the <see cref="PageErrorEventArgs"/> class.
         /// </summary>
         /// <param name="message">Message.</param>
         public PageErrorEventArgs(string message) => Message = message;
+
+        /// <summary>
+        /// Error Message
+        /// </summary>
+        /// <value>The message.</value>
+        public string Message { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/PdfOptions.cs
+++ b/lib/PuppeteerSharp/PdfOptions.cs
@@ -93,6 +93,13 @@ namespace PuppeteerSharp
         public bool OmitBackground { get; set; }
 
         /// <inheritdoc/>
+        public static bool operator ==(PdfOptions left, PdfOptions right)
+            => EqualityComparer<PdfOptions>.Default.Equals(left, right);
+
+        /// <inheritdoc/>
+        public static bool operator !=(PdfOptions left, PdfOptions right) => !(left == right);
+
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (obj == null || GetType() != obj.GetType())
@@ -136,12 +143,5 @@ namespace PuppeteerSharp
                 ^ EqualityComparer<object>.Default.GetHashCode(Height)
                 ^ EqualityComparer<MarginOptions>.Default.GetHashCode(MarginOptions)
                 ^ PreferCSSPageSize.GetHashCode();
-
-        /// <inheritdoc/>
-        public static bool operator ==(PdfOptions left, PdfOptions right)
-            => EqualityComparer<PdfOptions>.Default.Equals(left, right);
-
-        /// <inheritdoc/>
-        public static bool operator !=(PdfOptions left, PdfOptions right) => !(left == right);
     }
 }

--- a/lib/PuppeteerSharp/Puppeteer.cs
+++ b/lib/PuppeteerSharp/Puppeteer.cs
@@ -27,6 +27,41 @@ namespace PuppeteerSharp
         internal static string[] DefaultArgs => ChromiumLauncher.DefaultArgs;
 
         /// <summary>
+        /// Returns a list of devices to be used with <seealso cref="Page.EmulateAsync(DeviceDescriptor)"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///<![CDATA[
+        /// var iPhone = Puppeteer.Devices[DeviceDescriptorName.IPhone6];
+        /// using(var page = await browser.NewPageAsync())
+        /// {
+        ///     await page.EmulateAsync(iPhone);
+        ///     await page.goto('https://www.google.com');
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static IReadOnlyDictionary<DeviceDescriptorName, DeviceDescriptor> Devices => DeviceDescriptors.ToReadOnly();
+
+        /// <summary>
+        /// Returns a list of network conditions to be used with <seealso cref="Page.EmulateNetworkConditionsAsync(NetworkConditions)"/>.
+        /// Actual list of conditions can be found in <seealso cref="PredefinedNetworkConditions.Conditions"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///<![CDATA[
+        /// var slow3G = Puppeteer.NetworkConditions["Slow 3G"];
+        /// using(var page = await browser.NewPageAsync())
+        /// {
+        ///     await page.EmulateNetworkConditionsAsync(slow3G);
+        ///     await page.goto('https://www.google.com');
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static IReadOnlyDictionary<string, NetworkConditions> NetworkConditions => PredefinedNetworkConditions.ToReadOnly();
+
+        /// <summary>
         /// Returns an array of argument based on the options provided and the platform where the library is running
         /// </summary>
         /// <returns>Chromium arguments.</returns>
@@ -73,40 +108,5 @@ namespace PuppeteerSharp
         /// <param name="options">Options.</param>
         public static BrowserFetcher CreateBrowserFetcher(BrowserFetcherOptions options)
             => new BrowserFetcher(options);
-
-        /// <summary>
-        /// Returns a list of devices to be used with <seealso cref="Page.EmulateAsync(DeviceDescriptor)"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        ///<![CDATA[
-        /// var iPhone = Puppeteer.Devices[DeviceDescriptorName.IPhone6];
-        /// using(var page = await browser.NewPageAsync())
-        /// {
-        ///     await page.EmulateAsync(iPhone);
-        ///     await page.goto('https://www.google.com');
-        /// }
-        /// ]]>
-        /// </code>
-        /// </example>
-        public static IReadOnlyDictionary<DeviceDescriptorName, DeviceDescriptor> Devices => DeviceDescriptors.ToReadOnly();
-
-        /// <summary>
-        /// Returns a list of network conditions to be used with <seealso cref="Page.EmulateNetworkConditionsAsync(NetworkConditions)"/>.
-        /// Actual list of conditions can be found in <seealso cref="PredefinedNetworkConditions.Conditions"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        ///<![CDATA[
-        /// var slow3G = Puppeteer.NetworkConditions["Slow 3G"];
-        /// using(var page = await browser.NewPageAsync())
-        /// {
-        ///     await page.EmulateNetworkConditionsAsync(slow3G);
-        ///     await page.goto('https://www.google.com');
-        /// }
-        /// ]]>
-        /// </code>
-        /// </example>
-        public static IReadOnlyDictionary<string, NetworkConditions> NetworkConditions => PredefinedNetworkConditions.ToReadOnly();
     }
 }

--- a/lib/PuppeteerSharp/Response.cs
+++ b/lib/PuppeteerSharp/Response.cs
@@ -58,29 +58,6 @@ namespace PuppeteerSharp
             BodyLoadedTaskWrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
-        private string ParseStatusTextFromExtrInfo(ResponseReceivedExtraInfoResponse extraInfo)
-        {
-            if (extraInfo == null || extraInfo.HeadersText == null)
-            {
-                return null;
-            }
-
-            var lines = extraInfo.HeadersText.Split('\r');
-            if (lines.Length == 0)
-            {
-                return null;
-            }
-            var firstLine = lines[0];
-
-            var match = ExtraInfoLines.Match(firstLine);
-            if (!match.Success)
-            {
-                return null;
-            }
-            var statusText = match.Groups["text"].Value;
-            return statusText;
-        }
-
         /// <summary>
         /// Contains the URL of the response.
         /// </summary>
@@ -135,6 +112,29 @@ namespace PuppeteerSharp
         /// A <see cref="Frame"/> that initiated this request. Or null if navigating to error pages.
         /// </summary>
         public Frame Frame => Request.Frame;
+
+        private string ParseStatusTextFromExtrInfo(ResponseReceivedExtraInfoResponse extraInfo)
+        {
+            if (extraInfo == null || extraInfo.HeadersText == null)
+            {
+                return null;
+            }
+
+            var lines = extraInfo.HeadersText.Split('\r');
+            if (lines.Length == 0)
+            {
+                return null;
+            }
+            var firstLine = lines[0];
+
+            var match = ExtraInfoLines.Match(firstLine);
+            if (!match.Success)
+            {
+                return null;
+            }
+            var statusText = match.Groups["text"].Value;
+            return statusText;
+        }
 
         /// <summary>
         /// Returns a Task which resolves to a buffer with response body

--- a/lib/PuppeteerSharp/SelectorException.cs
+++ b/lib/PuppeteerSharp/SelectorException.cs
@@ -17,12 +17,6 @@ namespace PuppeteerSharp
     public class SelectorException : PuppeteerException
     {
         /// <summary>
-        /// Gets the selector.
-        /// </summary>
-        /// <value>The selector.</value>
-        public string Selector { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="SelectorException"/> class.
         /// </summary>
         public SelectorException()
@@ -63,5 +57,11 @@ namespace PuppeteerSharp
         protected SelectorException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+
+        /// <summary>
+        /// Gets the selector.
+        /// </summary>
+        /// <value>The selector.</value>
+        public string Selector { get; }
     }
 }

--- a/lib/PuppeteerSharp/States/StateManager.cs
+++ b/lib/PuppeteerSharp/States/StateManager.cs
@@ -5,6 +5,8 @@ namespace PuppeteerSharp.States
 {
     internal class StateManager
     {
+        private State _currentState;
+
         public StateManager()
         {
             Initial = new InitialState(this);
@@ -16,8 +18,6 @@ namespace PuppeteerSharp.States
             Disposed = new DisposedState(this);
             CurrentState = Initial;
         }
-
-        private State _currentState;
 
         public State CurrentState
         {

--- a/lib/PuppeteerSharp/Target.cs
+++ b/lib/PuppeteerSharp/Target.cs
@@ -19,10 +19,6 @@ namespace PuppeteerSharp
         private Task<Worker> _workerTask;
         #endregion
 
-        internal bool IsInitialized { get; set; }
-
-        internal TargetInfo TargetInfo { get; set; }
-
         internal Target(
             TargetInfo targetInfo,
             Func<Task<CDPSession>> sessionFactory,
@@ -111,6 +107,10 @@ namespace PuppeteerSharp
         internal TaskCompletionSource<bool> CloseTaskWrapper { get; }
 
         internal Task<Page> PageTask { get; set; }
+
+        internal bool IsInitialized { get; set; }
+
+        internal TargetInfo TargetInfo { get; set; }
         #endregion
 
         /// <summary>

--- a/lib/PuppeteerSharp/TargetClosedException.cs
+++ b/lib/PuppeteerSharp/TargetClosedException.cs
@@ -9,12 +9,6 @@ namespace PuppeteerSharp
     public class TargetClosedException : PuppeteerException
     {
         /// <summary>
-        /// Close Reason.
-        /// </summary>
-        /// <value>The close reason.</value>
-        public string CloseReason { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TargetClosedException"/> class.
         /// </summary>
         public TargetClosedException()
@@ -54,5 +48,11 @@ namespace PuppeteerSharp
         protected TargetClosedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+
+        /// <summary>
+        /// Close Reason.
+        /// </summary>
+        /// <value>The close reason.</value>
+        public string CloseReason { get; }
     }
 }

--- a/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
+++ b/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
@@ -9,6 +9,14 @@ namespace PuppeteerSharp.Transport
     public interface IConnectionTransport : IDisposable
     {
         /// <summary>
+        /// Occurs when the transport is closed.
+        /// </summary>
+        event EventHandler<TransportClosedEventArgs> Closed;
+        /// <summary>
+        /// Occurs when a message is received.
+        /// </summary>
+        event EventHandler<MessageReceivedEventArgs> MessageReceived;
+        /// <summary>
         /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
         /// </summary>
         bool IsClosed { get; }
@@ -22,13 +30,5 @@ namespace PuppeteerSharp.Transport
         /// <returns>The task.</returns>
         /// <param name="message">Message to send.</param>
         Task SendAsync(string message);
-        /// <summary>
-        /// Occurs when the transport is closed.
-        /// </summary>
-        event EventHandler<TransportClosedEventArgs> Closed;
-        /// <summary>
-        /// Occurs when a message is received.
-        /// </summary>
-        event EventHandler<MessageReceivedEventArgs> MessageReceived;
     }
 }

--- a/lib/PuppeteerSharp/Transport/TransportClosedEventArgs.cs
+++ b/lib/PuppeteerSharp/Transport/TransportClosedEventArgs.cs
@@ -8,13 +8,13 @@ namespace PuppeteerSharp.Transport
     public class TransportClosedEventArgs : EventArgs
     {
         /// <summary>
-        /// Gets or sets the close reason.
-        /// </summary>
-        public string CloseReason { get; set; }
-        /// <summary>
         /// Initializes a new instance of the <see cref="PuppeteerSharp.Transport.TransportClosedEventArgs"/> class.
         /// </summary>
         /// <param name="closeReason">Close reason.</param>
         public TransportClosedEventArgs(string closeReason) => CloseReason = closeReason;
+        /// <summary>
+        /// Gets or sets the close reason.
+        /// </summary>
+        public string CloseReason { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -32,32 +32,6 @@ namespace PuppeteerSharp.Transport
 
         #endregion
 
-        #region Static methods
-
-        private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
-        {
-            var result = new ClientWebSocket();
-            result.Options.KeepAliveInterval = TimeSpan.Zero;
-            await result.ConnectAsync(url, cancellationToken).ConfigureAwait(false);
-            return result;
-        }
-
-        private static async Task<IConnectionTransport> CreateDefaultTransport(Uri url, IConnectionOptions connectionOptions, CancellationToken cancellationToken)
-        {
-            var webSocketFactory = connectionOptions.WebSocketFactory ?? DefaultWebSocketFactory;
-            var webSocket = await webSocketFactory(url, connectionOptions, cancellationToken).ConfigureAwait(false);
-            return new WebSocketTransport(webSocket, DefaultTransportScheduler, connectionOptions.EnqueueTransportMessages);
-        }
-
-        private static void ScheduleTransportTask(Func<CancellationToken, Task> taskFactory, CancellationToken cancellationToken)
-            => Task.Factory.StartNew(
-                () => taskFactory(cancellationToken),
-                cancellationToken,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
-
-        #endregion
-
         #region Instance fields
 
         private readonly WebSocket _client;
@@ -94,12 +68,8 @@ namespace PuppeteerSharp.Transport
 
         #endregion
 
-        #region Properties
+        #region Events
 
-        /// <summary>
-        /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
-        /// </summary>
-        public bool IsClosed { get; private set; }
         /// <summary>
         /// Occurs when the transport is closed.
         /// </summary>
@@ -108,6 +78,41 @@ namespace PuppeteerSharp.Transport
         /// Occurs when a message is received.
         /// </summary>
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
+        /// </summary>
+        public bool IsClosed { get; private set; }
+
+        #endregion
+
+        #region Static methods
+
+        private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
+        {
+            var result = new ClientWebSocket();
+            result.Options.KeepAliveInterval = TimeSpan.Zero;
+            await result.ConnectAsync(url, cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        private static async Task<IConnectionTransport> CreateDefaultTransport(Uri url, IConnectionOptions connectionOptions, CancellationToken cancellationToken)
+        {
+            var webSocketFactory = connectionOptions.WebSocketFactory ?? DefaultWebSocketFactory;
+            var webSocket = await webSocketFactory(url, connectionOptions, cancellationToken).ConfigureAwait(false);
+            return new WebSocketTransport(webSocket, DefaultTransportScheduler, connectionOptions.EnqueueTransportMessages);
+        }
+
+        private static void ScheduleTransportTask(Func<CancellationToken, Task> taskFactory, CancellationToken cancellationToken)
+            => Task.Factory.StartNew(
+                () => taskFactory(cancellationToken),
+                cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
 
         #endregion
 

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -13,8 +13,6 @@ namespace PuppeteerSharp.Transport
     /// </summary>
     public class WebSocketTransport : IConnectionTransport
     {
-        #region Static fields
-
         /// <summary>
         /// Gets the default <see cref="WebSocketFactory"/>. This factory does not support Windows 7.
         /// </summary>
@@ -30,19 +28,11 @@ namespace PuppeteerSharp.Transport
         /// </summary>
         public static readonly TransportTaskScheduler DefaultTransportScheduler = ScheduleTransportTask;
 
-        #endregion
-
-        #region Instance fields
-
         private readonly WebSocket _client;
         private readonly bool _queueRequests;
         private readonly TaskQueue _socketQueue = new TaskQueue();
         [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", Justification = "False positive, as it is disposed in StopReading() method.")]
         private CancellationTokenSource _readerCancellationSource = new CancellationTokenSource();
-
-        #endregion
-
-        #region Constructor(s)
 
         /// <summary>
         /// Initialize the Transport
@@ -66,10 +56,6 @@ namespace PuppeteerSharp.Transport
             scheduler(GetResponseAsync, _readerCancellationSource.Token);
         }
 
-        #endregion
-
-        #region Events
-
         /// <summary>
         /// Occurs when the transport is closed.
         /// </summary>
@@ -79,18 +65,10 @@ namespace PuppeteerSharp.Transport
         /// </summary>
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
         /// </summary>
         public bool IsClosed { get; private set; }
-
-        #endregion
-
-        #region Static methods
 
         private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
         {
@@ -113,10 +91,6 @@ namespace PuppeteerSharp.Transport
                 cancellationToken,
                 TaskCreationOptions.LongRunning,
                 TaskScheduler.Default);
-
-        #endregion
-
-        #region  Public methods
 
         /// <summary>
         /// Sends a message using the transport.
@@ -165,10 +139,6 @@ namespace PuppeteerSharp.Transport
             _client?.Dispose();
             _socketQueue.Dispose();
         }
-
-        #endregion
-
-        #region Private methods
 
         /// <summary>
         /// Starts listening the socket
@@ -230,7 +200,5 @@ namespace PuppeteerSharp.Transport
                 Closed?.Invoke(this, new TransportClosedEventArgs(closeReason));
             }
         }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/WaitTaskTimeoutException.cs
+++ b/lib/PuppeteerSharp/WaitTaskTimeoutException.cs
@@ -10,17 +10,6 @@ namespace PuppeteerSharp
     public class WaitTaskTimeoutException : PuppeteerException
     {
         /// <summary>
-        /// Timeout that caused the exception
-        /// </summary>
-        /// <value>The timeout.</value>
-        public int Timeout { get; }
-        /// <summary>
-        /// Element type the WaitTask was waiting for
-        /// </summary>
-        /// <value>The element.</value>
-        public string ElementType { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PuppeteerSharp.WaitTaskTimeoutException"/> class.
         /// </summary>
         public WaitTaskTimeoutException()
@@ -63,5 +52,16 @@ namespace PuppeteerSharp
         protected WaitTaskTimeoutException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+
+        /// <summary>
+        /// Timeout that caused the exception
+        /// </summary>
+        /// <value>The timeout.</value>
+        public int Timeout { get; }
+        /// <summary>
+        /// Element type the WaitTask was waiting for
+        /// </summary>
+        /// <value>The element.</value>
+        public string ElementType { get; }
     }
 }

--- a/lib/PuppeteerSharp/Worker.cs
+++ b/lib/PuppeteerSharp/Worker.cs
@@ -76,6 +76,8 @@ namespace PuppeteerSharp
         /// <value>Worker URL.</value>
         public string Url { get; }
 
+        internal Task<ExecutionContext> ExecutionContextTask => _executionContextCallback.Task;
+
         /// <summary>
         /// Executes a script in browser context
         /// </summary>
@@ -127,8 +129,6 @@ namespace PuppeteerSharp
         /// <seealso cref="ExecutionContext.EvaluateExpressionHandleAsync(string)"/>
         public async Task<JSHandle> EvaluateExpressionHandleAsync(string script)
             => await (await ExecutionContextTask.ConfigureAwait(false)).EvaluateExpressionHandleAsync(script).ConfigureAwait(false);
-
-        internal Task<ExecutionContext> ExecutionContextTask => _executionContextCallback.Task;
 
         internal async void OnMessageReceived(object sender, MessageEventArgs e)
         {


### PR DESCRIPTION
The intention of this change is to enable the analyzer rule [SA1201: ElementsMustAppearInTheCorrectOrder](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md) as described in the issue #1388.

Please let me know if there is anything I've missed while raising the PR. 
