### PR TITLE
Fix duplicated test

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsPopupTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsPopupTests.cs
@@ -63,10 +63,10 @@ namespace PuppeteerSharp.Tests.PageTests
 
         [PuppeteerTest("page.spec.ts", "Page.Events.Popup", "should work with clicking target=_blank and with rel=opener")]
         [SkipBrowserFact(skipFirefox: true)]
-        public async Task ShouldWorkWithFakeClickingTargetBlankAndReNoopener()
+        public async Task ShouldWorkWithFakeClickingTargetBlankAndRelOpener()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            await Page.SetContentAsync("<a target=_blank rel=noopener href='/one-style.html'>yo</a>");
+            await Page.SetContentAsync("<a target=_blank rel=opener href='/one-style.html'>yo</a>");
 
             var popupTaskSource = new TaskCompletionSource<IPage>();
             Page.Popup += (_, e) => popupTaskSource.TrySetResult(e.PopupPage);
@@ -76,7 +76,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 Page.QuerySelectorAsync("a").EvaluateFunctionAsync("a => a.click()"));
 
             Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.False(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.True(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
         }
 
         [PuppeteerTest("page.spec.ts", "Page.Events.Popup", "should work with fake-clicking target=_blank and rel=noopener")]


### PR DESCRIPTION
[`ShouldWorkWithFakeClickingTargetBlankAndReNoopener`](https://github.com/hardkoded/puppeteer-sharp/blob/c18812b66ae07e1c0ecda5af5573a2d12accad8f/lib/PuppeteerSharp.Tests/PageTests/PageEventsPopupTests.cs#L64-L80) and [`ShouldWorkWithFakeClickingTargetBlankAndRelNoopener`](https://github.com/hardkoded/puppeteer-sharp/blob/c18812b66ae07e1c0ecda5af5573a2d12accad8f/lib/PuppeteerSharp.Tests/PageTests/PageEventsPopupTests.cs#L82-L98) are identical.
The first one should use `rel=opener`

Cross-checked with [puppeteer source](https://github.com/puppeteer/puppeteer/blob/415da9230066e5b399f60963b639bfbafdc8ec57/test/src/page.spec.ts#L296-L346)