### PR TITLE
Dropping .NET Framework test builds

### DIFF
--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '6.0.x' # The .NET SDK version to use
+  DOTNET_VERSION: '7.0.x' # The .NET SDK version to use
 
 jobs:
   PushToIntNugetOrg:
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Install dependencies
       run: |
         dotnet restore lib/PuppeteerSharp.sln

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -7,7 +7,7 @@ on:
         - v*
 
 env:
-  DOTNET_VERSION: '6.0.x' # The .NET SDK version to use
+  DOTNET_VERSION: '7.0.x' # The .NET SDK version to use
 
 jobs:
    PushToNugetOrg:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Run Project
       working-directory: ./demos/PuppeteerSharpPdfDemo
       run: |
-          dotnet run -p PuppeteerSharpPdfDemo-Local.csproj -f net6.0 auto-exit
+          dotnet run -p PuppeteerSharpPdfDemo-Local.csproj -f net7.0 auto-exit

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Run Project
       working-directory: ./demos/PuppeteerSharpPdfDemo
       run: |
-          dotnet run -p PuppeteerSharpPdfDemo-Local.csproj -f net7.0 auto-exit
+          dotnet run -p PuppeteerSharpPdfDemo-Local.csproj auto-exit

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Run Project
       working-directory: ./demos/PuppeteerSharpPdfDemo
       run: |
-          dotnet run -p PuppeteerSharpPdfDemo-Local.csproj auto-exit
+          dotnet run --project PuppeteerSharpPdfDemo-Local.csproj auto-exit

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [windows-2022, macos-latest]
     env:
-      DOTNET_VERSION: '6.0.x' # The .NET SDK version to use
+      DOTNET_VERSION: '7.0.x' # The .NET SDK version to use
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,12 +63,12 @@ jobs:
           Xvfb :1 -screen 5 1024x768x8 &
           export DISPLAY=:1.5
           cd lib/PuppeteerSharp.Tests
-          dotnet test -f net7.0 -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
+          dotnet test -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
     - name: Test (Windows)
       if: matrix.os == 'windows-latest'
       env:
         PRODUCT: ${{ matrix.browser }}
       run: |
         cd .\lib\PuppeteerSharp.Tests
-        dotnet test -f net7.0 -s test.runsettings
+        dotnet test -s test.runsettings
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ on:
     - '**.runsettings'
 
 env:
-  DOTNET_VERSION: '6.0.x' # The .NET SDK version to use
+  DOTNET_VERSION: '7.0.x' # The .NET SDK version to use
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
+        dotnet dev-certs https --clean
         dotnet dev-certs https -ep lib/PuppeteerSharp.TestServer/testCert.cer
         sudo openssl x509 -inform der -in lib/PuppeteerSharp.TestServer/testCert.cer -out /usr/local/share/ca-certificates/testCert.crt -outform pem
         sudo update-ca-certificates

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,11 +63,12 @@ jobs:
           Xvfb :1 -screen 5 1024x768x8 &
           export DISPLAY=:1.5
           cd lib/PuppeteerSharp.Tests
-          dotnet test -f net6.0 -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
+          dotnet test -f net7.0 -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml"
     - name: Test (Windows)
       if: matrix.os == 'windows-latest'
       env:
         PRODUCT: ${{ matrix.browser }}
       run: |
         cd .\lib\PuppeteerSharp.Tests
-        dotnet test -f net6.0 -s test.runsettings
+        dotnet test -f net7.0 -s test.runsettings
+

--- a/demos/PuppeteerSharpPdfDemo/Program.cs
+++ b/demos/PuppeteerSharpPdfDemo/Program.cs
@@ -17,12 +17,8 @@ namespace PuppeteerSharpPdfDemo
 
             Console.WriteLine("Downloading chromium");
 
