### PR TITLE
Automate nuget org push

### DIFF
--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -9,7 +9,6 @@ env:
 jobs:
   PushToIntNugetOrg:
     runs-on: ubuntu-latest
-    needs: build
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore lib/PuppeteerSharp.sln
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to int.nuget.org

--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -1,4 +1,4 @@
-name: build
+name: PushToIntNugetOrg
 
 on:
   workflow_dispatch:

--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -1,0 +1,27 @@
+name: build
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '6.0.x' # The .NET SDK version to use
+
+jobs:
+  PushToIntNugetOrg:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Build
+      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
+    - name: NugetPush to int.nuget.org
+      env:
+        NUGET_TOKEN_TEST_EXISTS: ${{ secrets.NUGET_INT_API_KEY }}
+      if: env.NUGET_TOKEN_TEST_EXISTS != ''
+      run: |
+        ls ./lib/PuppeteerSharp/bin/Release
+        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --api-key ${{secrets.NUGET_INT_API_KEY}} --source https://apiint.nugettest.org/v3/index.json

--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to int.nuget.org

--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build
-      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
+      run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to int.nuget.org
       env:
         NUGET_TOKEN_TEST_EXISTS: ${{ secrets.NUGET_INT_API_KEY }}

--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -15,8 +15,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore lib/PuppeteerSharp.sln
+    - name: Install dependencies
+      run: |
+        dotnet restore lib/PuppeteerSharp.sln
+        dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to int.nuget.org

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -12,7 +12,6 @@ env:
 jobs:
    PushToNugetOrg:
     runs-on: ubuntu-latest
-    needs: build
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -2,6 +2,9 @@ name: PushToNugetOrg
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+        - v*
 
 env:
   DOTNET_VERSION: '6.0.x' # The .NET SDK version to use

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build
-      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
+      run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to nuget.org
       env:
         NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_API_KEY  }}

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -18,8 +18,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore lib/PuppeteerSharp.sln
+    - name: Install dependencies
+      run: |
+        dotnet restore lib/PuppeteerSharp.sln
+        dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to nuget.org

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -1,0 +1,28 @@
+name: build
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '6.0.x' # The .NET SDK version to use
+
+jobs:
+   PushToNugetOrg:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Build
+      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
+    - name: NugetPush to nuget.org
+      env:
+        NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_API_KEY  }}
+      if: env.NUGET_TOKEN_EXISTS != ''
+      run: |
+        ls ./lib/PuppeteerSharp/bin/Release
+        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to nuget.org

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -1,4 +1,4 @@
-name: build
+name: PushToNugetOrg
 
 on:
   workflow_dispatch:

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore lib/PuppeteerSharp.sln
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln --configuration Release --no-restore
     - name: NugetPush to nuget.org

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build:
-
     name: build-${{ matrix.browser }}/${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -25,7 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         browser: [FIREFOX,CHROME]
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET Core
@@ -49,43 +47,3 @@ jobs:
           export DISPLAY=:1.5
           cd lib/PuppeteerSharp.Tests
           dotnet test -f net6.0 -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
-
-  deployRelease:
-    if: github.ref == 'refs/heads/release'
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Build
-      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
-    - name: NugetPush to nuget.org
-      env:
-        NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_TOKEN  }}
-      if: env.NUGET_TOKEN_EXISTS != '' && startsWith( github.ref, 'refs/heads/release-' )
-      run: |
-        ls ./lib/PuppeteerSharp/bin/Release
-        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
-
-  deployMaster:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Build
-      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
-    - name: NugetPush to nuget.org
-      env:
-        NUGET_TOKEN_TEST_EXISTS: ${{ secrets.NUGET_TEST_TOKEN }}
-      if: env.NUGET_TOKEN_TEST_EXISTS != '' && github.ref == 'refs/heads/master'
-      run: |
-        ls ./lib/PuppeteerSharp/bin/Release
-        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TEST_TOKEN}} --source https://apiint.nugettest.org/v3/index.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,6 +28,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: browser-actions/setup-firefox@v1
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
@@ -39,8 +40,7 @@ jobs:
         dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
-        sudo snap remove firefox
-        sudo apt-get install firefox
+        firefox --version
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,9 +27,9 @@ jobs:
         browser: [FIREFOX,CHROME]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -49,11 +49,11 @@ jobs:
           export DISPLAY=:1.5
           cd lib/PuppeteerSharp.Tests
           dotnet test -f net6.0 -s test.runsettings -c Release --logger "trx;LogFileName=TestResults.xml"
-      
+
   deployRelease:
     if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
