### PR TITLE
Fix memory leaks with `AsyncDictionaryHelper`

### DIFF
--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -148,7 +148,7 @@ namespace PuppeteerSharp
 
         /// <inheritdoc/>
         public ITarget[] Targets()
-            => TargetManager.GetAvailableTargets().InnerDictionary.Values.ToArray();
+            => TargetManager.GetAvailableTargets().Values.ToArray();
 
         /// <inheritdoc/>
         public async Task<IBrowserContext> CreateIncognitoBrowserContextAsync()

--- a/lib/PuppeteerSharp/FrameTree.cs
+++ b/lib/PuppeteerSharp/FrameTree.cs
@@ -10,24 +10,18 @@ namespace PuppeteerSharp
 {
     internal class FrameTree
     {
-        private readonly ConcurrentDictionary<string, Frame> _frames = new();
+        private readonly AsyncDictionaryHelper<string, Frame> _frames = new("Frame {0} not found");
         private readonly ConcurrentDictionary<string, string> _parentIds = new();
         private readonly ConcurrentDictionary<string, List<string>> _childIds = new();
         private readonly ConcurrentDictionary<string, List<TaskCompletionSource<Frame>>> _waitRequests = new();
-        private readonly AsyncDictionaryHelper<string, Frame> _asyncFrames;
-
-        public FrameTree()
-        {
-            _asyncFrames = new AsyncDictionaryHelper<string, Frame>(_frames, "Frame {0} not found");
-        }
 
         public Frame MainFrame { get; set; }
 
         public Frame[] Frames => _frames.Values.ToArray();
 
-        internal Task<Frame> GetFrameAsync(string frameId) => _asyncFrames.GetItemAsync(frameId);
+        internal Task<Frame> GetFrameAsync(string frameId) => _frames.GetItemAsync(frameId);
 
-        internal Task<Frame> TryGetFrameAsync(string frameId) => _asyncFrames.TryGetItemAsync(frameId);
+        internal Task<Frame> TryGetFrameAsync(string frameId) => _frames.TryGetItemAsync(frameId);
 
         internal Frame GetById(string id)
         {
@@ -52,7 +46,7 @@ namespace PuppeteerSharp
 
         internal void AddFrame(Frame frame)
         {
-            _asyncFrames.AddItem(frame.Id, frame);
+            _frames.AddItem(frame.Id, frame);
             if (frame.ParentId != null)
             {
                 _parentIds.TryAdd(frame.Id, frame.ParentId);
@@ -78,7 +72,7 @@ namespace PuppeteerSharp
 
         internal void RemoveFrame(Frame frame)
         {
-            _frames.TryRemove(frame.Id, out var _);
+            _frames.TryRemove(frame.Id, out _);
             _parentIds.TryRemove(frame.Id, out var _);
 
             if (frame.ParentId != null)

--- a/lib/PuppeteerSharp/Helpers/MultiMap.cs
+++ b/lib/PuppeteerSharp/Helpers/MultiMap.cs
@@ -20,7 +20,13 @@ namespace PuppeteerSharp.Helpers
         internal bool Delete(TKey key, TValue value)
             => _map.TryGetValue(key, out var set) && set.Remove(value);
 
+        internal bool TryRemove(TKey key, out ICollection<TValue> value)
+            => _map.TryRemove(key, out value);
+
         internal TValue FirstValue(TKey key)
             => _map.TryGetValue(key, out var set) ? set.FirstOrDefault() : default;
+
+        internal void Clear()
+            => _map.Clear();
     }
 }

--- a/lib/PuppeteerSharp/Target.cs
+++ b/lib/PuppeteerSharp/Target.cs
@@ -88,7 +88,7 @@ namespace PuppeteerSharp
 
         /// <inheritdoc/>
         public ITarget Opener => TargetInfo.OpenerId != null ?
-            ((Browser)Browser).TargetManager.GetAvailableTargets().InnerDictionary.GetValueOrDefault(TargetInfo.OpenerId) : null;
+            ((Browser)Browser).TargetManager.GetAvailableTargets().GetValueOrDefault(TargetInfo.OpenerId) : null;
 
         /// <inheritdoc/>
         public IBrowser Browser => BrowserContext.Browser;


### PR DESCRIPTION
To ensure that entries from `_pendingRequests` are removed when removing a key from `_dictionary`.

See [discussion](https://github.com/hardkoded/puppeteer-sharp/discussions/2283) for more details.