### PR TITLE
Configure SA1124 action as error. Remove regions.

### DIFF
--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -21,7 +21,7 @@
     <Rule Id="SA1204" Action="None" /> <!-- Error SA1204: Static members should appear before non-static members (SA1204)-->
     <Rule Id="SA1004" Action="None" /> <!-- Error SA1004: Documentation line should begin with a space. (SA1004)-->
     <Rule Id="SA1513" Action="None" /> <!-- Error SA1513: Closing brace should be followed by blank line (SA1513)-->
-    <Rule Id="SA1124" Action="None" /> <!-- Error SA1124: Don't use regions-->
+    <Rule Id="SA1124" Action="Error" /> <!-- Error SA1124: Don't use regions-->
     <Rule Id="SA1009" Action="Error" /> <!-- Error SA1009: Closing parenthesis should not be preceded by a space. (SA1009)-->
     <Rule Id="SA1413" Action="None" /> <!-- Error SA1413: Use trailing comma in multi-line initializers (SA1413)-->
     <Rule Id="SA1602" Action="None" /> <!-- Error SA1602: Enumeration items should be documented (SA1602)-->

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -67,18 +67,12 @@ namespace PuppeteerSharp
             _targetFilterCallback = targetFilter ?? ((TargetInfo _) => true);
         }
 
-        #region Private members
-
         internal IDictionary<string, Target> TargetsMap { get; }
 
         private readonly ConcurrentDictionary<string, BrowserContext> _contexts;
         private readonly ILogger<Browser> _logger;
         private readonly Func<TargetInfo, bool> _targetFilterCallback;
         private Task _closeTask;
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         /// Raised when the <see cref="Browser"/> gets closed.
@@ -167,9 +161,6 @@ namespace PuppeteerSharp
         /// Indicates that the browser is connected.
         /// </summary>
         public bool IsConnected => !Connection.IsClosed;
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         /// Creates a new page
@@ -366,10 +357,6 @@ namespace PuppeteerSharp
             Closed?.Invoke(this, new EventArgs());
         }
 
-        #endregion
-
-        #region Private Methods
-
         internal void ChangeTarget(Target target)
         {
             var args = new TargetChangedArgs { Target = target };
@@ -534,9 +521,6 @@ namespace PuppeteerSharp
 
             return browser;
         }
-        #endregion
-
-        #region IDisposable
 
         /// <inheritdoc />
         public void Dispose()
@@ -555,17 +539,11 @@ namespace PuppeteerSharp
                 _ => ScreenshotTaskQueue.DisposeAsync(),
                 TaskScheduler.Default);
 
-        #endregion
-
-        #region IAsyncDisposable
-
         /// <summary>
         /// Closes <see cref="Connection"/> and any Chromium <see cref="Process"/> that was
         /// created by Puppeteer.
         /// </summary>
         /// <returns>ValueTask</returns>
         public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -46,11 +46,8 @@ namespace PuppeteerSharp
             _callbacks = new ConcurrentDictionary<int, MessageTask>();
         }
 
-        #region Private Members
         private readonly ConcurrentDictionary<int, MessageTask> _callbacks;
-        #endregion
 
-        #region Properties
         /// <summary>
         /// Gets the target type.
         /// </summary>
@@ -97,9 +94,6 @@ namespace PuppeteerSharp
         /// </summary>
         /// <value>The logger factory.</value>
         public ILoggerFactory LoggerFactory => Connection.LoggerFactory;
-        #endregion
-
-        #region Public Methods
 
         internal void Send(string method, object args = null)
             => _ = SendAsync(method, args, false);
@@ -185,10 +179,6 @@ namespace PuppeteerSharp
 
         internal bool HasPendingCallbacks() => _callbacks.Count != 0;
 
