### PR TITLE
Skip `ShouldDownloadAndExtractFirefoxLinuxBinary` on Windows

### DIFF
--- a/lib/PuppeteerSharp.Tests/Attributes/SkipWindowsFact.cs
+++ b/lib/PuppeteerSharp.Tests/Attributes/SkipWindowsFact.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace PuppeteerSharp.Tests.Attributes
+{
+    internal class SkipWindowsFact : FactAttribute
+    {
+        public SkipWindowsFact()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            Skip = "Test will not run on windows.";
+        }
+    }
+}

--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserFetcherTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserFetcherTests.cs
@@ -74,7 +74,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
         }
 
         [PuppeteerTest("launcher.spec.ts", "BrowserFetcher", "should download and extract firefox linux binary")]
-        [PuppeteerFact]
+        [SkipWindowsFact]
         public async Task ShouldDownloadAndExtractFirefoxLinuxBinary()
         {
             using var browserFetcher = Puppeteer.CreateBrowserFetcher(new BrowserFetcherOptions


### PR DESCRIPTION
The built-in Windows command `tar` delegates handling of .tar.bzip2 archives to another command `bzip2`.
Windows 10 does not come with `bzip2` pre-installed.

Tests can only be decorated with a single attribute deriving from `FactAttribute`, that's the reason I replaced `PuppeteerFact`.

Fixes https://github.com/hardkoded/puppeteer-sharp/discussions/2130