### PR TITLE
Fix ShouldWorkForElementHandleWaitForSelector

### DIFF
--- a/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/WaitForSelectorAriaTests.cs
+++ b/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/WaitForSelectorAriaTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Configuration;
 using System.Diagnostics;
 using System.Linq;
@@ -43,8 +43,8 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
                 @"() => {
                     return (document.body.innerHTML = `<div><button>test</button></div>`);
                 }");
-            var element = Page.QuerySelectorAsync("div");
-            await Page.WaitForSelectorAsync("aria/test");
+            var element = await Page.QuerySelectorAsync("div");
+            await element.WaitForSelectorAsync("aria/test");
         }
 
         [PuppeteerTest("ariaqueryhandler.spec.ts", "waitForSelector (aria)", "should persist query handler bindings across reloads")]


### PR DESCRIPTION
I noticed that `element` was unused, so looked up the corresponding [puppeteer test](https://github.com/puppeteer/puppeteer/blob/823a9df4429480f597d45368e763fdb05d1e9210/test/src/ariaqueryhandler.spec.ts#L235-L243)
where `WaitForSelectorAsync` is called on `element` and not `page`.