### PR TITLE
Update samples to use PuppeteerSharp v9.0.2

### DIFF
--- a/samples/complex-js-objects/Program.cs
+++ b/samples/complex-js-objects/Program.cs
@@ -31,7 +31,7 @@ namespace Example.ComplexJSObjects
                 await page.GoToAsync("https://news.ycombinator.com/");
                 Console.WriteLine("Get all urls from page");
                 var jsCode = @"() => {
-const selectors = Array.from(document.querySelectorAll('a[class=""storylink""]'));
+const selectors = Array.from(document.querySelectorAll('span[class=""titleline""] > a:first-child'));
 return selectors.map( t=> {return { title: t.innerHTML, url: t.href}});
 }";
                 var results = await page.EvaluateFunctionAsync<Data[]>(jsCode);

--- a/samples/complex-js-objects/Program.cs
+++ b/samples/complex-js-objects/Program.cs
@@ -21,7 +21,7 @@ namespace Example.ComplexJSObjects
 
             Console.WriteLine("Downloading chromium");
 
-            await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+            await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
 
             Console.WriteLine("Navigating to Hacker News");
 

--- a/samples/complex-js-objects/complex-js-objects.csproj
+++ b/samples/complex-js-objects/complex-js-objects.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PuppeteerSharp" Version="1.9.0" />
+    <PackageReference Include="PuppeteerSharp" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/get-all-links/Program.cs
+++ b/samples/get-all-links/Program.cs
@@ -10,7 +10,7 @@ namespace Example.GetAllLinks
         {
             var options = new LaunchOptions { Headless = true };
             Console.WriteLine("Downloading chromium");
-            await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+            await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
             Console.WriteLine("Navigating to google.com");
 
             using (var browser = await Puppeteer.LaunchAsync(options))

--- a/samples/get-all-links/get-all-links.csproj
+++ b/samples/get-all-links/get-all-links.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="puppeteersharp" Version="1.9.0" />
+    <PackageReference Include="puppeteersharp" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/reuse-downloaded-chrome/Program.cs
+++ b/samples/reuse-downloaded-chrome/Program.cs
@@ -26,9 +26,9 @@ namespace Example.ReuseDownloadedChrome
 
             var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
             var browserFetcher = new BrowserFetcher(browserFetcherOptions);
-            await browserFetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
+            await browserFetcher.DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
 
-            var executablePath = browserFetcher.GetExecutablePath(BrowserFetcher.DefaultRevision);
+            var executablePath = browserFetcher.GetExecutablePath(BrowserFetcher.DefaultChromiumRevision);
 
             if (string.IsNullOrEmpty(executablePath))
             {

--- a/samples/reuse-downloaded-chrome/reuse-downloaded-chrome.csproj
+++ b/samples/reuse-downloaded-chrome/reuse-downloaded-chrome.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PuppeteerSharp" Version="1.10.0" />
+    <PackageReference Include="PuppeteerSharp" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/searching/Program.cs
+++ b/samples/searching/Program.cs
@@ -19,7 +19,7 @@ namespace Example.Searching
             {
                 await page.GoToAsync("https://developers.google.com/web/");
                 // Type into search box.
-                await page.TypeAsync("#searchbox input", "Headless Chrome");
+                await page.TypeAsync(".devsite-search-field", "Headless Chrome");
 
                 // Wait for suggest overlay to appear and click "show all results".
                 var allResultsSelector = ".devsite-suggest-all-results";

--- a/samples/searching/Program.cs
+++ b/samples/searching/Program.cs
@@ -11,7 +11,7 @@ namespace Example.Searching
             var options = new LaunchOptions { Headless = true };
             Console.WriteLine("Downloading chromium");
 
-            await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+            await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
             Console.WriteLine("Navigating to developers.google.com");
 
             using (var browser = await Puppeteer.LaunchAsync(options))

--- a/samples/searching/searching.csproj
+++ b/samples/searching/searching.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="puppeteersharp" Version="1.9.0" />
+    <PackageReference Include="puppeteersharp" Version="9.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated PuppeteerSharp to 9.0.2 in the samples.

There is no constant called `BrowserFetcher.DefaultRevision` since version 7.0.0. Changed it to `BrowserFetcher.DefaultChromiumRevision`.

Fixed broken CSS selectors in samples. All samples working correctly now.