### PR TITLE
Implement BrowserContext.IsClosed

### DIFF
--- a/lib/PuppeteerSharp/BrowserContext.cs
+++ b/lib/PuppeteerSharp/BrowserContext.cs
@@ -33,6 +33,9 @@ namespace PuppeteerSharp
         /// <inheritdoc/>
         public bool IsIncognito => Id != null;
 
+        /// <inheritdoc/>
+        public bool IsClosed => Browser.BrowserContexts().Contains(this);
+
         /// <inheritdoc cref="Browser"/>
         public Browser Browser { get; }
 

--- a/lib/PuppeteerSharp/IBrowserContext.cs
+++ b/lib/PuppeteerSharp/IBrowserContext.cs
@@ -36,6 +36,11 @@ namespace PuppeteerSharp
         IBrowser Browser { get; }
 
         /// <summary>
+        /// Whether this <see href="IBrowserContext"/> is closed.
+        /// </summary>
+        bool IsClosed { get; }
+
+        /// <summary>
         /// Returns whether BrowserContext is incognito
         /// The default browser context is the only non-incognito browser context.
         /// </summary>


### PR DESCRIPTION
Puppeteer implemented that [here](https://github.com/puppeteer/puppeteer/pull/10928) with the name `Closed`, but I think `IsClosed` matches other properties.