### PR TITLE
Improve timing related tests

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
@@ -22,7 +22,12 @@ namespace PuppeteerSharp.Tests.PageTests
             var t2 = DateTime.UtcNow;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var task = Page.WaitForNetworkIdleAsync().ContinueWith(x => t1 = DateTime.UtcNow);
+            var task = Page.WaitForNetworkIdleAsync()
+                .ContinueWith(x =>
+                {
+                    if (x.IsFaulted) throw x.Exception;
+                    return t1 = DateTime.UtcNow;
+                });
 
             await Task.WhenAll(
                 task,
@@ -35,7 +40,11 @@ namespace PuppeteerSharp.Tests.PageTests
                     await fetch('/digits/3.png');
                     await new Promise((resolve) => setTimeout(resolve, 200));
                     await fetch('/digits/4.png');
-                }").ContinueWith(x => t2 = DateTime.UtcNow)
+                }").ContinueWith(x =>
+                {
+                    if (x.IsFaulted) throw x.Exception;
+                    t2 = DateTime.UtcNow;
+                })
             );
 
             Assert.True(t1 > t2);
@@ -63,7 +72,12 @@ namespace PuppeteerSharp.Tests.PageTests
             var t2 = DateTime.UtcNow;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var task = Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { IdleTime = 10 }).ContinueWith(x => t1 = DateTime.UtcNow);
+            var task = Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { IdleTime = 10 })
+                .ContinueWith(x =>
+                {
+                    if (x.IsFaulted) throw x.Exception;
+                    return t1 = DateTime.UtcNow;
+                });
 
             await Task.WhenAll(
                 task,
@@ -73,7 +87,11 @@ namespace PuppeteerSharp.Tests.PageTests
                     fetch('/digits/2.png'),
                     ]);
                     await new Promise((resolve) => setTimeout(resolve, 250));
-                }").ContinueWith(x => t2 = DateTime.UtcNow)
+                }").ContinueWith(x =>
+                {
+                    if (x.IsFaulted) throw x.Exception;
+                    return t2 = DateTime.UtcNow;
+                })
             );
 
             Assert.True(t2 > t1);

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
@@ -18,11 +18,11 @@ namespace PuppeteerSharp.Tests.PageTests
         [PuppeteerFact]
         public async Task ShouldWork()
         {
-            var t1 = DateTime.Now;
-            var t2 = DateTime.Now;
+            var t1 = DateTime.UtcNow;
+            var t2 = DateTime.UtcNow;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var task = Page.WaitForNetworkIdleAsync().ContinueWith(x => t1 = DateTime.Now);
+            var task = Page.WaitForNetworkIdleAsync().ContinueWith(x => t1 = DateTime.UtcNow);
 
             await Task.WhenAll(
                 task,
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     await fetch('/digits/3.png');
                     await new Promise((resolve) => setTimeout(resolve, 200));
                     await fetch('/digits/4.png');
-                }").ContinueWith(x => t2 = DateTime.Now)
+                }").ContinueWith(x => t2 = DateTime.UtcNow)
             );
 
             Assert.True(t1 > t2);
@@ -59,11 +59,11 @@ namespace PuppeteerSharp.Tests.PageTests
         [SkipBrowserFact(skipFirefox: true)]
         public async Task ShouldRespectIdleTimeout()
         {
-            var t1 = DateTime.Now;
-            var t2 = DateTime.Now;
+            var t1 = DateTime.UtcNow;
+            var t2 = DateTime.UtcNow;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var task = Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { IdleTime = 10 }).ContinueWith(x => t1 = DateTime.Now);
+            var task = Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { IdleTime = 10 }).ContinueWith(x => t1 = DateTime.UtcNow);
 
             await Task.WhenAll(
                 task,
@@ -73,7 +73,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     fetch('/digits/2.png'),
                     ]);
                     await new Promise((resolve) => setTimeout(resolve, 250));