-        #endregion
-
-        #region Private Methods
-
         internal void OnMessage(ConnectionResponse obj)
         {
             var id = obj.Id;
@@ -232,7 +222,5 @@ namespace PuppeteerSharp
 
         internal void OnSessionAttached(CDPSession session)
             => SessionAttached?.Invoke(this, new SessionAttachedEventArgs { Session = session });
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/ChromiumLauncher.cs
+++ b/lib/PuppeteerSharp/ChromiumLauncher.cs
@@ -13,8 +13,6 @@ namespace PuppeteerSharp
     /// </summary>
     public class ChromiumLauncher : LauncherBase
     {
-        #region Constants
-
         internal static readonly string[] DefaultArgs = {
             "--disable-background-networking",
             "--enable-features=NetworkService,NetworkServiceInProcess",
@@ -44,10 +42,6 @@ namespace PuppeteerSharp
 
         private const string UserDataDirArgument = "--user-data-dir";
 
-        #endregion
-
-        #region Constructor
-
         /// <summary>
         /// Creates a new <see cref="ChromiumLauncher"/> instance.
         /// </summary>
@@ -62,16 +56,8 @@ namespace PuppeteerSharp
             Process.StartInfo.Arguments = string.Join(" ", chromiumArgs);
         }
 
-        #endregion
-
-        #region Public methods
-
         /// <inheritdoc />
         public override string ToString() => $"Chromium process; EndPoint={EndPoint}; State={CurrentState}";
-
-        #endregion
-
-        #region Private methods
 
         private static (List<string> ChromiumArgs, TempDirectory TempUserDataDirectory) PrepareChromiumArgs(LaunchOptions options)
         {
@@ -138,7 +124,5 @@ namespace PuppeteerSharp
             chromiumArguments.AddRange(options.Args);
             return chromiumArguments.ToArray();
         }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -38,14 +38,11 @@ namespace PuppeteerSharp
             _asyncSessions = new AsyncDictionaryHelper<string, CDPSession>(_sessions, "Session {0} not found");
         }
 
-        #region Private Members
         private readonly ConcurrentDictionary<int, MessageTask> _callbacks;
         private readonly ConcurrentDictionary<string, CDPSession> _sessions;
         private readonly AsyncDictionaryHelper<string, CDPSession> _asyncSessions;
         private int _lastId;
-        #endregion
 
-        #region Properties
         /// <summary>
         /// Gets the WebSocket URL.
         /// </summary>
@@ -94,10 +91,6 @@ namespace PuppeteerSharp
         public ILoggerFactory LoggerFactory { get; }
 
         internal AsyncMessageQueue MessageQueue { get; }
-
-        #endregion
-
-        #region Public Methods
 
         internal int GetMessageID() => Interlocked.Increment(ref _lastId);
 
@@ -152,7 +145,6 @@ namespace PuppeteerSharp
         }
 
         internal bool HasPendingCallbacks() => _callbacks.Count != 0;
-        #endregion
 
         internal void Close(string closeReason)
         {
@@ -190,8 +182,6 @@ namespace PuppeteerSharp
         internal CDPSession GetSession(string sessionId) => _sessions.GetValueOrDefault(sessionId);
 
         internal Task<CDPSession> GetSessionAsync(string sessionId) => _asyncSessions.GetItemAsync(sessionId);
-
-        #region Private Methods
 
         private async void Transport_MessageReceived(object sender, MessageReceivedEventArgs e)
             => await _callbackQueue.Enqueue(() => ProcessMessage(e)).ConfigureAwait(false);
@@ -282,10 +272,6 @@ namespace PuppeteerSharp
 
         private void Transport_Closed(object sender, TransportClosedEventArgs e) => Close(e.CloseReason);
 
-        #endregion
-
-        #region Static Methods
-
         /// <summary>
         /// Gets default web socket factory implementation.
         /// </summary>
@@ -331,6 +317,5 @@ namespace PuppeteerSharp
             Transport.Dispose();
             _callbackQueue.Dispose();
         }
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -70,7 +70,6 @@ namespace PuppeteerSharp
             }
         }
 
-        #region Properties
         /// <summary>
         /// Gets the child frames of the this frame
         /// </summary>
@@ -107,9 +106,6 @@ namespace PuppeteerSharp
         public Frame ParentFrame { get; private set; }
 
         internal FrameManager FrameManager { get; }
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         /// Navigates to an url
@@ -602,7 +598,5 @@ namespace PuppeteerSharp
             }
             ParentFrame = null;
         }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -36,8 +36,6 @@ namespace PuppeteerSharp
             Client.MessageReceived += Client_MessageReceived;
         }
 
