### PR TITLE
Browser - Dispose of ScreenshotTaskQueue when async dispose

### DIFF
--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -268,6 +268,7 @@ namespace PuppeteerSharp
         public async ValueTask DisposeAsync()
         {
             await CloseAsync().ConfigureAwait(false);
+            await ScreenshotTaskQueue.DisposeAsync().ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
The `ScreenshotTaskQueue` is currently only disposed when `Dispose()` is called, doesn't appear to be disposed when `DisposeAsync` is called.

