### PR TITLE
Prefer IsEmpty over Count/Any

### DIFF
--- a/lib/PuppeteerSharp.ruleset
+++ b/lib/PuppeteerSharp.ruleset
@@ -77,6 +77,7 @@
     <Rule Id="CA1724" Action="Error" /> <!-- Error CA1724: The type name Extensions conflicts in whole or in part with the namespace name 'Microsoft.Extensions'. Change either name to eliminate the conflict. (CA1724) -->
     <Rule Id="CA1806" Action="Error" /> <!-- Error CA1806: DownloadAsync calls Chmod but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method. (CA1806)-->
     <Rule Id="CA1816" Action="Error" /> <!-- Error CA1816: Change Connection.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it. (CA1816) -->
+    <Rule Id="CA1836" Action="Error" /> <!-- Error CA1836: Prefer IsEmpty over Count when available. (CA1836) -->
     <Rule Id="CA2000" Action="Error" /> <!-- Error CA2000: Call System.IDisposable.Dispose on object created by 'new Process()' before all references to it are out of scope. (CA2000) -->
     <Rule Id="CA2008" Action="Error" /> <!-- Error ca2008: Pass TaskScheduler-->
     <Rule Id="CA2200" Action="Error" /> <!-- Error CA2200: Re-throwing caught exception changes stack information. (CA2200)  -->

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -111,7 +111,7 @@ namespace PuppeteerSharp
         internal void Send(string method, object args = null)
             => _ = SendAsync(method, args, false);
 
-        internal bool HasPendingCallbacks() => _callbacks.Count != 0;
+        internal bool HasPendingCallbacks() => !_callbacks.IsEmpty;
 
         internal void OnMessage(ConnectionResponse obj)
         {

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -190,7 +190,7 @@ namespace PuppeteerSharp
             return await GetSessionAsync(sessionId).ConfigureAwait(false);
         }
 
-        internal bool HasPendingCallbacks() => _callbacks.Count != 0;
+        internal bool HasPendingCallbacks() => !_callbacks.IsEmpty;
 
         internal void Close(string closeReason)
         {

--- a/lib/PuppeteerSharp/DOMWorld.cs
+++ b/lib/PuppeteerSharp/DOMWorld.cs
@@ -48,7 +48,7 @@ namespace PuppeteerSharp
             _logger = _client.Connection.LoggerFactory.CreateLogger<DOMWorld>();
         }
 
-        internal ICollection<WaitTask> WaitTasks { get; set; }
+        internal ConcurrentSet<WaitTask> WaitTasks { get; set; }
 
         internal Frame Frame { get; }
 
@@ -143,7 +143,7 @@ namespace PuppeteerSharp
         internal void Detach()
         {
             _detached = true;
-            while (WaitTasks.Count > 0)
+            while (!WaitTasks.IsEmpty)
             {
                 WaitTasks.First().Terminate(new Exception("waitForFunction failed: frame got detached."));
             }

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -986,7 +986,7 @@ namespace PuppeteerSharp
         /// <inheritdoc/>
         public async Task<FileChooser> WaitForFileChooserAsync(WaitForFileChooserOptions options = null)
         {
-            if (!_fileChooserInterceptors.Any())
+            if (_fileChooserInterceptors.IsEmpty)
             {
                 await Client.SendAsync("Page.setInterceptFileChooserDialog", new PageSetInterceptFileChooserDialog
                 {
@@ -1472,7 +1472,7 @@ namespace PuppeteerSharp
 
         private async Task OnFileChooserAsync(PageFileChooserOpenedResponse e)
         {
-            if (_fileChooserInterceptors.Count == 0)
+            if (_fileChooserInterceptors.IsEmpty)
             {
                 try
                 {
@@ -1493,7 +1493,7 @@ namespace PuppeteerSharp
             var world = context.World;
             var element = await world.AdoptBackendNodeAsync(e.BackendNodeId).ConfigureAwait(false);
             var fileChooser = new FileChooser(element, e);
-            while (_fileChooserInterceptors.Count > 0)
+            while (!_fileChooserInterceptors.IsEmpty)
             {
                 var key = _fileChooserInterceptors.FirstOrDefault().Key;
 


### PR DESCRIPTION
[Roslyn Aanalyzers](https://github.com/dotnet/roslyn-analyzers) reports [CA1836: Prefer IsEmpty over Count when available](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1836).

E.g. [`ConcurrentDictionary.IsEmpty`](https://source.dot.net/#System.Collections.Concurrent/System/Collections/Concurrent/ConcurrentDictionary.cs,1479) has a lock-free fast path, whereas [`ConcurrentDictionary.Count`](https://source.dot.net/#System.Collections.Concurrent/System/Collections/Concurrent/ConcurrentDictionary.cs,1116) always acquires all locks.