### PR TITLE
Fix: `BrowserContext.IsClosed` returns true when a context is not closed

### DIFF
--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -132,6 +132,8 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
 
             // Cleanup contexts.
             await Task.WhenAll(context1.CloseAsync(), context2.CloseAsync());
+            Assert.True(context1.IsClosed);
+            Assert.True(context2.IsClosed);
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
         }
 

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -32,6 +32,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             Assert.AreEqual(2, Browser.BrowserContexts().Length);
             Assert.Contains(context, Browser.BrowserContexts());
             await context.CloseAsync();
+            Assert.True(context.IsClosed);
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
         }
 
@@ -45,6 +46,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             Assert.AreEqual(2, (await Browser.PagesAsync()).Length);
             Assert.That((await context.PagesAsync()), Has.Exactly(1).Items);
             await context.CloseAsync();
+            Assert.True(context.IsClosed);
             Assert.That((await Browser.PagesAsync()), Has.Exactly(1).Items);
         }
 

--- a/lib/PuppeteerSharp/BrowserContext.cs
+++ b/lib/PuppeteerSharp/BrowserContext.cs
@@ -25,7 +25,7 @@ namespace PuppeteerSharp
         public bool IsIncognito => Id != null;
 
         /// <inheritdoc/>
-        public bool IsClosed => Browser.BrowserContexts().Contains(this);
+        public bool IsClosed => !Browser.BrowserContexts().Contains(this);
 
         /// <inheritdoc cref="Browser"/>
         public Browser Browser { get; protected init; }


### PR DESCRIPTION
The PR fixes `BrowserContext.IsClosed`. The property returns true when a context is not closed.