### PR TITLE
Deprecate is incognito

### DIFF
--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -13,7 +13,9 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         {
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
             var defaultContext = Browser.BrowserContexts()[0];
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.False(defaultContext.IsIncognito);
+#pragma warning restore CS0618 // Type or member is obsolete
             var exception = Assert.ThrowsAsync<PuppeteerException>(defaultContext.CloseAsync);
             Assert.AreSame(defaultContext, Browser.DefaultContext);
             StringAssert.Contains("cannot be closed", exception!.Message);
@@ -24,7 +26,9 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         {
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
             var context = await Browser.CreateIncognitoBrowserContextAsync();
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.True(context.IsIncognito);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.AreEqual(2, Browser.BrowserContexts().Length);
             Assert.Contains(context, Browser.BrowserContexts());
             await context.CloseAsync();

--- a/lib/PuppeteerSharp/IBrowserContext.cs
+++ b/lib/PuppeteerSharp/IBrowserContext.cs
@@ -47,6 +47,7 @@ namespace PuppeteerSharp
         /// <remarks>
         /// The default browser context cannot be closed.
         /// </remarks>
+        [Obsolete("In Chrome, the default browser context can also be \"icognito\" if configured via the arguments and in such cases this getter returns wrong results. Also, the term \"incognito\" is not applicable to other browsers. To migrate, check the default browser context instead: in Chrome all non-default contexts are incognito, and the default context might be incognito if you provide the `--incognito` argument when launching the browser.")]
         bool IsIncognito { get; }
 
         /// <summary>


### PR DESCRIPTION
In Chrome, the default browser context can also be "icognito" if configured via the arguments and in such cases this getter returns wrong results (see https://github.com/puppeteer/puppeteer/issues/8836). Also, the term "incognito" is not applicable to other browsers. To migrate, check the default browser context instead: in Chrome all non-default contexts are incognito, and the default context might be incognito if you provide the `--incognito` argument when launching the browser.

closes #2462