### PR TITLE
Remove System.Text.Encodings.Web

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -47,7 +47,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.3.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Microsoft.AspNetCore.WebUtilities 2.2.0 depends on System.Text.Encodings.Web 4.5.0 which is marked as vulnerable.
System.Text.Encodings.Web was bumped to 6.0.0 in #2016.
Microsoft.AspNetCore.WebUtilities was removed in #2324.