### PR TITLE
Bump patch version to 18.0.2

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>18.0.1</PackageVersion>
-    <ReleaseVersion>18.0.1</ReleaseVersion>
-    <AssemblyVersion>18.0.1</AssemblyVersion>
-    <FileVersion>18.0.0</FileVersion>
+    <PackageVersion>18.0.2</PackageVersion>
+    <ReleaseVersion>18.0.2</ReleaseVersion>
+    <AssemblyVersion>18.0.2</AssemblyVersion>
+    <FileVersion>18.0.2</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Updates the version numbers in `lib/PuppeteerSharp/PuppeteerSharp.csproj` to 18.0.2.

- **Version Updates**: Changes the `<PackageVersion>`, `<AssemblyVersion>`, and `<FileVersion>` tags from `18.0.1` to `18.0.2`, ensuring all version references within the project file are consistent with the new patch version.
- **Consistency**: Maintains the alignment of version numbers across the project, facilitating better version tracking and package management.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hardkoded/puppeteer-sharp?shareId=aef35461-6107-4e55-b4cc-694e7889832f).