-        #region Properties
-
         internal event EventHandler<FrameEventArgs> FrameAttached;
 
         internal event EventHandler<FrameEventArgs> FrameDetached;
@@ -57,9 +55,7 @@ namespace PuppeteerSharp
         internal Page Page { get; }
 
         internal TimeoutSettings TimeoutSettings { get; }
-        #endregion
 
-        #region Public Methods
         internal static async Task<FrameManager> CreateFrameManagerAsync(
             CDPSession client,
             Page page,
@@ -161,10 +157,6 @@ namespace PuppeteerSharp
                 return watcher.NavigationResponse;
             }
         }
-
-        #endregion
-
-        #region Private Methods
 
         private async void Client_MessageReceived(object sender, MessageEventArgs e)
         {
@@ -431,7 +423,5 @@ namespace PuppeteerSharp
         internal Task<Frame> GetFrameAsync(string frameId) => _asyncFrames.GetItemAsync(frameId);
 
         internal Task<Frame> TryGetFrameAsync(string frameId) => _asyncFrames.TryGetItemAsync(frameId);
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/FrameTree.cs
+++ b/lib/PuppeteerSharp/FrameTree.cs
@@ -25,13 +25,9 @@ namespace PuppeteerSharp
             LoadChilds(this, frameTree);
         }
 
-        #region Properties
         internal FramePayload Frame { get; set; }
 
         internal List<FrameTree> Childs { get; set; }
-        #endregion
-
-        #region Private Functions
 
         private void LoadChilds(FrameTree frame, PageGetFrameTreeItem frameTree)
         {
@@ -59,7 +55,5 @@ namespace PuppeteerSharp
                 }
             }
         }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -13,13 +13,9 @@ namespace PuppeteerSharp
     /// </summary>
     public class Launcher
     {
-        #region Private members
-
         private readonly ILoggerFactory _loggerFactory;
         private bool _processLaunched;
         private Product _product;
-
-        #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Launcher"/> class.
@@ -27,14 +23,11 @@ namespace PuppeteerSharp
         /// <param name="loggerFactory">Logger factory.</param>
         public Launcher(ILoggerFactory loggerFactory = null) => _loggerFactory = loggerFactory ?? new LoggerFactory();
 
-        #region Properties
         /// <summary>
         /// Gets the process, if any was created by this launcher.
         /// </summary>
         public LauncherBase Process { get; private set; }
-        #endregion
 
-        #region Public methods
         /// <summary>
         /// The method launches a browser instance with given arguments. The browser will be closed when the Browser is disposed.
         /// </summary>
@@ -165,10 +158,6 @@ namespace PuppeteerSharp
         /// <returns>The executable path.</returns>
         public Task<string> GetExecutablePathAsync() => ResolveExecutablePathAsync();
 
-        #endregion
-
-        #region Private methods
-
         private void EnsureSingleLaunchOrConnect()
         {
             if (_processLaunched)
@@ -228,7 +217,5 @@ namespace PuppeteerSharp
             }
             return revisionInfo.ExecutablePath;
         }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/LifecycleWatcher.cs
@@ -70,7 +70,6 @@ namespace PuppeteerSharp
             CheckLifecycleComplete();
         }
 
-        #region Properties
         public Task<bool> SameDocumentNavigationTask => _sameDocumentNavigationTaskWrapper.Task;
 
         public Task<bool> NewDocumentNavigationTask => _newDocumentNavigationTaskWrapper.Task;
@@ -80,10 +79,6 @@ namespace PuppeteerSharp
         public Task TimeoutOrTerminationTask => _terminationTaskWrapper.Task.WithTimeout(_timeout, cancellationToken: _terminationCancellationToken.Token);
 
         public Task LifecycleTask => _lifecycleTaskWrapper.Task;
-
-        #endregion
-
-        #region Private methods
 
         private void OnClientDisconnected(object sender, EventArgs e)
             => Terminate(new TargetClosedException("Navigation failed because browser has disconnected!", _frameManager.Client.CloseReason));
