### PR TITLE
Test - Use Assert.ThrowsAsync for exceptions instead of ContinueWith

### DIFF
--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
@@ -262,7 +262,11 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             };
             IRequest failedRequest = null;
             Page.RequestFailed += (_, e) => failedRequest = e.Request;
-            await Page.GoToAsync(TestConstants.EmptyPage).ContinueWith(_ => { });
+
+            var exception = await Assert.ThrowsAsync<NavigationException>(
+                () => Page.GoToAsync(TestConstants.EmptyPage));
+
+            Assert.StartsWith("net::ERR_INTERNET_DISCONNECTED", exception.Message);
             Assert.NotNull(failedRequest);
             Assert.Equal("net::ERR_INTERNET_DISCONNECTED", failedRequest.Failure);
         }

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using PuppeteerSharp.Tests.Attributes;
@@ -102,9 +103,10 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             var frame = Page.FirstChildFrame();
-            var waitTask = frame.WaitForSelectorAsync(".box").ContinueWith(task => task?.Exception?.InnerException);
+            var waitTask = frame.WaitForSelectorAsync(".box");
             await FrameUtils.DetachFrameAsync(Page, "frame1");
-            var waitException = await waitTask;
+            var waitException = await Assert.ThrowsAsync<Exception>(() => waitTask);
+
             Assert.NotNull(waitException);
             Assert.Contains("waitForFunction failed: frame got detached.", waitException.Message);
         }


### PR DESCRIPTION
After reviewing `ContinueWith` usage in the tests there are a couple of cases which can be improved by changing to Assert.ThrowsAsync.

