### PR TITLE
[BREAKING] Update file chooser events

### DIFF
--- a/lib/PuppeteerSharp.Tests/CoverageTests/JSCoverageTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/JSCoverageTests.cs
@@ -117,6 +117,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
         {
             await Page.Coverage.StartJSCoverageAsync();
             await Page.GoToAsync(TestConstants.ServerUrl + "/jscoverage/ranges.html");
+            // Prevent flaky tests.
+            await Task.Delay(1000);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
             var entry = coverage[0];

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
@@ -49,7 +49,7 @@ namespace PuppeteerSharp.Tests.InputTests
             var fileChooser = waitForTask.Result;
             await fileChooser.CancelAsync();
 
-            var ex = Assert.Throws<PuppeteerException>(() => fileChooser.Cancel());
+            var ex = Assert.ThrowsAsync<PuppeteerException>(() => fileChooser.CancelAsync());
             Assert.AreEqual("Cannot accept FileChooser which is already handled!", ex.Message);
         }
     }

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 Page.ClickAsync("input"));
 
             var fileChooser = waitForTask.Result;
-            await fileChooser.Cancel();
+            await fileChooser.CancelAsync();
 
             await Task.WhenAll(
                 Page.WaitForFileChooserAsync(),
@@ -47,7 +47,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 Page.ClickAsync("input"));
 
             var fileChooser = waitForTask.Result;
-            await fileChooser.Cancel();
+            await fileChooser.CancelAsync();
 
             var ex = Assert.Throws<PuppeteerException>(() => fileChooser.Cancel());
             Assert.AreEqual("Cannot accept FileChooser which is already handled!", ex.Message);

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 Page.ClickAsync("input"));
 
             var fileChooser = waitForTask.Result;
-            fileChooser.Cancel();
+            await fileChooser.Cancel();
 
             await Task.WhenAll(
                 Page.WaitForFileChooserAsync(),
@@ -47,7 +47,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 Page.ClickAsync("input"));
 
             var fileChooser = waitForTask.Result;
-            fileChooser.Cancel();
+            await fileChooser.Cancel();
 
             var ex = Assert.Throws<PuppeteerException>(() => fileChooser.Cancel());
             Assert.AreEqual("Cannot accept FileChooser which is already handled!", ex.Message);

--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -189,6 +189,26 @@ namespace PuppeteerSharp
                 throw new PuppeteerException("Multiple file uploads only work with <input type=file multiple>");
             }
 
+            /**
+            * The zero-length array is a special case, it seems that
+            * DOM.setFileInputFiles does not actually update the files in that case, so
+            * the solution is to eval the element value to a new FileList directly.
+            */
+            if (!filePaths.Any() || filePaths == null)
+            {
+                await EvaluateFunctionAsync(@"(element) => {
+                    element.files = new DataTransfer().files;
+
+                    // Dispatch events for this case because it should behave akin to a user action.
+                    element.dispatchEvent(
+                        new Event('input', {bubbles: true, composed: true})
+                    );
+                    element.dispatchEvent(new Event('change', { bubbles: true }));
+                }").ConfigureAwait(false);
+
+                return;
+            }
+
             var objectId = RemoteObject.ObjectId;
             var node = await Client.SendAsync<DomDescribeNodeResponse>("DOM.describeNode", new DomDescribeNodeRequest
             {
@@ -196,27 +216,14 @@ namespace PuppeteerSharp
             }).ConfigureAwait(false);
             var backendNodeId = node.Node.BackendNodeId;
 
