### PR TITLE
IFrame.ChildFrames change from IEnumerable to IReadOnlyCollection

### DIFF
--- a/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
+++ b/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
@@ -38,7 +38,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             );
             await frameTask.WithTimeout();
-            Assert.Equal(2, Page.MainFrame.ChildFrames.Count());
+            Assert.Equal(2, Page.MainFrame.ChildFrames.Count);
         }
 
         [PuppeteerTest("oopif.spec.ts", "OOPIF", "should track navigations within OOP iframes")]

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -23,7 +23,7 @@ namespace PuppeteerSharp
         }
 
         /// <inheritdoc/>
-        public IEnumerable<IFrame> ChildFrames => FrameManager.FrameTree.GetChildFrames(Id);
+        public IReadOnlyCollection<IFrame> ChildFrames => FrameManager.FrameTree.GetChildFrames(Id);
 
         /// <inheritdoc/>
         public string Name { get; private set; }

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -372,7 +372,7 @@ namespace PuppeteerSharp
             // Detach all child frames first.
             if (frame != null)
             {
-                while (frame.ChildFrames.Any())
+                while (frame.ChildFrames.Count > 0)
                 {
                     RemoveFramesRecursively(frame.ChildFrames.First() as Frame);
                 }

--- a/lib/PuppeteerSharp/IFrame.cs
+++ b/lib/PuppeteerSharp/IFrame.cs
@@ -41,7 +41,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Gets the child frames of the this frame.
         /// </summary>
-        IEnumerable<IFrame> ChildFrames { get; }
+        IReadOnlyCollection<IFrame> ChildFrames { get; }
 
         /// <summary>
         /// Gets a value indicating if the frame is detached or not.


### PR DESCRIPTION
Follow up to #2187

Change IFrame.ChildFrames from IEnumerable to [IReadOnlyCollection](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ireadonlycollection-1?view=net-8.0)

My opinion it's just a little bit nicer to have a `Count` property rather than calling `Count()`.
