### PR TITLE
Return a `Task` instead of `null`

### DIFF
--- a/lib/PuppeteerSharp/States/DisposedState.cs
+++ b/lib/PuppeteerSharp/States/DisposedState.cs
@@ -9,11 +9,11 @@ namespace PuppeteerSharp.States
         {
         }
 
-        public override Task EnterFromAsync(LauncherBase p, State fromState, TimeSpan timeSpan)
+        public override Task EnterFromAsync(LauncherBase p, State fromState, TimeSpan timeout)
         {
             if (fromState == StateManager.Exited)
             {
-                return null;
+                return Task.CompletedTask;
             }
 
             Kill(p);
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.States
             p.ExitCompletionSource.TrySetException(new ObjectDisposedException(p.ToString()));
             p.TempUserDataDir?.Dispose();
 
-            return null;
+            return Task.CompletedTask;
         }
 
         public override Task StartAsync(LauncherBase p) => throw new ObjectDisposedException(p.ToString());


### PR DESCRIPTION
`await`'ing `null` `Task` throws a `NullReferenceException`.
See e.g. this [example](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEUCuA7AHwAEAGAAiIEYBWAbgFgAoJogTjIDEIIAKASgbNGRJJ278yAXgB8ZPDgA2C2kA)

`DisposedState.EnterFromAsync` is, as far as I can tell, only invoked as a fire-and-forget from `State.Dispose`, so _currently_ this isn't a problem.

Instead I propose returning a completed `Task`.

`Task.CompletedTask` is a [cached `Task`](https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs,1477), so there's no overhead in using that over returning `null`.

The rename of `timeSpan` to `timeout` is to match the parameter name in the overridden method `State.EnterFromAsync(LauncherBase p, State fromState, TimeSpan timeout)`