### PR TITLE
Fix PageGotoTests

### DIFF
--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageGotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageGotoTests.cs
@@ -294,6 +294,36 @@ namespace PuppeteerSharp.Tests.NavigationTests
             Assert.Equal(HttpStatusCode.NotFound, response.Status);
         }
 
+        [PuppeteerTest("navigation.spec.ts", "Page.goto", "should not throw an error for a 404 response with an empty body")]
+        [PuppeteerFact]
+        public async Task ShouldNotThrowAnErrorForA404ResponseWithAnEmptyBody()
+        {
+            Server.SetRoute("/404-error", context =>
+            {
+                context.Response.StatusCode = 404;
+                return Task.CompletedTask;
+            });
+
+            var response = await Page.GoToAsync(TestConstants.ServerUrl + "/404-error");
+            Assert.False(response.Ok);
+            Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        }
+
+        [PuppeteerTest("navigation.spec.ts", "Page.goto", "should not throw an error for a 500 response with an empty body")]
+        [PuppeteerFact]
+        public async Task ShouldNotThrowAnErrorForA500ResponseWithAnEmptyBody()
+        {
+            Server.SetRoute("/500-error", context =>
+            {
+                context.Response.StatusCode = 500;
+                return Task.CompletedTask;
+            });
+
+            var response = await Page.GoToAsync(TestConstants.ServerUrl + "/500-error");
+            Assert.False(response.Ok);
+            Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        }
+
         [PuppeteerTest("navigation.spec.ts", "Page.goto", "should return last response in redirect chain")]
         [PuppeteerFact]
         public async Task ShouldReturnLastResponseInRedirectChain()

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -193,7 +193,7 @@ namespace PuppeteerSharp
 
             _ensureNewDocumentNavigation = !string.IsNullOrEmpty(response.LoaderId);
 
-            if (!string.IsNullOrEmpty(response.ErrorText))
+            if (!string.IsNullOrEmpty(response.ErrorText) && response.ErrorText != "net::ERR_HTTP_RESPONSE_CODE_FAILURE")
             {
                 throw new NavigationException(response.ErrorText, url);
             }

--- a/lib/PuppeteerSharp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/LifecycleWatcher.cs
@@ -35,7 +35,6 @@ namespace PuppeteerSharp
         private IRequest _navigationRequest;
         private bool _hasSameDocumentNavigation;
         private bool _swapped;
-        private bool _newDocumentNavigation;
 
         public LifecycleWatcher(
             FrameManager frameManager,
@@ -99,7 +98,6 @@ namespace PuppeteerSharp
                 return;
             }
 
-            _newDocumentNavigation = true;
             CheckLifecycleComplete();
         }
 
@@ -143,7 +141,7 @@ namespace PuppeteerSharp
                 _sameDocumentNavigationTaskWrapper.TrySetResult(true);
             }
 
-            if (_swapped || _newDocumentNavigation)
+            if (_swapped || _frame.LoaderId != _initialLoaderId)
             {
                 _newDocumentNavigationTaskWrapper.TrySetResult(true);
             }


### PR DESCRIPTION
I started investigating why PageGotoTests were failing sometimes with NullReferenceException (e.g. https://github.com/hardkoded/puppeteer-sharp/actions/runs/5257640661/jobs/9500723964).

I found that, when the tests fails, the Response object wasn't initialized yet in the test's thread, but another thread was concurrently processing a message that would initialize it. More investigation indicated that the timing and order of two messages would determine if the test passed/failed.
* The `Page.navigate` message is sent to initiate the navigation. This message awaits for `NewDocumentNavigationTask` from LifecycleWatcher.
* Two messages, `Network.responseReceived` and `Network.responseReceivedExtraInfo`, are received as a result of the navigation. It seems that `Network.responseReceived` is always delivered before the `Page.navigate` resolves. But the order that the two messages are delivered varies with each test execution.
* When `Network.responseReceivedExtraInfo` is delivered before `Network.responseReceived`, the code in `NetworkManager.OnResponseReceived` is able to find the `extraInfo` and proceeds to execute `EmitResponseEvent()` which sets the Response object.
* When `Network.responseReceived` is delivered before `Network.responseReceivedExtraInfo`, the execution of `NetworkManager.OnResponseReceived` does not find the `extraInfo` object and queues the response event. In this state, the `NewDocumentNavigationTask` can resolve and continue the test execution before the Response object is set.


I compared the relevant code with upstream, and found some differences that were committed in https://github.com/puppeteer/puppeteer/pull/8717. My understanding is that the `_newDocumentNavigation` flag was being set too early by a same-document navigation (somehow related to beforeunload events), and thus causing the `NewDocumentNavigationTask` to resolve before it should have. I am still investigating if that is sufficient to make sure the Response object is set.

I also found that ShouldWorkWhenNavigatingTo404 was failing consistently when executed in headful mode, and this had been fixed upstream by https://github.com/puppeteer/puppeteer/pull/9577.