### PR TITLE
Gracefully tear down test if SetUp failed

### DIFF
--- a/lib/PuppeteerSharp.Tests/PuppeteerBrowserBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerBrowserBaseTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -18,7 +17,13 @@ namespace PuppeteerSharp.Tests
                 TestConstants.LoggerFactory);
 
         [TearDown]
-        public virtual async Task DisposeAsync() => await Browser.CloseAsync();
+        public virtual async Task DisposeAsync()
+        {
+            if (Browser is not null)
+            {
+                await Browser.CloseAsync();
+            }
+        }
 
         public void Dispose()
         {

--- a/lib/PuppeteerSharp.Tests/PuppeteerPageBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerPageBaseTest.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -11,11 +12,17 @@ namespace PuppeteerSharp.Tests
         public async Task CreatePageAsync()
         {
             Page = await Context.NewPageAsync();
-            Page.DefaultTimeout = System.Diagnostics.Debugger.IsAttached ? TestConstants.DebuggerAttachedTestTimeout : TestConstants.DefaultPuppeteerTimeout;
+            Page.DefaultTimeout = Debugger.IsAttached ? TestConstants.DebuggerAttachedTestTimeout : TestConstants.DefaultPuppeteerTimeout;
         }
 
         [TearDown]
-        public Task ClosePageAsync() => Page.CloseAsync();
+        public async Task ClosePageAsync()
+        {
+            if (Page is not null)
+            {
+                await Page.CloseAsync();
+            }
+        }
 
         protected Task WaitForError()
         {


### PR DESCRIPTION
If the `[SetUp]` methods failed to construct and assign `Browser` or `Page`, the `[TearDown]` methods would throw an NRE.