### PR TITLE
Allow for passing IJSHandle as argument to EvaluateFunctionAsync/EvaluateFunctionHandleAsync

### DIFF
--- a/lib/PuppeteerSharp/ExecutionContext.cs
+++ b/lib/PuppeteerSharp/ExecutionContext.cs
@@ -196,7 +196,7 @@ namespace PuppeteerSharp
 
                     break;
 
-                case JSHandle objectHandle:
+                case IJSHandle objectHandle:
                     return objectHandle.FormatArgument(this);
             }
 

--- a/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
@@ -8,8 +8,37 @@ using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp.Helpers
 {
-    internal class RemoteObjectHelper
+    internal static class RemoteObjectHelper
     {
+        internal static object FormatArgument(this IJSHandle jSHandle, ExecutionContext context)
+        {
+            if (jSHandle.Disposed)
+            {
+                throw new PuppeteerException("JSHandle is disposed!");
+            }
+
+            if (jSHandle.ExecutionContext != context)
+            {
+                throw new PuppeteerException("JSHandles can be evaluated only in the context they were created!");
+            }
+
+            var unserializableValue = jSHandle.RemoteObject.UnserializableValue;
+
+            if (unserializableValue != null)
+            {
+                return new { unserializableValue };
+            }
+
+            if (jSHandle.RemoteObject.ObjectId == null)
+            {
+                return new { jSHandle.RemoteObject.Value };
+            }
+
+            var objectId = jSHandle.RemoteObject.ObjectId;
+
+            return new { objectId };
+        }
+
         internal static object ValueFromRemoteObject<T>(RemoteObject remoteObject, bool stringify = false)
         {
             var unserializableValue = remoteObject.UnserializableValue;

--- a/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
@@ -8,37 +8,8 @@ using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp.Helpers
 {
-    internal static class RemoteObjectHelper
+    internal class RemoteObjectHelper
     {
-        internal static object FormatArgument(this IJSHandle jSHandle, ExecutionContext context)
-        {
-            if (jSHandle.Disposed)
-            {
-                throw new PuppeteerException("JSHandle is disposed!");
-            }
-
-            if (jSHandle.ExecutionContext != context)
-            {
-                throw new PuppeteerException("JSHandles can be evaluated only in the context they were created!");
-            }
-
-            var unserializableValue = jSHandle.RemoteObject.UnserializableValue;
-
-            if (unserializableValue != null)
-            {
-                return new { unserializableValue };
-            }
-
-            if (jSHandle.RemoteObject.ObjectId == null)
-            {
-                return new { jSHandle.RemoteObject.Value };
-            }
-
-            var objectId = jSHandle.RemoteObject.ObjectId;
-
-            return new { objectId };
-        }
-
         internal static object ValueFromRemoteObject<T>(RemoteObject remoteObject, bool stringify = false)
         {
             var unserializableValue = remoteObject.UnserializableValue;

--- a/lib/PuppeteerSharp/IJSHandle.cs
+++ b/lib/PuppeteerSharp/IJSHandle.cs
@@ -24,7 +24,7 @@ namespace PuppeteerSharp
         IExecutionContext ExecutionContext { get; }
 
         /// <summary>
-        /// Gets or sets the remote object.
+        /// Gets the remote object.
         /// </summary>
         /// <value>The remote object.</value>
         RemoteObject RemoteObject { get; }

--- a/lib/PuppeteerSharp/JSHandle.cs
+++ b/lib/PuppeteerSharp/JSHandle.cs
@@ -152,34 +152,5 @@ namespace PuppeteerSharp
             list.Insert(0, this);
             return ExecutionContext.EvaluateFunctionAsync<T>(script, list.ToArray());
         }
-
-        internal object FormatArgument(ExecutionContext context)
-        {
-            if (ExecutionContext != context)
-            {
-                throw new PuppeteerException("JSHandles can be evaluated only in the context they were created!");
-            }
-
-            if (Disposed)
-            {
-                throw new PuppeteerException("JSHandle is disposed!");
-            }
-
-            var unserializableValue = RemoteObject.UnserializableValue;
-
-            if (unserializableValue != null)
-            {
-                return new { unserializableValue };
-            }
-
-            if (RemoteObject.ObjectId == null)
-            {
-                return new { RemoteObject.Value };
-            }
-
-            var objectId = RemoteObject.ObjectId;
-
-            return new { objectId };
-        }
     }
 }

--- a/lib/PuppeteerSharp/PuppeteerHandleExtensions.cs
+++ b/lib/PuppeteerSharp/PuppeteerHandleExtensions.cs
@@ -112,5 +112,34 @@ namespace PuppeteerSharp
             await arrayHandle.DisposeAsync().ConfigureAwait(false);
             return result;
         }
+
+        internal static object FormatArgument(this IJSHandle jSHandle, ExecutionContext context)
+        {
+            if (jSHandle.Disposed)
+            {
+                throw new PuppeteerException("JSHandle is disposed!");
+            }
+
+            if (jSHandle.ExecutionContext != context)
+            {
+                throw new PuppeteerException("JSHandles can be evaluated only in the context they were created!");
+            }
+
+            var unserializableValue = jSHandle.RemoteObject.UnserializableValue;
+
+            if (unserializableValue != null)
+            {
+                return new { unserializableValue };
+            }
+
+            if (jSHandle.RemoteObject.ObjectId == null)
+            {
+                return new { jSHandle.RemoteObject.Value };
+            }
+
+            var objectId = jSHandle.RemoteObject.ObjectId;
+
+            return new { objectId };
+        }
     }
 }


### PR DESCRIPTION
Motivation for this change is to allow for [PuppeteerSharp.Dom](https://github.com/ChromiumDotNet/PuppeteerSharp.Dom) to pass it's custom `DOM` object instances as `IJSHandle` args to EvaluateFunctionAsync/EvaluateFunctionHandleAsync. 

Currently you have to cast to `JSHandle`. e.g. https://github.com/ChromiumDotNet/PuppeteerSharp.Dom/blob/b1f862ee24dcc2a025dfea43d198597dbdedf17c/PuppeteerSharp.Dom.Tests/ElementHandleTests/BoundingBoxTests.cs#L61