-                }").ContinueWith(x => t2 = DateTime.Now)
+                }").ContinueWith(x => t2 = DateTime.UtcNow)
             );
 
             Assert.True(t2 > t1);

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         public async Task ShouldPollOnInterval()
         {
             var success = false;
-            var startTime = DateTime.Now;
+            var startTime = DateTime.UtcNow;
             var polling = 100;
             var watchdog = Page.WaitForFunctionAsync("() => window.__FOO === 'hit'", new WaitForFunctionOptions { PollingInterval = polling })
                 .ContinueWith(_ => success = true);
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             Assert.False(success);
             await Page.EvaluateExpressionAsync("document.body.appendChild(document.createElement('div'))");
             await watchdog;
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds > polling / 2);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > polling / 2);
         }
         
         [PuppeteerTest("waittask.spec.ts", "Frame.waitForFunction", "should poll on interval async")]
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         public async Task ShouldPollOnIntervalAsync()
         {
             var success = false;
-            var startTime = DateTime.Now;
+            var startTime = DateTime.UtcNow;
             var polling = 100;
             var watchdog = Page.WaitForFunctionAsync("async () => window.__FOO === 'hit'", new WaitForFunctionOptions { PollingInterval = polling })
                 .ContinueWith(_ => success = true);
@@ -56,7 +56,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             Assert.False(success);
             await Page.EvaluateExpressionAsync("document.body.appendChild(document.createElement('div'))");
             await watchdog;
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds > polling / 2);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > polling / 2);
         }
 
         [PuppeteerTest("waittask.spec.ts", "Frame.waitForFunction", "should poll on mutation")]

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForTimeoutTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForTimeoutTests.cs
@@ -19,10 +19,10 @@ namespace PuppeteerSharp.Tests.WaitForTests
         public async Task WaitsForTheGivenTimeoutBeforeResolving()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var startTime = DateTime.Now;
+            var startTime = DateTime.UtcNow;
             await Page.MainFrame.WaitForTimeoutAsync(1000);
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds > 700);
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds < 1300);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > 700);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds < 1300);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/PageWaitForTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/PageWaitForTests.cs
@@ -56,10 +56,10 @@ namespace PuppeteerSharp.Tests.WaitForTests
         [PuppeteerFact]
         public async Task ShouldTimeout()
         {
-            var startTime = DateTime.Now;
+            var startTime = DateTime.UtcNow;
             var timeout = 42;
             await Page.WaitForTimeoutAsync(timeout);
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds > timeout / 2);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > timeout / 2);
         }
 
         [PuppeteerTest("waittask.spec.ts", "Page.waitFor", "should work with multiline body")]

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/PageWaitForTimeoutTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/PageWaitForTimeoutTests.cs
@@ -19,10 +19,10 @@ namespace PuppeteerSharp.Tests.WaitForTests
         public async Task WaitsForTheGivenTimeoutBeforeResolving()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var startTime = DateTime.Now;
+            var startTime = DateTime.UtcNow;
             await Page.WaitForTimeoutAsync(1000);
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds > 700);
-            Assert.True((DateTime.Now - startTime).TotalMilliseconds < 1300);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > 700);
+            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds < 1300);
         }
     }
 }


### PR DESCRIPTION
This PR consists of two commits related to timing:

1) JavaScript's [`Date.now()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now) is documented as 
> The `Date.now()` static method returns the number of milliseconds elapsed since the [epoch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps), which is defined as the midnight at the beginning of January 1, 1970, UTC.

C#[ `DateTime.Now`](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.now?view=net-8.0) on the other hand is documented as:  
> Gets a [DateTime](https://learn.microsoft.com/en-us/dotnet/api/system.datetime?view=net-8.0) object that is set to the current date and time on this computer, expressed as the local time.

If running a test while changing from/to DST, the difference between two calls to `DateTime.Now` is no longer only an approximation of the time to run some code, but also the difference in UTC offsets.
By changing usages of `DateTime.Now` to `DateTime.UtcNow` we remove that "race-condition" and brings the intention closer to the puppeteer tests.

The second commit includes idea from https://github.com/hardkoded/puppeteer-sharp/pull/2090#issuecomment-1445203137 to avoid silently ignoring exceptions in some tests.
@amaitland I did see your wish for a more elegant solution, but do you agree that including the less pretty solution for now is better than keeping status quo?