@@ -173,7 +168,5 @@ namespace PuppeteerSharp
             _frameManager.Client.Disconnected -= OnClientDisconnected;
             _terminationCancellationToken.Cancel();
         }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/MessageTask.cs
+++ b/lib/PuppeteerSharp/MessageTask.cs
@@ -10,10 +10,8 @@ namespace PuppeteerSharp
         {
         }
 
-        #region public Properties
         internal TaskCompletionSource<JObject> TaskWrapper { get; set; }
 
         internal string Method { get; set; }
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp/Target.cs
+++ b/lib/PuppeteerSharp/Target.cs
@@ -13,11 +13,9 @@ namespace PuppeteerSharp
     [DebuggerDisplay("Target {Type} - {Url}")]
     public class Target
     {
-        #region Private members
         private readonly Func<Task<CDPSession>> _sessionFactory;
         private readonly TaskCompletionSource<bool> _initializedTaskWrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         private Task<Worker> _workerTask;
-        #endregion
 
         internal bool IsInitialized { get; set; }
 
@@ -66,7 +64,6 @@ namespace PuppeteerSharp
             }
         }
 
-        #region Properties
         /// <summary>
         /// Gets the URL.
         /// </summary>
@@ -111,7 +108,6 @@ namespace PuppeteerSharp
         internal TaskCompletionSource<bool> CloseTaskWrapper { get; }
 
         internal Task<Page> PageTask { get; set; }
-        #endregion
 
         /// <summary>
         /// Returns the <see cref="Page"/> associated with the target. If the target is not <c>"page"</c> or <c>"background_page"</c> returns <c>null</c>

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -13,8 +13,6 @@ namespace PuppeteerSharp.Transport
     /// </summary>
     public class WebSocketTransport : IConnectionTransport
     {
-        #region Static fields
-
         /// <summary>
         /// Gets the default <see cref="WebSocketFactory"/>. This factory does not support Windows 7.
         /// </summary>
@@ -29,10 +27,6 @@ namespace PuppeteerSharp.Transport
         /// Gets the default <see cref="TransportTaskScheduler"/>
         /// </summary>
         public static readonly TransportTaskScheduler DefaultTransportScheduler = ScheduleTransportTask;
-
-        #endregion
-
-        #region Static methods
 
         private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
         {
@@ -56,19 +50,11 @@ namespace PuppeteerSharp.Transport
                 TaskCreationOptions.LongRunning,
                 TaskScheduler.Default);
 
-        #endregion
-
-        #region Instance fields
-
         private readonly WebSocket _client;
         private readonly bool _queueRequests;
         private readonly TaskQueue _socketQueue = new TaskQueue();
         [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", Justification = "False positive, as it is disposed in StopReading() method.")]
         private CancellationTokenSource _readerCancellationSource = new CancellationTokenSource();
-
-        #endregion
-
-        #region Constructor(s)
 
         /// <summary>
         /// Initialize the Transport
@@ -92,10 +78,6 @@ namespace PuppeteerSharp.Transport
             scheduler(GetResponseAsync, _readerCancellationSource.Token);
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
         /// </summary>
@@ -108,10 +90,6 @@ namespace PuppeteerSharp.Transport
         /// Occurs when a message is received.
         /// </summary>
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
-
-        #endregion
-
-        #region  Public methods
 
         /// <summary>
         /// Sends a message using the transport.
@@ -160,10 +138,6 @@ namespace PuppeteerSharp.Transport
             _client?.Dispose();
             _socketQueue.Dispose();
         }
-
-        #endregion
-
-        #region Private methods
 
         /// <summary>
         /// Starts listening the socket
@@ -225,7 +199,5 @@ namespace PuppeteerSharp.Transport
                 Closed?.Invoke(this, new TransportClosedEventArgs(closeReason));
             }
         }
-
-        #endregion
     }
 }


### PR DESCRIPTION
The intention of this change is to enable the analyzer rule [SA1124: DoNotUseRegions](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md) as described in the issue #1395 .

Please let me know if there is anything I've missed while raising the PR.