### PR TITLE
Remove unused members

### DIFF
--- a/lib/PuppeteerSharp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/ChromeTargetManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -71,8 +71,6 @@ namespace PuppeteerSharp
         public event EventHandler<TargetChangedArgs> TargetChanged;
 
         public event EventHandler<TargetChangedArgs> TargetDiscovered;
-
-        internal IDictionary<string, Target> TargetsMap { get; }
 
         public ConcurrentDictionary<string, Target> GetAvailableTargets() => _attachedTargetsByTargetId;
 

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -51,8 +51,6 @@ namespace PuppeteerSharp
 
         internal List<string> LifecycleEvents { get; }
 
-        internal string NavigationURL { get; private set; }
-
         internal IsolatedWorld MainWorld { get; private set; }
 
         internal IsolatedWorld PuppeteerWorld { get; private set; }
@@ -343,7 +341,6 @@ namespace PuppeteerSharp
         internal void Navigated(FramePayload framePayload)
         {
             Name = framePayload.Name ?? string.Empty;
-            NavigationURL = framePayload.Url + framePayload.UrlFragment;
             Url = framePayload.Url + framePayload.UrlFragment;
         }
 


### PR DESCRIPTION
This [comment](https://github.com/hardkoded/puppeteer-sharp/pull/2190#discussion_r1174459542) triggered me to try making more members private instead of internal.
When a member is unused and then made private, it'll trigger different kinds of static analyzers it's unused.

See each commit description for more information about the two changes.

There were plenty of more places, where the member visibility could be reduced from internal -> private.
I'll be happy to open a PR with those changes if you like.