### PR TITLE
Safer double disposal

### DIFF
--- a/lib/PuppeteerSharp/Helpers/TaskQueue.cs
+++ b/lib/PuppeteerSharp/Helpers/TaskQueue.cs
@@ -71,7 +71,15 @@ namespace PuppeteerSharp.Helpers
 
         protected virtual async ValueTask DisposeAsyncCore()
         {
-            await _semaphore.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await _semaphore.WaitAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore
+            }
+
             _semaphore.Dispose();
         }
     }

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -273,7 +273,14 @@ async function waitForPredicatePageFunction(
         {
             if (!_cts.IsCancellationRequested)
             {
-                _cts.Cancel();
+                try
+                {
+                    _cts.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Ignore
+                }
             }
 
             _world.WaitTasks.Remove(this);


### PR DESCRIPTION
When running tests with a debugger attached I found some places that weren't thread-safe.

1) Disposing `TaskQueue` twice would throw an `ObjectDisposedException` on `_semaphore.WaitAsync()` when a previous call to `DisposeAsyncCore` has already disposed the `_semaphore`.


2) Running `PageWaitForTests.ShouldWaitForAnXpath` makes two concurrent calls as shown below

| TaskA                | TaskB                          |
|----------------------|--------------------------------|
| `WaitTask.Dispose()` | `WaitTask.Cleanup()`           |
|                      | `_cts.IsCancellationRequested` |
| `_cts.Dispose()`     |                                |
|                      | `_cts.Cancel()` // throws `ObjectDisposedException`               |

When this race-condition is hit, `_world.WaitTasks.Remove(this);` in `WaitTasks.Cleanup` is not called.