-            if (!filePaths.Any() || filePaths == null)
+            var files = resolveFilePaths ? filePaths.Select(Path.GetFullPath).ToArray() : filePaths;
+            CheckForFileAccess(files);
+            await Client.SendAsync("DOM.setFileInputFiles", new DomSetFileInputFilesRequest
             {
-                await EvaluateFunctionAsync(@"(element) => {
-                    element.files = new DataTransfer().files;
-
-                    // Dispatch events for this case because it should behave akin to a user action.
-                    element.dispatchEvent(new Event('input', { bubbles: true }));
-                    element.dispatchEvent(new Event('change', { bubbles: true }));
-                }").ConfigureAwait(false);
-            }
-            else
-            {
-                var files = resolveFilePaths ? filePaths.Select(Path.GetFullPath).ToArray() : filePaths;
-                CheckForFileAccess(files);
-                await Client.SendAsync("DOM.setFileInputFiles", new DomSetFileInputFilesRequest
-                {
-                    ObjectId = objectId,
-                    Files = files,
-                    BackendNodeId = backendNodeId,
-                }).ConfigureAwait(false);
-            }
+                ObjectId = objectId,
+                Files = files,
+                BackendNodeId = backendNodeId,
+            }).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -189,11 +189,9 @@ namespace PuppeteerSharp
                 throw new PuppeteerException("Multiple file uploads only work with <input type=file multiple>");
             }
 
-            /**
-            * The zero-length array is a special case, it seems that
-            * DOM.setFileInputFiles does not actually update the files in that case, so
-            * the solution is to eval the element value to a new FileList directly.
-            */
+            // The zero-length array is a special case, it seems that
+            // DOM.setFileInputFiles does not actually update the files in that case, so
+            // the solution is to eval the element value to a new FileList directly.
             if (!filePaths.Any() || filePaths == null)
             {
                 await EvaluateFunctionAsync(@"(element) => {

--- a/lib/PuppeteerSharp/FileChooser.cs
+++ b/lib/PuppeteerSharp/FileChooser.cs
@@ -64,6 +64,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Closes the file chooser without selecting any files.
         /// </summary>
+        /// <returns>A task that resolves after the cancel event is sent to the browser.</returns>
         public Task CancelAsync()
         {
             if (_handled)

--- a/lib/PuppeteerSharp/FileChooser.cs
+++ b/lib/PuppeteerSharp/FileChooser.cs
@@ -64,7 +64,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Closes the file chooser without selecting any files.
         /// </summary>
-        public void Cancel()
+        public Task Cancel()
         {
             if (_handled)
             {
@@ -72,6 +72,7 @@ namespace PuppeteerSharp
             }
 
             _handled = true;
+            return _element.EvaluateFunctionAsync("element => element.dispatchEvent(new Event('cancel', {bubbles: true}))");
         }
     }
 }

--- a/lib/PuppeteerSharp/FileChooser.cs
+++ b/lib/PuppeteerSharp/FileChooser.cs
@@ -64,7 +64,7 @@ namespace PuppeteerSharp
         /// <summary>
         /// Closes the file chooser without selecting any files.
         /// </summary>
-        public Task Cancel()
+        public Task CancelAsync()
         {
             if (_handled)
             {

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>12.0.0</PackageVersion>
-    <ReleaseVersion>12.0.0</ReleaseVersion>
-    <AssemblyVersion>12.0.0</AssemblyVersion>
-    <FileVersion>12.0.0</FileVersion>
+<PackageVersion>13.0.0</PackageVersion>
+<ReleaseVersion>13.0.0</ReleaseVersion>
+<AssemblyVersion>13.0.0</AssemblyVersion>
+<FileVersion>13.0.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-<PackageVersion>13.0.0</PackageVersion>
-<ReleaseVersion>13.0.0</ReleaseVersion>
-<AssemblyVersion>13.0.0</AssemblyVersion>
-<FileVersion>13.0.0</FileVersion>
+    <PackageVersion>13.0.0</PackageVersion>
+    <ReleaseVersion>13.0.0</ReleaseVersion>
+    <AssemblyVersion>13.0.0</AssemblyVersion>
+    <FileVersion>13.0.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
BREAKING CHANGE: FileChooser.Cancel was renamed to FileChooser.CancelAsync, and it nows returns a task.

[See upstream change](https://github.com/puppeteer/puppeteer/pull/11057)

