### PR TITLE
[BREAKING] Update permissions overrides

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/BrowserContextOverridePermissionsTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using PuppeteerSharp.Tests.Attributes;
 using PuppeteerSharp.Xunit;
@@ -112,6 +114,18 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.Equal("granted", await GetPermissionAsync(otherPage, "geolocation"));
 
             await otherContext.CloseAsync();
+        }
+
+        [SkipBrowserFact(skipFirefox: true)]
+        public async Task AllEnumsdAreValid()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            await Context.OverridePermissionsAsync(
+                TestConstants.EmptyPage,
+                Enum.GetValues(typeof(OverridePermission)).Cast<OverridePermission>().ToArray());
+            Assert.Equal("granted", await GetPermissionAsync(Page, "geolocation"));
+            await Context.ClearPermissionOverridesAsync();
+            Assert.Equal("prompt", await GetPermissionAsync(Page, "geolocation"));
         }
     }
 }

--- a/lib/PuppeteerSharp/OverridePermission.cs
+++ b/lib/PuppeteerSharp/OverridePermission.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -30,12 +31,6 @@ namespace PuppeteerSharp
         Notifications,
 
         /// <summary>
-        /// Push.
-        /// </summary>
-        [EnumMember(Value = "push")]
-        Push,
-
-        /// <summary>
         /// Camera.
         /// </summary>
         [EnumMember(Value = "videoCapture")]
@@ -66,16 +61,10 @@ namespace PuppeteerSharp
         AccessibilityEvents,
 
         /// <summary>
-        /// Clipboard read.
+        /// Clipboard read/write.
         /// </summary>
-        [EnumMember(Value = "clipboardRead")]
-        ClipboardRead,
-
-        /// <summary>
-        /// Clipboard write.
-        /// </summary>
-        [EnumMember(Value = "clipboardWrite")]
-        ClipboardWrite,
+        [EnumMember(Value = "clipboardReadWrite")]
+        ClipboardReadWrite,
 
         /// <summary>
         /// Payment handler.
@@ -94,5 +83,11 @@ namespace PuppeteerSharp
         /// </summary>
         [EnumMember(Value = "idleDetection")]
         IdleDetection,
+
+        /// <summary>
+        /// Persistent Storage.
+        /// </summary>
+        [EnumMember(Value = "durableStorage")]
+        PersistentStorage,
     }
 }


### PR DESCRIPTION
I had to remove the `Push` enum and rename the  `Clipboard` ones.

closes #2052