### PR TITLE
Fix URL for Chromium ResolveBuildIdAsync()

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chromium.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chromium.cs
@@ -8,7 +8,7 @@ namespace PuppeteerSharp.BrowserData
     internal class Chromium
     {
         internal static Task<string> ResolveBuildIdAsync(Platform platform)
-            => JsonUtils.GetTextAsync($"https://storage.googleapis.com/chromium-browser-snapshots/${GetFolder(platform)}/LAST_CHANGE");
+            => JsonUtils.GetTextAsync($"https://storage.googleapis.com/chromium-browser-snapshots/{GetFolder(platform)}/LAST_CHANGE");
 
         internal static string ResolveDownloadUrl(Platform platform, string buildId, string baseUrl)
             => $"{baseUrl ?? "https://storage.googleapis.com/chromium-browser-snapshots"}/{string.Join("/", ResolveDownloadPath(platform, buildId))}";

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>11.0.1</PackageVersion>
-    <ReleaseVersion>11.0.1</ReleaseVersion>
-    <AssemblyVersion>11.0.1</AssemblyVersion>
-    <FileVersion>11.0.1</FileVersion>
+    <PackageVersion>11.0.2</PackageVersion>
+    <ReleaseVersion>11.0.2</ReleaseVersion>
+    <AssemblyVersion>11.0.2</AssemblyVersion>
+    <FileVersion>11.0.2</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
There is an issue where the URL has an extra dollar sign (`$`) in the string interpolation, breaking the URL.

This results in a URL like this, giving 404 Not Found
- https://storage.googleapis.com/chromium-browser-snapshots/$Mac_Arm/LAST_CHANGE

Removing the extra dollar sign fixes the issue, giving a correct URL:
- https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/LAST_CHANGE