### PR TITLE
Improve SetBurstModeOffAsync return statement

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1027,7 +1027,7 @@ namespace PuppeteerSharp
             _screenshotBurstModeOn = false;
             if (_screenshotBurstModeOptions != null)
             {
-                ResetBackgroundColorAndViewportAsync(_screenshotBurstModeOptions);
+                return ResetBackgroundColorAndViewportAsync(_screenshotBurstModeOptions);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
https://github.com/hardkoded/puppeteer-sharp/pull/705#discussion_r226365932 suggested to return `ResetBackgroundColorAndViewportAsync` directly to save an `await` when `_screenshotBurstModeOptions` is not set.

f18c3f19e9cc4dc661af64f6b1d4bf962f2fbc36 missed the `return`, so `ResetBackgroundColorAndViewportAsync` may not be complete when `await SetBurstModeOffAsync` completes.