### PR TITLE
Option to download the browser by yourself

### DIFF
--- a/lib/PuppeteerSharp/IBrowserFetcher.cs
+++ b/lib/PuppeteerSharp/IBrowserFetcher.cs
@@ -62,6 +62,34 @@ namespace PuppeteerSharp
         Task<bool> CanDownloadAsync(string revision);
 
         /// <summary>
+        /// BringYourOwnBrowser
+        /// </summary>
+        /// <param name="filePath">File.</param>
+        /// <returns>Revision.</returns>
+        Task<RevisionInfo> BringYourOwnBrowser(string filePath);
+
+        /// <summary>
+        /// BringYourOwnBrowser
+        /// </summary>
+        /// <param name="revision">Revision.</param>
+        /// <param name="filePath">File.</param>
+        /// <returns>Revision.</returns>
+        Task<RevisionInfo> BringYourOwnBrowser(string revision, string filePath);
+
+        /// <summary>
+        /// Returns the download URL for the revision.
+        /// </summary>
+        /// <param name="revision">Revision.</param>
+        /// <returns>Download URL for the revision.</returns>
+        Task<string> GetDownloadUrl(string revision);
+
+        /// <summary>
+        /// Returns the download URL for the revision.
+        /// </summary>
+        /// <returns>Download URL for the revision.</returns>
+        Task<string> GetDownloadUrl();
+
+        /// <summary>
         /// Downloads the revision.
         /// </summary>
         /// <returns>Task which resolves to the completed download.</returns>


### PR DESCRIPTION
Option for downloading the browser outside puppeteer-sharp. Example:

```csharp
using var browserFetcher = new BrowserFetcher(new BrowserFetcherOptions()
{
	Path = Path.GetTempPath()
});

var downloadUrl = browserFetcher.GetDownloadUrl();

var fileBytes = await new HttpClient().GetByteArrayAsync(downloadUrl);
await File.WriteAllBytesAsync("C:\\downloadbrowser.zip", fileBytes);

await browserFetcher.BringYourOwnBrowser("C:\\downloadbrowser.zip");

var chromiumExecutablePath = browserFetcher
	.RevisionInfo(BrowserFetcher.DefaultChromiumRevision)
	.ExecutablePath;

var launchOptions = new LaunchOptions
{
	Headless = true,
	Args = new[] { "--no-sandbox --font-render-hinting=none" },
	ExecutablePath = chromiumExecutablePath
};
```

To-do:

- [ ] Discussion about naming
- [ ] Unit tests
- [ ] Proper test it
