### PR TITLE
BREAKING: Use target for filters

### DIFF
--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -99,7 +99,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
                 var browser = await Puppeteer.ConnectAsync(new ConnectOptions {
                     BrowserWSEndpoint = originalBrowser.WebSocketEndpoint,
-                    TargetFilter = (TargetInfo targetInfo) => !targetInfo.Url.Contains("should-be-ignored"),
+                    TargetFilter = (Target target) => !target.Url.Contains("should-be-ignored"),
                 }, TestConstants.LoggerFactory);
 
                 var pages = await browser.PagesAsync();

--- a/lib/PuppeteerSharp/BrowserContext.cs
+++ b/lib/PuppeteerSharp/BrowserContext.cs
@@ -52,7 +52,7 @@ namespace PuppeteerSharp
             Targets()
                 .Where(t =>
                     t.Type == TargetType.Page ||
-                    (t.Type == TargetType.Other && Browser.IsPageTargetFunc((t as Target).TargetInfo)))
+                    (t.Type == TargetType.Other && Browser.IsPageTargetFunc(t as Target)))
                 .Select(t => t.PageAsync())).ConfigureAwait(false))
             .Where(p => p != null).ToArray();
 

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -89,7 +89,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.
         /// </summary>
-        public Func<TargetInfo, bool> TargetFilter { get; set; }
+        public Func<Target, bool> TargetFilter { get; set; }
 
         /// <summary>
         /// Optional callback to initialize properties as soon as the <see cref="IBrowser"/> instance is created, i.e., set up event handlers.

--- a/lib/PuppeteerSharp/IConnectionOptions.cs
+++ b/lib/PuppeteerSharp/IConnectionOptions.cs
@@ -50,6 +50,6 @@ namespace PuppeteerSharp
         /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.
         /// </summary>
-        public Func<TargetInfo, bool> TargetFilter { get; set; }
+        public Func<Target, bool> TargetFilter { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -186,6 +186,6 @@ namespace PuppeteerSharp
         /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.
         /// </summary>
-        public Func<TargetInfo, bool> TargetFilter { get; set; }
+        public Func<Target, bool> TargetFilter { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>11.0.6</PackageVersion>
-    <ReleaseVersion>11.0.6</ReleaseVersion>
-    <AssemblyVersion>11.0.6</AssemblyVersion>
-    <FileVersion>11.0.6</FileVersion>
+    <PackageVersion>12.0.0</PackageVersion>
+    <ReleaseVersion>12.0.0</ReleaseVersion>
+    <AssemblyVersion>12.0.0</AssemblyVersion>
+    <FileVersion>12.0.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
This will bring [these changes](https://github.com/puppeteer/puppeteer/pull/10601).

It's a breaking change because we are exposing the TargetFilter, and we changed its type.