### PR TITLE
Remove unused dependency on SharpZipLib

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -48,7 +48,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Included in #1640 but since 407dd6ffa4ac0e3caeaeef1859253b8b13eda34a it's not used anymore.