-            using var browserFetcher = new BrowserFetcher(new BrowserFetcherOptions
-            {
-                Path = Path.GetTempPath(),
-                Browser = SupportedBrowser.Chromium
-            });
-            await browserFetcher.DownloadAsync(BrowserTag.Latest).ConfigureAwait(false);
+            using var browserFetcher = new BrowserFetcher();
+            await browserFetcher.DownloadAsync();
 
             Console.WriteLine("Navigating google");
             using (var browser = await Puppeteer.LaunchAsync(options))

--- a/demos/PuppeteerSharpPdfDemo/Program.cs
+++ b/demos/PuppeteerSharpPdfDemo/Program.cs
@@ -16,8 +16,13 @@ namespace PuppeteerSharpPdfDemo
             };
 
             Console.WriteLine("Downloading chromium");
-            using var browserFetcher = new BrowserFetcher();
-            await browserFetcher.DownloadAsync();
+
+            using var browserFetcher = new BrowserFetcher(new BrowserFetcherOptions
+            {
+                Path = Path.GetTempPath(),
+                Browser = SupportedBrowser.Chromium
+            });
+            await browserFetcher.DownloadAsync(BrowserTag.Latest).ConfigureAwait(false);
 
             Console.WriteLine("Navigating google");
             using (var browser = await Puppeteer.LaunchAsync(options))

--- a/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo-Local.csproj
+++ b/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo-Local.csproj
@@ -2,11 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net471'">
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\lib\PuppeteerSharp\PuppeteerSharp.csproj" />

--- a/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo-Local.csproj
+++ b/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo-Local.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net471</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net471'">

--- a/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo.csproj
+++ b/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="PuppeteerSharp" Version="3.0.0" />

--- a/lib/PuppeteerSharp.DevicesFetcher/PuppeteerSharp.DevicesFetcher.csproj
+++ b/lib/PuppeteerSharp.DevicesFetcher/PuppeteerSharp.DevicesFetcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/lib/PuppeteerSharp.Nunit/PuppeteerSharp.Nunit.csproj
+++ b/lib/PuppeteerSharp.Nunit/PuppeteerSharp.Nunit.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="NUnit" Version="3.13.3" />

--- a/lib/PuppeteerSharp.Nunit/PuppeteerSharp.Nunit.csproj
+++ b/lib/PuppeteerSharp.Nunit/PuppeteerSharp.Nunit.csproj
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="NUnit" Version="3.13.3" />

--- a/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
+++ b/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
+++ b/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -11,8 +11,7 @@
   </ItemGroup>
   <Import Project="../Common/SignAssembly.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <Target Name="testCertCheck" BeforeTargets="BeforeBuild" Condition="!Exists('testCert.cer')">
     <Error Text="Follow https://github.com/hardkoded/puppeteer-sharp/blob/master/CONTRIBUTING.md#getting-setup to setup a development certificate." />

--- a/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
+++ b/lib/PuppeteerSharp.TestServer/PuppeteerSharp.TestServer.csproj
@@ -10,9 +10,6 @@
     </Content>
   </ItemGroup>
   <Import Project="../Common/SignAssembly.props" />
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
   <Target Name="testCertCheck" BeforeTargets="BeforeBuild" Condition="!Exists('testCert.cer')">
     <Error Text="Follow https://github.com/hardkoded/puppeteer-sharp/blob/master/CONTRIBUTING.md#getting-setup to setup a development certificate." />
   </Target>

