### PR TITLE
WaitTask Refactor - Fix Evaluation failed: TypeError: fun is not a function

### DIFF
--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForXPathTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForXPathTests.cs
@@ -100,10 +100,12 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         [PuppeteerFact]
         public async Task ShouldRespectTimeout()
         {
-            var exception = await Assert.ThrowsAsync<WaitTaskTimeoutException>(()
-                    => Page.WaitForXPathAsync("//div", new WaitForSelectorOptions { Timeout = 10 }));
+            const int timeout = 10;
 
-            Assert.Contains("waiting for XPath '//div' failed: timeout", exception.Message);
+            var exception = await Assert.ThrowsAsync<WaitTaskTimeoutException>(()
+                    => Page.WaitForXPathAsync("//div", new WaitForSelectorOptions { Timeout = timeout }));
+
+            Assert.Contains($"Waiting failed: {timeout}ms exceeded", exception.Message);
         }
     }
 }

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -618,8 +618,7 @@ namespace PuppeteerSharp
             options ??= new WaitForSelectorOptions();
             var timeout = options.Timeout ?? _timeoutSettings.Timeout;
 
-            const string predicate = @"
-              function predicate(selectorOrXPath, isXPath, waitForVisible, waitForHidden) {
+            const string predicate = @"function predicate(selectorOrXPath, isXPath, waitForVisible, waitForHidden) {
                 const node = isXPath
                   ? document.evaluate(selectorOrXPath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue
                   : document.querySelector(selectorOrXPath);

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -133,7 +133,7 @@ namespace PuppeteerSharp
                     _poller = await _isolatedWorld.EvaluateFunctionHandleAsync(
                             @"
                             ({MutationPoller, createFunction}, root, fn, ...args) => {
-                                const fun = createFunction(fn.trim());
+                                const fun = createFunction(fn);
                                 return new MutationPoller(() => {
                                     return fun(...args);
                                 }, root || document);

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -133,7 +133,7 @@ namespace PuppeteerSharp
                     _poller = await _isolatedWorld.EvaluateFunctionHandleAsync(
                             @"
                             ({MutationPoller, createFunction}, root, fn, ...args) => {
-                                const fun = createFunction(fn);
+                                const fun = createFunction(fn.trim());
                                 return new MutationPoller(() => {
                                     return fun(...args);
                                 }, root || document);


### PR DESCRIPTION
This should hopefully fix the `Evaluation failed: TypeError: fun is not a function` error. At least it does when I run it locally.

It looks like the whitespace is causing the `new Function` call to eval to null.

Lots of different places the whitespace could be trimmed, Could just as easily be done in `.Net`.

Reformatting the `const string` is also an option, my concern would be that formatting changes could break this again.



