### PR TITLE
Avoid unhandled exceptions on unawaited async path

### DIFF
--- a/lib/PuppeteerSharp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/ChromeTargetManager.cs
@@ -129,7 +129,7 @@ namespace PuppeteerSharp
             }
         }
 
-        private async Task EnsureTargetsIdsForInit()
+        private async Task EnsureTargetsIdsForInitAsync()
         {
             if (_targetDiscoveryTimeout > 0)
             {
@@ -203,7 +203,7 @@ namespace PuppeteerSharp
             try
             {
                 _discoveredTargetsByTargetId.TryRemove(e.TargetId, out var targetInfo);
-                await EnsureTargetsIdsForInit().ConfigureAwait(false);
+                await EnsureTargetsIdsForInitAsync().ConfigureAwait(false);
                 FinishInitializationIfReady(e.TargetId);
 
                 if (targetInfo?.Type == TargetType.ServiceWorker && _availableTargetsByTargetIdDictionary.TryRemove(e.TargetId, out var target))
@@ -231,7 +231,7 @@ namespace PuppeteerSharp
             TargetChanged?.Invoke(this, new TargetChangedArgs { Target = target, TargetInfo = e.TargetInfo });
         }
 
-        private async Task OnAttachedToTarget(object sender, TargetAttachedToTargetResponse e)
+        private async Task OnAttachedToTargetAsync(object sender, TargetAttachedToTargetResponse e)
         {
             var parent = sender as ICDPConnection;
             var targetInfo = e.TargetInfo;
@@ -263,7 +263,7 @@ namespace PuppeteerSharp
             if (targetInfo.Type == TargetType.ServiceWorker &&
                 _connection.IsAutoAttached(targetInfo.TargetId))
             {
-                await EnsureTargetsIdsForInit().ConfigureAwait(false);
+                await EnsureTargetsIdsForInitAsync().ConfigureAwait(false);
                 FinishInitializationIfReady(targetInfo.TargetId);
                 await SilentDetach().ConfigureAwait(false);
                 if (_availableTargetsByTargetIdDictionary.ContainsKey(targetInfo.TargetId))
@@ -280,7 +280,7 @@ namespace PuppeteerSharp
             if (_targetFilterFunc?.Invoke(targetInfo) == false)
             {
                 _ignoredTargets.Add(targetInfo.TargetId);
-                await EnsureTargetsIdsForInit().ConfigureAwait(false);
+                await EnsureTargetsIdsForInitAsync().ConfigureAwait(false);
                 FinishInitializationIfReady(targetInfo.TargetId);
                 await SilentDetach().ConfigureAwait(false);
                 return;
@@ -318,7 +318,7 @@ namespace PuppeteerSharp
                 }
             }
 
-            await EnsureTargetsIdsForInit().ConfigureAwait(false);
+            await EnsureTargetsIdsForInitAsync().ConfigureAwait(false);
             _targetsIdsForInit.Remove(target.TargetId);
 
             if (!existingTarget)
@@ -349,7 +349,7 @@ namespace PuppeteerSharp
         {
             try
             {
-                await OnAttachedToTarget(sender, e).ConfigureAwait(false);
+                await OnAttachedToTargetAsync(sender, e).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -448,7 +448,7 @@ namespace PuppeteerSharp
                 switch (e.MessageID)
                 {
                     case "Runtime.bindingCalled":
-                        await OnBindingCalled(e.MessageData.ToObject<BindingCalledResponse>(true)).ConfigureAwait(false);
+                        await OnBindingCalledAsync(e.MessageData.ToObject<BindingCalledResponse>(true)).ConfigureAwait(false);
                         break;
                 }
             }
@@ -460,7 +460,7 @@ namespace PuppeteerSharp
             }
         }
 
-        private async Task OnBindingCalled(BindingCalledResponse e)
+        private async Task OnBindingCalledAsync(BindingCalledResponse e)
         {
             var payload = e.BindingPayload;
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -329,9 +329,9 @@ namespace PuppeteerSharp
             => MainFrame.QuerySelectorAllHandleAsync(selector);
 
         /// <inheritdoc/>
-        #pragma warning disable CS0618 // Using obsolets
+#pragma warning disable CS0618 // Using obsolets
         public Task<IElementHandle[]> XPathAsync(string expression) => MainFrame.XPathAsync(expression);
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
 
         /// <inheritdoc/>
         public async Task<IJSHandle> EvaluateExpressionHandleAsync(string script)
@@ -784,10 +784,10 @@ namespace PuppeteerSharp
             => MainFrame.WaitForSelectorAsync(selector, options ?? new WaitForSelectorOptions());
 
         /// <inheritdoc/>
-        #pragma warning disable CS0618 // WaitForXPathAsync is obsolete
+#pragma warning disable CS0618 // WaitForXPathAsync is obsolete
         public Task<IElementHandle> WaitForXPathAsync(string xpath, WaitForSelectorOptions options = null)
             => MainFrame.WaitForXPathAsync(xpath, options ?? new WaitForSelectorOptions());
-        #pragma warning restore CS0618
+#pragma warning restore CS0618
 
         /// <inheritdoc/>
         public Task<IResponse> WaitForNavigationAsync(NavigationOptions options = null)
@@ -1470,7 +1470,7 @@ namespace PuppeteerSharp
                         await OnLogEntryAddedAsync(e.MessageData.ToObject<LogEntryAddedResponse>(true)).ConfigureAwait(false);
                         break;
                     case "Runtime.bindingCalled":
-                        await OnBindingCalled(e.MessageData.ToObject<BindingCalledResponse>(true)).ConfigureAwait(false);
+                        await OnBindingCalledAsync(e.MessageData.ToObject<BindingCalledResponse>(true)).ConfigureAwait(false);
                         break;
                     case "Page.fileChooserOpened":
                         await OnFileChooserAsync(e.MessageData.ToObject<PageFileChooserOpenedResponse>(true)).ConfigureAwait(false);
@@ -1519,7 +1519,7 @@ namespace PuppeteerSharp
             }
         }
 
-        private async Task OnBindingCalled(BindingCalledResponse e)
+        private async Task OnBindingCalledAsync(BindingCalledResponse e)
         {
             if (e.BindingPayload.Type != "exposedFun" || !_bindings.ContainsKey(e.BindingPayload.Name))
             {

--- a/lib/PuppeteerSharp/Worker.cs
+++ b/lib/PuppeteerSharp/Worker.cs
@@ -138,7 +138,7 @@ namespace PuppeteerSharp
                         OnExecutionContextCreated(e.MessageData.ToObject<RuntimeExecutionContextCreatedResponse>(true));
                         break;
                     case "Runtime.consoleAPICalled":
-                        await OnConsoleAPICalled(e).ConfigureAwait(false);
+                        await OnConsoleAPICalledAsync(e).ConfigureAwait(false);
                         break;
                     case "Runtime.exceptionThrown":
                         OnExceptionThrown(e.MessageData.ToObject<RuntimeExceptionThrownResponse>(true));
@@ -155,7 +155,7 @@ namespace PuppeteerSharp
 
         private void OnExceptionThrown(RuntimeExceptionThrownResponse e) => _exceptionThrown(e.ExceptionDetails);
 
-        private async Task OnConsoleAPICalled(MessageEventArgs e)
+        private async Task OnConsoleAPICalledAsync(MessageEventArgs e)
         {
             var consoleData = e.MessageData.ToObject<PageConsoleResponse>(true);
             await _consoleAPICalled(


### PR DESCRIPTION
Follow-up to #2214 where `OnTargetDestroyed` was changed from `void` to `async void`.