### PR TITLE
ElementHandle - Improve Debugger Display

### DIFF
--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace PuppeteerSharp
     /// Inherits from <see cref="JSHandle"/>. It represents an in-page DOM element.
     /// ElementHandles can be created by <see cref="PuppeteerSharp.Page.QuerySelectorAsync(string)"/> or <see cref="PuppeteerSharp.Page.QuerySelectorAllAsync(string)"/>.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ElementHandle : JSHandle
     {
         private readonly FrameManager _frameManager;
@@ -32,6 +34,9 @@ namespace PuppeteerSharp
             _frameManager = frameManager;
             _logger = client.LoggerFactory.CreateLogger<ElementHandle>();
         }
+
+        private string DebuggerDisplay =>
+            string.IsNullOrEmpty(RemoteObject.ClassName) ? ToString() : $"{RemoteObject.ClassName}@{RemoteObject.Description}";
 
         internal Page Page { get; }
 

--- a/lib/PuppeteerSharp/Messaging/RemoteObject.cs
+++ b/lib/PuppeteerSharp/Messaging/RemoteObject.cs
@@ -3,10 +3,18 @@ using Newtonsoft.Json.Linq;
 namespace PuppeteerSharp.Messaging
 {
     /// <summary>
-    /// Remote object.
+    /// Remote object is a mirror object referencing original JavaScript object.
     /// </summary>
     public class RemoteObject
     {
+        /// <summary>
+        /// Gets or sets String representation of the object. (Optional)
+        /// </summary>
+        public string Description { get; set; }
+        /// <summary>
+        ///Gets or sets the Object class (constructor) name. Specified for object type values only. (Optional)
+        /// </summary>
+        public string ClassName { get; set; }
         /// <summary>
         /// Gets or sets the type.
         /// </summary>


### PR DESCRIPTION
- Add RemoteObject.ClassName and RemoteObject.Description
- Add ElementHandle.DebuggerDisplay attribute to use newly added ClassName and Description

Doesn't change any runtime functionality, just improves the debugging output

Viewing an `ElementHandle` in the debugger will now show for example `HtmlButtonElement@button`.