### PR TITLE
Update list of paths with ExecutableFilePermissions

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -322,9 +322,12 @@ namespace PuppeteerSharp
                 var executables = new string[]
                 {
                     "chrome",
+                    "chrome_crashpad_handler",
+                    "chrome-management-service",
                     "chrome_sandbox", // setuid
                     "crashpad_handler",
                     "google-chrome",
+                    "libvulkan.so.1",
                     "nacl_helper",
                     "nacl_helper_bootstrap",
                     "xdg-mime",


### PR DESCRIPTION
Fixes crash on launch on Linux:
```
[FATAL:double_fork_and_exec.cc(131)] execv .local-chromium/Linux-970485/chrome-linux/chrome_crashpad_handler: Permission denied (13)
```
See #1774