-    needs: build 
+    needs: build
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -73,7 +73,7 @@ jobs:
   deployMaster:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: build 
+    needs: build
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: browser-actions/setup-firefox@v1
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
@@ -40,7 +39,6 @@ jobs:
         dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
-        firefox --version
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln
     - name: Test
@@ -50,7 +48,7 @@ jobs:
           Xvfb :1 -screen 5 1024x768x8 &
           export DISPLAY=:1.5
           cd lib/PuppeteerSharp.Tests
-          dotnet test -f net6.0 -s test.runsettings -c Release --logger "trx;LogFileName=TestResults.xml"
+          dotnet test -f net6.0 -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
 
   deployRelease:
     if: github.ref == 'refs/heads/release'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,7 @@ on:
       - master
       - release-*
   pull_request:
-    branches: [ master, release ]
+    branches: [ master ]
     paths:
     - '**.cs'
     - '**.csproj'
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        browser: [CHROME]
+        browser: [FIREFOX,CHROME]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -40,21 +40,52 @@ jobs:
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
     - name: Build
-      run: dotnet build lib/PuppeteerSharp.sln --configuration Release
+      run: dotnet build lib/PuppeteerSharp.sln
     - name: Test
-      run: dotnet test lib/PuppeteerSharp.sln --no-build --verbosity normal --configuration Release
-    - name: NugetPush to int.nugettest.org
+      env:
+        PRODUCT: ${{ matrix.browser }}
+      run: |
+          Xvfb :1 -screen 5 1024x768x8 &
+          export DISPLAY=:1.5
+          cd lib/PuppeteerSharp.Tests
+          dotnet test -f net6.0 -s test.runsettings -c Release --logger "trx;LogFileName=TestResults.xml"
+      
+  deployRelease:
+    if: github.ref == 'refs/heads/release'
+    runs-on: ubuntu-latest
+    needs: build 
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Build
+      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
+    - name: NugetPush to nuget.org
+      env:
+        NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_TOKEN  }}
+      if: env.NUGET_TOKEN_EXISTS != '' && startsWith( github.ref, 'refs/heads/release-' )
+      run: |
+        ls ./lib/PuppeteerSharp/bin/Release
+        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
+
+  deployMaster:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build 
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Build
+      run: dotnet build  lib/PuppeteerSharp.sln --configuration Release --no-restore
+    - name: NugetPush to nuget.org
       env:
         NUGET_TOKEN_TEST_EXISTS: ${{ secrets.NUGET_TEST_TOKEN }}
       if: env.NUGET_TOKEN_TEST_EXISTS != '' && github.ref == 'refs/heads/master'
       run: |
         ls ./lib/PuppeteerSharp/bin/Release
         dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TEST_TOKEN}} --source https://apiint.nugettest.org/v3/index.json
-    - name: NugetPush to nuget.org
-      env:
-        NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_TOKEN  }}
-      if: env.NUGET_TOKEN_EXISTS != '' && github.ref == 'refs/heads/release'
-      run: |
-        ls ./lib/PuppeteerSharp/bin/Release
-        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
-      

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,12 +1,13 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
       - release-*
   pull_request:
-    branches: [ master ]
+    branches: [ master, release ]
     paths:
     - '**.cs'
     - '**.csproj'
@@ -23,12 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        browser: [FIREFOX,CHROME]
+        browser: [CHROME]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -39,12 +40,21 @@ jobs:
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
     - name: Build
-      run: dotnet build lib/PuppeteerSharp.sln
+      run: dotnet build lib/PuppeteerSharp.sln --configuration Release
     - name: Test
+      run: dotnet test lib/PuppeteerSharp.sln --no-build --verbosity normal --configuration Release
+    - name: NugetPush to int.nugettest.org
       env:
-        PRODUCT: ${{ matrix.browser }}
+        NUGET_TOKEN_TEST_EXISTS: ${{ secrets.NUGET_TEST_TOKEN }}
+      if: env.NUGET_TOKEN_TEST_EXISTS != '' && github.ref == 'refs/heads/master'
       run: |
-          Xvfb :1 -screen 5 1024x768x8 &
-          export DISPLAY=:1.5
-          cd lib/PuppeteerSharp.Tests
-          dotnet test -f net6.0 -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
+        ls ./lib/PuppeteerSharp/bin/Release
+        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TEST_TOKEN}} --source https://apiint.nugettest.org/v3/index.json
+    - name: NugetPush to nuget.org
+      env:
+        NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_TOKEN  }}
+      if: env.NUGET_TOKEN_EXISTS != '' && github.ref == 'refs/heads/release'
+      run: |
+        ls ./lib/PuppeteerSharp/bin/Release
+        dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
+      

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,7 +39,7 @@ jobs:
         dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
