### PR TITLE
Ensure members are initialized before attaching event handlers

### DIFF
--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -37,12 +37,13 @@ namespace PuppeteerSharp
 
             _logger = LoggerFactory.CreateLogger<Connection>();
 
-            Transport.MessageReceived += Transport_MessageReceived;
-            Transport.Closed += Transport_Closed;
             _callbacks = new ConcurrentDictionary<int, MessageTask>();
             _sessions = new ConcurrentDictionary<string, CDPSession>();
             MessageQueue = new AsyncMessageQueue(enqueueAsyncMessages, _logger);
             _asyncSessions = new AsyncDictionaryHelper<string, CDPSession>(_sessions, "Session {0} not found");
+
+            Transport.MessageReceived += Transport_MessageReceived;
+            Transport.Closed += Transport_Closed;
         }
 
         /// <summary>

--- a/lib/PuppeteerSharp/Worker.cs
+++ b/lib/PuppeteerSharp/Worker.cs
@@ -45,9 +45,8 @@ namespace PuppeteerSharp
             Url = url;
             _consoleAPICalled = consoleAPICalled;
             _exceptionThrown = exceptionThrown;
-            _client.MessageReceived += OnMessageReceived;
-
             _executionContextCallback = new TaskCompletionSource<ExecutionContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _client.MessageReceived += OnMessageReceived;
 
             _ = _client.SendAsync("Runtime.enable").ContinueWith(
                 task =>


### PR DESCRIPTION
Inspired by #2218 I found some more places, where we attach event handlers, before initializing instance members used by the event handlers.

Note, I haven't investigated if these scenarios can happen in practice, so this is a better-safe-than-sorry change.

```
Connection.ctor
    attaching Transport_Closed
        Close(string closeReason)
            using _sessions
            using _callbacks
            using MessageQueue

    initialize _callbacks
    initialize _sessions
    initialize MessageQueue
```    

```    
Worker.ctor
    attaching OnMessageReceived
        OnExecutionContextCreated(RuntimeExecutionContextCreatedResponse e)
            using _executionContextCallback
    initialize _executionContextCallback
```