### PR TITLE
Detach client event handler when detaching `IsolatedWorld`

### DIFF
--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -141,6 +141,7 @@ namespace PuppeteerSharp
         internal void Detach()
         {
             _detached = true;
+            _client.MessageReceived -= Client_MessageReceived;
             TaskManager.TerminateAll(new Exception("waitForFunction failed: frame got detached."));
         }
 


### PR DESCRIPTION
When working on #2297 I noticed that something related to `IsolatedWorld` also leaked memory.

master:
![image](https://github.com/hardkoded/puppeteer-sharp/assets/919634/284d46c8-481d-4b29-82e3-9e7daa49b1f2)

PR:
![image](https://github.com/hardkoded/puppeteer-sharp/assets/919634/669619a8-95a7-4f1e-aef6-d397ff09f0a7)

The many remaining `TaskCompletionSource<>` are handled in #2297

With both PRs:
![image](https://github.com/hardkoded/puppeteer-sharp/assets/919634/56e4a017-b243-42bd-8eeb-15dd0bd96a7f)

Tested with this code

```cs
[PuppeteerTest("frame.spec.ts", "Frame Management", "should handle nested frames")]
[Skip(SkipAttribute.Targets.Firefox)]
public async Task ShouldHandleNestedFrames()
{
    GC.Collect(4, GCCollectionMode.Forced, true, true);
    GC.WaitForPendingFinalizers();
    // <-- heap dump
    for (var i = 0; i < 100; i++)
    {
        _ = await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
    }

    GC.Collect(4, GCCollectionMode.Forced, true, true);
    GC.WaitForPendingFinalizers();
    // <-- heap dump and showed diff
}
```