### PR TITLE
Use Headers from extraInfo when available

### DIFF
--- a/lib/PuppeteerSharp/Response.cs
+++ b/lib/PuppeteerSharp/Response.cs
@@ -36,7 +36,7 @@ namespace PuppeteerSharp
             var headers = extraInfo != null ? extraInfo.Headers : responseMessage.Headers;
             if (headers != null)
             {
-                foreach (var keyValue in responseMessage.Headers)
+                foreach (var keyValue in headers)
                 {
                     Headers[keyValue.Key] = keyValue.Value;
                 }


### PR DESCRIPTION
No tests seems to be asserting on this feature.
And only a few tests produces different `extra.Headers` `responseMessage.Headers`.
For e.g. `ShouldProperlyReportHttpOnlyCookie` `extraInfo.Headers` has an extra `Set-Cookie` header that `responseMessage.Headers` does not have.