### PR TITLE
More idiomatic usage of ConcurrentDictionary

### DIFF
--- a/lib/PuppeteerSharp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/ChromeTargetManager.cs
@@ -198,13 +198,12 @@ namespace PuppeteerSharp
             _discoveredTargetsByTargetId[e.TargetInfo.TargetId] = e.TargetInfo;
 
             if (_ignoredTargets.Contains(e.TargetInfo.TargetId) ||
-                !_attachedTargetsByTargetId.ContainsKey(e.TargetInfo.TargetId) ||
+                !_attachedTargetsByTargetId.TryGetValue(e.TargetInfo.TargetId, out var target) ||
                 !e.TargetInfo.Attached)
             {
                 return;
             }
 
-            _attachedTargetsByTargetId.TryGetValue(e.TargetInfo.TargetId, out var target);
             TargetChanged?.Invoke(this, new TargetChangedArgs { Target = target, TargetInfo = e.TargetInfo });
         }
 

--- a/lib/PuppeteerSharp/FirefoxTargetManager.cs
+++ b/lib/PuppeteerSharp/FirefoxTargetManager.cs
@@ -114,12 +114,10 @@ namespace PuppeteerSharp
 
         private void OnTargetCreated(TargetCreatedResponse e)
         {
-            if (_discoveredTargetsByTargetId.ContainsKey(e.TargetInfo.TargetId))
+            if (!_discoveredTargetsByTargetId.TryAdd(e.TargetInfo.TargetId, e.TargetInfo))
             {
                 return;
             }
-
-            _discoveredTargetsByTargetId[e.TargetInfo.TargetId] = e.TargetInfo;
 
             if (e.TargetInfo.Type == TargetType.Browser && e.TargetInfo.Attached)
             {

--- a/lib/PuppeteerSharp/NetworkEventManager.cs
+++ b/lib/PuppeteerSharp/NetworkEventManager.cs
@@ -28,18 +28,7 @@ namespace PuppeteerSharp
         }
 
         internal List<ResponseReceivedExtraInfoResponse> ResponseExtraInfo(string networkRequestId)
-        {
-            if (!_responseReceivedExtraInfoMap.ContainsKey(networkRequestId))
-            {
-                _responseReceivedExtraInfoMap.AddOrUpdate(
-                    networkRequestId,
-                    new List<ResponseReceivedExtraInfoResponse>(),
-                    (_, __) => new List<ResponseReceivedExtraInfoResponse>());
-            }
-
-            _responseReceivedExtraInfoMap.TryGetValue(networkRequestId, out var result);
-            return result;
-        }
+            => _responseReceivedExtraInfoMap.GetOrAdd(networkRequestId, static _ => new());
 
         internal void QueueRedirectInfo(string fetchRequestId, RedirectInfo redirectInfo)
             => QueuedRedirectInfo(fetchRequestId).Add(redirectInfo);
@@ -59,12 +48,7 @@ namespace PuppeteerSharp
 
         internal ResponseReceivedExtraInfoResponse ShiftResponseExtraInfo(string networkRequestId)
         {
-            if (!_responseReceivedExtraInfoMap.ContainsKey(networkRequestId))
-            {
-                _responseReceivedExtraInfoMap.TryAdd(networkRequestId, new List<ResponseReceivedExtraInfoResponse>());
-            }
-
-            _responseReceivedExtraInfoMap.TryGetValue(networkRequestId, out var list);
+            var list = _responseReceivedExtraInfoMap.GetOrAdd(networkRequestId, static _ => new());
             var result = list.FirstOrDefault();
 
             if (result != null)
@@ -125,14 +109,6 @@ namespace PuppeteerSharp
             => _queuedEventGroupMap.TryRemove(networkRequestId, out _);
 
         private List<RedirectInfo> QueuedRedirectInfo(string fetchRequestId)
-        {
-            if (!_queuedRedirectInfoMap.ContainsKey(fetchRequestId))
-            {
-                _queuedRedirectInfoMap.TryAdd(fetchRequestId, new List<RedirectInfo>());
-            }
-
-            _queuedRedirectInfoMap.TryGetValue(fetchRequestId, out var result);
-            return result;
-        }
+            => _queuedRedirectInfoMap.GetOrAdd(fetchRequestId, static _ => new());
     }
 }

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1700,12 +1700,10 @@ namespace PuppeteerSharp
 
         private async Task ExposeFunctionAsync(string name, Delegate puppeteerFunction)
         {
-            if (_pageBindings.ContainsKey(name))
+            if (!_pageBindings.TryAdd(name, puppeteerFunction))
             {
                 throw new PuppeteerException($"Failed to add page binding with name {name}: window['{name}'] already exists!");
             }
-
-            _pageBindings.TryAdd(name, puppeteerFunction);
 
             const string addPageBinding = @"function addPageBinding(type, bindingName) {
               const binding = window[bindingName];


### PR DESCRIPTION
Found some places, where we can use built-in ConcurrentDictionary methods to reduce the number of lookups.
It might also improve thread-safety a tad, as currently a value could theoretically be removed/added between calls to `ContainsKey` and `TryGetValue`.

I refrained from updating `ChromeTargetManager.OnTargetCreated` and `ChromeTargetManager.OnAttachedToTarget` as the `valueFactory` might be evaluated more than once, to ensure that `_targetFactoryFunc` is still only evaluated once.

> If you call [GetOrAdd](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-7.0) simultaneously on different threads, valueFactory may be called multiple times, but only one key/value pair will be added to the dictionary.

https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-7.0#system-collections-concurrent-concurrentdictionary-2-getoradd(-0-system-func((-0-1)))