### PR TITLE
Use IAsyncLifetime for async initialization/disposal

### DIFF
--- a/lib/PuppeteerSharp.Tests/PuppeteerLoaderFixture.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerLoaderFixture.cs
@@ -1,23 +1,18 @@
 using PuppeteerSharp.TestServer;
 using System;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace PuppeteerSharp.Tests
 {
-    public sealed class PuppeteerLoaderFixture : IDisposable
+    public sealed class PuppeteerLoaderFixture : IAsyncLifetime
     {
         public static SimpleServer Server { get; private set; }
         public static SimpleServer HttpsServer { get; private set; }
 
-        public PuppeteerLoaderFixture()
-        {
-            SetupAsync().GetAwaiter().GetResult();
-        }
+        Task IAsyncLifetime.InitializeAsync() => SetupAsync();
 
-        public void Dispose()
-        {
-            Task.WaitAll(Server.StopAsync(), HttpsServer.StopAsync());
-        }
+        Task IAsyncLifetime.DisposeAsync() => Task.WhenAll(Server.StopAsync(), HttpsServer.StopAsync());
 
         private async Task SetupAsync()
         {


### PR DESCRIPTION
Removes some blocking calls around xunit initialization/disposal
Found on https://jimmybogard.com/integration-testing-with-xunit/#sharedfixturedesign

https://github.com/xunit/xunit/blob/1892224c60f8499b42ee1d8a521d65995ef32aea/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunner.cs#L107-L121

https://github.com/xunit/xunit/blob/1892224c60f8499b42ee1d8a521d65995ef32aea/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunner.cs#L56-L64