### PR TITLE
JObject.Merge does not work with object

### DIFF
--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -126,11 +126,8 @@ namespace PuppeteerSharp
             if (viewport != null && (boundingBox.Width > viewport.Width || boundingBox.Height > viewport.Height))
             {
                 var newRawViewport = JObject.FromObject(viewport);
-                newRawViewport.Merge(new ViewPortOptions
-                {
-                    Width = (int)Math.Max(viewport.Width, Math.Ceiling(boundingBox.Width)),
-                    Height = (int)Math.Max(viewport.Height, Math.Ceiling(boundingBox.Height)),
-                });
+                newRawViewport["Width"] = (int)Math.Max(viewport.Width, Math.Ceiling(boundingBox.Width));
+                newRawViewport["Height"] = (int)Math.Max(viewport.Height, Math.Ceiling(boundingBox.Height));
                 await Page.SetViewportAsync(newRawViewport.ToObject<ViewPortOptions>(true)).ConfigureAwait(false);
                 needsViewportReset = true;
             }


### PR DESCRIPTION
https://github.com/JamesNK/Newtonsoft.Json/issues/2352

The call to `JObject.Merge` doesn't actually do anything in `Newtonsoft.Json` version `13.0.1`

Newer versions of NewtonSoft.Json will throw "Could not determine JSON object type for type PuppeteerSharp.ViewPortOptions"

Resolves #2199