### PR TITLE
Make ElementHandle.ClickablePointAsync public

### DIFF
--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -638,7 +638,7 @@ namespace PuppeteerSharp
         /// Gets a clickable point for the current element (currently the mid point).
         /// </summary>
         /// <returns>Task that resolves to the x, y point that describes the element's position.</returns>
-        Public async Task<(decimal X, decimal Y)> ClickablePointAsync()
+        public async Task<(decimal X, decimal Y)> ClickablePointAsync()
         {
             GetContentQuadsResponse result = null;
 

--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -634,7 +634,11 @@ namespace PuppeteerSharp
             await Page.Mouse.DragAndDropAsync(x, y, targetPoint.X, targetPoint.Y, delay).ConfigureAwait(false);
         }
 
-        private async Task<(decimal X, decimal Y)> ClickablePointAsync()
+        /// <summary>
+        /// Gets a clickable point for the current element (currently the mid point).
+        /// </summary>
+        /// <returns>Task that resolves to the x, y point that describes the element's position.</returns>
+        Public async Task<(decimal X, decimal Y)> ClickablePointAsync()
         {
             GetContentQuadsResponse result = null;
 


### PR DESCRIPTION
So that the user can choose a variable point where to press in the button

https://github.com/hardkoded/puppeteer-sharp/pull/1984


I don't want to open a ticket now. Wouldn't it make sense to write your own function so that it is variable for the user and not fixed in the middle? Or Optional variables in the ClickAsync function? If you want it, I'll be happy to open an extra ticket for it.