### PR TITLE
Initialize logging earlier

### DIFF
--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -46,6 +46,7 @@ namespace PuppeteerSharp
             Connection = connection;
             _closeCallback = closeCallback;
             _targetFilterCallback = targetFilter ?? ((TargetInfo _) => true);
+            _logger = Connection.LoggerFactory.CreateLogger<Browser>();
             _isPageTargetFunc =
                 isPageTargetFunc ??
                 new Func<TargetInfo, bool>((TargetInfo target) =>
@@ -75,8 +76,6 @@ namespace PuppeteerSharp
                     CreateTarget,
                     _targetFilterCallback);
             }
-
-            _logger = Connection.LoggerFactory.CreateLogger<Browser>();
         }
 
         /// <inheritdoc/>

--- a/lib/PuppeteerSharp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/ChromeTargetManager.cs
@@ -33,9 +33,9 @@ namespace PuppeteerSharp
             _connection = connection;
             _targetFilterFunc = targetFilterFunc;
             _targetFactoryFunc = targetFactoryFunc;
+            _logger = _connection.LoggerFactory.CreateLogger<ChromeTargetManager>();
             _connection.MessageReceived += OnMessageReceived;
             _connection.SessionDetached += Connection_SessionDetached;
-            _logger = _connection.LoggerFactory.CreateLogger<ChromeTargetManager>();
 
             _ = _connection.SendAsync("Target.setDiscoverTargets", new TargetSetDiscoverTargetsRequest
             {

--- a/lib/PuppeteerSharp/FirefoxTargetManager.cs
+++ b/lib/PuppeteerSharp/FirefoxTargetManager.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0067 // Temporal, do not merge with this
+#pragma warning disable CS0067 // Temporal, do not merge with this
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -31,9 +31,9 @@ namespace PuppeteerSharp
             _connection = connection;
             _targetFilterFunc = targetFilterFunc;
             _targetFactoryFunc = targetFactoryFunc;
+            _logger = _connection.LoggerFactory.CreateLogger<FirefoxTargetManager>();
             _connection.MessageReceived += OnMessageReceived;
             _connection.SessionDetached += Connection_SessionDetached;
-            _logger = _connection.LoggerFactory.CreateLogger<FirefoxTargetManager>();
         }
 
         public event EventHandler<TargetChangedArgs> TargetAvailable;

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -39,7 +39,7 @@ namespace PuppeteerSharp
             Frame frame,
             TimeoutSettings timeoutSettings)
         {
-            Logger = client.Connection.LoggerFactory.CreateLogger<IsolatedWorld>();
+            _logger = client.Connection.LoggerFactory.CreateLogger<IsolatedWorld>();
             _client = client;
             _frameManager = frameManager;
             _customQueriesManager = ((Browser)frameManager.Page.Browser).CustomQueriesManager;
@@ -48,7 +48,6 @@ namespace PuppeteerSharp
 
             _detached = false;
             _client.MessageReceived += Client_MessageReceived;
-            _logger = _client.Connection.LoggerFactory.CreateLogger<IsolatedWorld>();
         }
 
         internal TaskManager TaskManager { get; set; } = new();
@@ -56,8 +55,6 @@ namespace PuppeteerSharp
         internal Frame Frame { get; }
 
         internal bool HasContext => _contextResolveTaskWrapper?.Task.IsCompleted == true;
-
-        internal ILogger Logger { get; }
 
         internal ConcurrentDictionary<string, Delegate> BoundFunctions { get; } = new();
 
@@ -500,7 +497,7 @@ namespace PuppeteerSharp
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex.ToString());
+                _logger.LogError(ex.ToString());
             }
         }
 
@@ -518,7 +515,7 @@ namespace PuppeteerSharp
             catch (Exception ex)
             {
                 var message = $"IsolatedWorld failed to process {e.MessageID}. {ex.Message}. {ex.StackTrace}";
-                Logger.LogError(ex, message);
+                _logger.LogError(ex, message);
                 _client.Close(message);
             }
         }

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -36,8 +36,8 @@ namespace PuppeteerSharp
             FrameManager = frameManager;
             _client = client;
             _ignoreHTTPSErrors = ignoreHTTPSErrors;
-            _client.MessageReceived += Client_MessageReceived;
             _logger = _client.Connection.LoggerFactory.CreateLogger<NetworkManager>();
+            _client.MessageReceived += Client_MessageReceived;
         }
 
         internal event EventHandler<ResponseCreatedEventArgs> Response;


### PR DESCRIPTION
When an event handler is attached as part of the constructor and invoked before `_logger` has been populated we might throw an NRE.

Found by @leonardo-fernandes 