### PR TITLE
FrameManager - Add new frames via AsyncDictionaryHelper.AddItem

### DIFF
--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -457,7 +457,7 @@ namespace PuppeteerSharp
             {
                 var parentFrame = _frames[parentFrameId];
                 var frame = new Frame(this, parentFrame, frameId, session);
-                _frames[frame.Id] = frame;
+                _asyncFrames.AddItem(frame.Id, frame);
                 FrameAttached?.Invoke(this, new FrameEventArgs(frame));
             }
         }


### PR DESCRIPTION
There are two ways Frames are added to the ConcurrentDictionary, only the frames created in OnFrameNavigatedAsync will resolve the Task created by GetItemAsync. The frames created in OnFrameAttached are added to the ConcurrentDictionary directly and never resolve any pending Tasks.

`AsyncDictionaryHelper.AddItem` is now used to add all frames to the dictionary.