--- a/lib/PuppeteerSharp.TestServer/SimpleServer.cs
+++ b/lib/PuppeteerSharp.TestServer/SimpleServer.cs
@@ -75,6 +75,7 @@ namespace PuppeteerSharp.TestServer
                     }))
                 .UseKestrel(options =>
                 {
+                    options.ConfigureEndpointDefaults(lo => lo.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
                     if (isHttps)
                     {
                         options.Listen(IPAddress.Loopback, port, listenOptions => listenOptions.UseHttps("testCert.cer"));

--- a/lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
+++ b/lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PuppeteerSharp\PuppeteerSharp.csproj" />

--- a/lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
+++ b/lib/PuppeteerSharp.Tests.DumpIO/PuppeteerSharp.Tests.DumpIO.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PuppeteerSharp\PuppeteerSharp.csproj" />

--- a/lib/PuppeteerSharp.Tests.SingleFileDeployment/PuppeteerSharp.Tests.SingleFileDeployment.csproj
+++ b/lib/PuppeteerSharp.Tests.SingleFileDeployment/PuppeteerSharp.Tests.SingleFileDeployment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -363,7 +363,12 @@ namespace PuppeteerSharp.Tests.CookiesTests
             Assert.AreEqual("/", cookie.Path);
             Assert.AreEqual(cookie.Expires, -1);
             Assert.AreEqual(14, cookie.Size);
-            Assert.AreEqual(SameSite.None, cookie.SameSite);
+
+            // Puppeteer uses expectCookieEquals which excludes SameSite attribute
+            if(TestConstants.IsChrome)
+            {
+                Assert.AreEqual(SameSite.None, cookie.SameSite);
+            }
             Assert.False(cookie.HttpOnly);
             Assert.True(cookie.Secure);
             Assert.True(cookie.Session);

--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -328,7 +328,6 @@ namespace PuppeteerSharp.Tests.CookiesTests
         }
 
         [PuppeteerTest("cookies.spec.ts", "Page.setCookie", "should set secure same-site cookies from a frame")]
-        [Skip(SkipAttribute.Targets.Firefox)]
         public async Task ShouldSetSecureSameSiteCookiesFromAFrame()
         {
             var options = TestConstants.DefaultBrowserOptions();
@@ -336,7 +335,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
 
             await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
             await using var page = await browser.NewPageAsync();
-            await page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/grid.html");
             await page.EvaluateFunctionAsync(@"src => {
                     let fulfill;
                     const promise = new Promise(x => fulfill = x);

--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -344,7 +344,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
                     iframe.onload = fulfill;
                     iframe.src = src;
                     return promise;
-                }", TestConstants.CrossProcessHttpsPrefix);
+                }", TestConstants.CrossProcessHttpsPrefix + "/grid.html");
             await page.SetCookieAsync(
                 new CookieParam
                 {

--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -349,36 +349,23 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 new CookieParam
                 {
                     Name = "127-cookie",
-                    Value = "worst",
-                    Url = TestConstants.CrossProcessHttpsPrefix,
+                    Value = "best",
+                    Url = TestConstants.CrossProcessHttpsPrefix + "/grid.html",
                     SameSite = SameSite.None,
                 });
-            Assert.AreEqual("localhost-cookie=best", await page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"));
-            var cookies = await page.GetCookiesAsync();
+            Assert.AreEqual("127-cookie=best", await page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"));
+            var cookies = await page.GetCookiesAsync(TestConstants.CrossProcessHttpsPrefix + "/grid.html");
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("localhost-cookie", cookie.Name);
-            Assert.AreEqual("best", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(20, cookie.Size);
-            Assert.AreEqual(SameSite.None, cookie.SameSite);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
-
-            cookies = await page.GetCookiesAsync(TestConstants.CrossProcessHttpPrefix);
-            Assert.That(cookies, Has.Exactly(1).Items);
-            cookie = cookies.First();
             Assert.AreEqual("127-cookie", cookie.Name);
-            Assert.AreEqual("worst", cookie.Value);
+            Assert.AreEqual("best", cookie.Value);
             Assert.AreEqual("127.0.0.1", cookie.Domain);
             Assert.AreEqual("/", cookie.Path);
             Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(15, cookie.Size);
+            Assert.AreEqual(14, cookie.Size);
+            Assert.AreEqual(SameSite.None, cookie.SameSite);
             Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
+            Assert.True(cookie.Secure);
             Assert.True(cookie.Session);
         }
     }

--- a/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
@@ -131,7 +131,7 @@ namespace PuppeteerSharp.Tests.FixturesTests
                 dir,
                 "bin",
                 build,
-                "net6.0");
+                "net7.0");
 #else
             return Path.Combine(
                 TestUtils.FindParentDirectory("lib"),

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 	<ItemGroup>

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' ">net48;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' ">net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 	<ItemGroup>

--- a/lib/PuppeteerSharp.Tests/TestConstants.cs
+++ b/lib/PuppeteerSharp.Tests/TestConstants.cs
@@ -19,6 +19,7 @@ namespace PuppeteerSharp.Tests
         public const string HttpsPrefix = "https://localhost:8082";
         public const string AboutBlank = "about:blank";
         public static readonly string CrossProcessHttpPrefix = "http://127.0.0.1:8081";
+        public static readonly string CrossProcessHttpsPrefix = "https://127.0.0.1:8081";
         public static readonly string EmptyPage = $"{ServerUrl}/empty.html";
         public static readonly string CrossProcessUrl = ServerIpUrl;
         public static readonly string ExtensionPath = Path.Combine(AppContext.BaseDirectory, "Assets", "simple-extension");

--- a/lib/PuppeteerSharp.Tests/TestConstants.cs
+++ b/lib/PuppeteerSharp.Tests/TestConstants.cs
@@ -16,10 +16,10 @@ namespace PuppeteerSharp.Tests
         public const int HttpsPort = Port + 1;
         public const string ServerUrl = "http://localhost:8081";
         public const string ServerIpUrl = "http://127.0.0.1:8081";
-        public const string HttpsPrefix = "https://localhost:8081";
+        public const string HttpsPrefix = "https://localhost:8082";
         public const string AboutBlank = "about:blank";
         public static readonly string CrossProcessHttpPrefix = "http://127.0.0.1:8081";
-        public static readonly string CrossProcessHttpsPrefix = "https://127.0.0.1:8081";
+        public static readonly string CrossProcessHttpsPrefix = "https://127.0.0.1:8082";
         public static readonly string EmptyPage = $"{ServerUrl}/empty.html";
         public static readonly string CrossProcessUrl = ServerIpUrl;
         public static readonly string ExtensionPath = Path.Combine(AppContext.BaseDirectory, "Assets", "simple-extension");

--- a/lib/PuppeteerSharp.Tests/TestConstants.cs
+++ b/lib/PuppeteerSharp.Tests/TestConstants.cs
@@ -16,7 +16,7 @@ namespace PuppeteerSharp.Tests
         public const int HttpsPort = Port + 1;
         public const string ServerUrl = "http://localhost:8081";
         public const string ServerIpUrl = "http://127.0.0.1:8081";
-        public const string HttpsPrefix = "https://localhost:8082";
+        public const string HttpsPrefix = "https://localhost:8081";
         public const string AboutBlank = "about:blank";
         public static readonly string CrossProcessHttpPrefix = "http://127.0.0.1:8081";
         public static readonly string CrossProcessHttpsPrefix = "https://127.0.0.1:8081";

--- a/lib/PuppeteerSharp.Tooling/PuppeteerSharp.Tooling.csproj
+++ b/lib/PuppeteerSharp.Tooling/PuppeteerSharp.Tooling.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<IsTool>true</IsTool>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>

--- a/samples/complex-js-objects/complex-js-objects.csproj
+++ b/samples/complex-js-objects/complex-js-objects.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>complex_js_objects</RootNamespace>
   </PropertyGroup>
 

--- a/samples/get-all-links/get-all-links.csproj
+++ b/samples/get-all-links/get-all-links.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>
 

--- a/samples/reuse-downloaded-chrome/reuse-downloaded-chrome.csproj
+++ b/samples/reuse-downloaded-chrome/reuse-downloaded-chrome.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Exaxmple</RootNamespace>
   </PropertyGroup>
 

--- a/samples/searching/searching.csproj
+++ b/samples/searching/searching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It moves all the builds to net7 and removes builds for .NET Framework. As Puppeteer-Sharp is a netstandard library, it will still work in .NET Framework, but we won't run on that framework anymore.

It also closes #2175