-        snap remove firefox
+        sudo snap remove firefox
         sudo apt-get install firefox
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,7 +40,7 @@ jobs:
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
         snap remove firefox
-        suto apt-get install firefox
+        sudo apt-get install firefox
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,6 +39,8 @@ jobs:
         dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates
+        snap remove firefox
+        suto apt-get install firefox
     - name: Build
       run: dotnet build lib/PuppeteerSharp.sln
     - name: Test

--- a/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
+++ b/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
+++ b/lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PuppeteerSharp\PuppeteerSharp.csproj" />

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 	<ItemGroup>

--- a/lib/PuppeteerSharp.Xunit/PuppeteerSharp.Xunit.csproj
+++ b/lib/PuppeteerSharp.Xunit/PuppeteerSharp.Xunit.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="../Common/SignAssembly.props" />
 </Project>

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -452,7 +452,7 @@ namespace PuppeteerSharp
             {
                 var parentFrame = _frames[parentFrameId];
                 var frame = new Frame(this, parentFrame, frameId, session);
-                _frames[frame.Id] = frame;
+                _asyncFrames.AddItem(frame.Id, frame);
                 FrameAttached?.Invoke(this, new FrameEventArgs(frame));
             }
         }

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -6,7 +6,6 @@
     <Authors>Darío Kondratiuk</Authors>
     <Owners>Darío Kondratiuk</Owners>
     <PackageProjectUrl>https://github.com/hardkoded/puppeteer-sharp</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/hardkoded/puppeteer-sharp</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Summary>Headless Browser .NET API</Summary>
     <PackageTags>headless,chrome,puppeteer</PackageTags>
@@ -14,32 +13,28 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>9.0.0</PackageVersion>
-    <ReleaseVersion>9.0.0</ReleaseVersion>
-    <AssemblyVersion>9.0.0.0</AssemblyVersion>
-    <FileVersion>9.0.0.0</FileVersion>
+    <PackageVersion>9.0.2</PackageVersion>
+    <ReleaseVersion>9.0.2</ReleaseVersion>
+    <AssemblyVersion>9.0.2.0</AssemblyVersion>
+    <FileVersion>9.0.2.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <CodeAnalysisRuleSet>../PuppeteerSharp.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="../Common/SignAssembly.props" />
   <PropertyGroup>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <PackageProjectUrl>https://github.com/hardkoded/puppeteer-sharp</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-    <ContinuousIntegrationBuild Condition="'$(APPVEYOR)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -13,10 +13,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>8.0.0</PackageVersion>
-    <ReleaseVersion>8.0.0</ReleaseVersion>
-    <AssemblyVersion>8.0.0.0</AssemblyVersion>
-    <FileVersion>8.0.0.0</FileVersion>
+    <PackageVersion>9.0.0</PackageVersion>
+    <ReleaseVersion>9.0.0</ReleaseVersion>
+    <AssemblyVersion>9.0.0.0</AssemblyVersion>
+    <FileVersion>9.0.0.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <CodeAnalysisRuleSet>../PuppeteerSharp.ruleset</CodeAnalysisRuleSet>

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -6,6 +6,7 @@
     <Authors>Darío Kondratiuk</Authors>
     <Owners>Darío Kondratiuk</Owners>
     <PackageProjectUrl>https://github.com/hardkoded/puppeteer-sharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/hardkoded/puppeteer-sharp</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Summary>Headless Browser .NET API</Summary>
     <PackageTags>headless,chrome,puppeteer</PackageTags>
@@ -23,18 +24,22 @@
   </PropertyGroup>
   <Import Project="../Common/SignAssembly.props" />
   <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <PackageProjectUrl>https://github.com/hardkoded/puppeteer-sharp</PackageProjectUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition="'$(APPVEYOR)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated api keys

There are two steps that I wont be able to prepare... btw. not able without authorization at nuget.org to change your package.

- Obtain an api key from nuget.org and add it using the key "NUGET_API_KEY" to your secrets to enable pushing built packages to nuget.org. That will get triggerd on pushing to "release-*" branches.
- Obtain an api key from https://int.nugettest.org/ and add it using the key "NUGET_INT_API_KEY" to your secrets to enable pushing built packages to int.nugettest.org. That will get triggered on pushing to "master" branch and will run online similar checks on the package like need to be satisfied publishing using nuget.org.