### PR TITLE
Rollback to Chrome 124

### DIFF
--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageWaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageWaitForNavigationTests.cs
@@ -30,31 +30,34 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldWorkWithBothDomcontentloadedAndLoad()
         {
             var responseCompleted = new TaskCompletionSource<bool>();
-            Server.SetRoute("/one-style.css", _ => responseCompleted.Task);
+            Server.SetRoute("/one-style.css", _ =>
+            {
+                return responseCompleted.Task;
+            });
 
             var waitForRequestTask = Server.WaitForRequest("/one-style.css");
             var navigationTask = Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
             var domContentLoadedTask = Page.WaitForNavigationAsync(new NavigationOptions
             {
-                WaitUntil = [WaitUntilNavigation.DOMContentLoaded]
+                WaitUntil = new[] { WaitUntilNavigation.DOMContentLoaded }
             });
 
             var bothFired = false;
             var bothFiredTask = Page.WaitForNavigationAsync(new NavigationOptions
             {
-                WaitUntil =
-                [
+                WaitUntil = new[]
+                {
                     WaitUntilNavigation.Load,
                     WaitUntilNavigation.DOMContentLoaded
-                ]
+                }
             }).ContinueWith(_ => bothFired = true);
 
-            await waitForRequestTask.WithTimeout(5_000);
-            await domContentLoadedTask.WithTimeout(5_000);
+            await waitForRequestTask.WithTimeout();
+            await domContentLoadedTask.WithTimeout();
             Assert.False(bothFired);
             responseCompleted.SetResult(true);
-            await bothFiredTask.WithTimeout(5_000);
-            await navigationTask.WithTimeout(5_000);
+            await bothFiredTask.WithTimeout();
+            await navigationTask.WithTimeout();
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.waitForNavigation", "should work with clicking on anchor links")]

--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -13,9 +13,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "125.0.6422.76";
-
-        internal static int ChromeVersionRequiringPermissionsFix => 125;
+        public static string DefaultBuildId => "124.0.6367.201";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -258,7 +258,7 @@ namespace PuppeteerSharp
                 throw new PuppeteerException($"Failed to download {browser} for {Platform} from {url}", ex);
             }
 
-            await UnpackArchiveAsync(archivePath, outputPath, fileName, browser, buildId).ConfigureAwait(false);
+            await UnpackArchiveAsync(archivePath, outputPath, fileName).ConfigureAwait(false);
             new FileInfo(archivePath).Delete();
 
             return new InstalledBrowser(cache, browser, buildId, Platform);
@@ -374,7 +374,7 @@ namespace PuppeteerSharp
             }
         }
 
-        private async Task UnpackArchiveAsync(string archivePath, string outputPath, string archiveName, SupportedBrowser browser, string buildId)
+        private async Task UnpackArchiveAsync(string archivePath, string outputPath, string archiveName)
         {
             if (archivePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
             {
@@ -425,36 +425,6 @@ namespace PuppeteerSharp
                         }
                     }
                 }
-            }
-
-            if (browser == SupportedBrowser.Chrome && (GetCurrentPlatform() == Platform.Win64 || GetCurrentPlatform() == Platform.Win32))
-            {
-                if (int.TryParse(buildId.Split('.').First(), out var majorVersion) &&
-                    majorVersion >= Chrome.ChromeVersionRequiringPermissionsFix)
-                {
-                    TrySetWindowsPermissions(outputPath);
-                }
-            }
-        }
-
-        private void TrySetWindowsPermissions(string outputPath)
-        {
-            try
-            {
-                var startInfo = new ProcessStartInfo
-                {
-                    FileName = "icacls.exe",
-                    Arguments = $"\"{outputPath}\" /grant *S-1-15-2-2:(OI)(CI)(RX)",
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                };
-                var process = Process.Start(startInfo);
-                process?.WaitForExit();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Unable to fix permissions: " + e.Message);
-                Console.WriteLine($"Visit https://pptr.dev/troubleshooting#chrome-reports-sandbox-errors-on-windows for more information");
-                throw;
             }
         }
 


### PR DESCRIPTION
This reverts commit 1b2236945528535214a90f4022eed0ca76238200.

Chrome 125 proved to be a headache for many windows users. We will roll this back till we find a better solution.

Closes #2658 and #2657