### PR TITLE
Align per-test and per-class disposal

### DIFF
--- a/lib/PuppeteerSharp.Tests/PuppeteerBrowserBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerBrowserBaseTest.cs
@@ -1,42 +1,27 @@
-using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace PuppeteerSharp.Tests
 {
-    public class PuppeteerBrowserBaseTest : PuppeteerBaseTest, IDisposable, IAsyncDisposable
+    public class PuppeteerBrowserBaseTest : PuppeteerBaseTest
     {
         protected IBrowser Browser { get; set; }
 
         protected LaunchOptions DefaultOptions { get; set; }
 
         [SetUp]
-        public virtual async Task InitializeAsync()
+        public async Task InitializeAsync()
             => Browser = await Puppeteer.LaunchAsync(
                 DefaultOptions ?? TestConstants.DefaultBrowserOptions(),
                 TestConstants.LoggerFactory);
 
         [TearDown]
-        public virtual async Task DisposeAsync()
+        public async Task TearDownAsync()
         {
             if (Browser is not null)
             {
-                await Browser.CloseAsync();
+                await Browser.DisposeAsync();
             }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing) => _ = DisposeAsync();
-
-        ValueTask IAsyncDisposable.DisposeAsync()
-        {
-            GC.SuppressFinalize(this);
-            return Browser.DisposeAsync();
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
+++ b/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
@@ -9,7 +9,7 @@ using PuppeteerSharp.Nunit;
 
 namespace PuppeteerSharp.Tests.TracingTests
 {
-    public class TracingTests : PuppeteerPageBaseTest
+    public sealed class TracingTests : PuppeteerPageBaseTest, IAsyncDisposable
     {
         private readonly string _file;
 
@@ -18,10 +18,8 @@ namespace PuppeteerSharp.Tests.TracingTests
             _file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         }
 
-        public override async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            await base.DisposeAsync();
-
             var attempts = 0;
             const int maxAttempts = 5;
 

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
@@ -6,7 +6,7 @@ using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp.Tests.WaitTaskTests
 {
-    public sealed class FrameWaitForFunctionTests : PuppeteerPageBaseTest
+    public sealed class FrameWaitForFunctionTests : PuppeteerPageBaseTest, IDisposable
     {
         private PollerInterceptor _pollerInterceptor;
 
@@ -27,9 +27,8 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             };
         }
 
-        protected override void Dispose(bool disposing)
+        public void Dispose()
         {
-            base.Dispose(disposing);
             _pollerInterceptor.Dispose();
         }
 

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -7,7 +8,7 @@ using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp.Tests.WaitTaskTests
 {
-    public class FrameWaitForSelectorTests : PuppeteerPageBaseTest
+    public sealed class FrameWaitForSelectorTests : PuppeteerPageBaseTest, IDisposable
     {
         private const string AddElement = "tag => document.body.appendChild(document.createElement(tag))";
         private PollerInterceptor _pollerInterceptor;
@@ -29,9 +30,8 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             };
         }
 
-        protected override void Dispose(bool disposing)
+        public void Dispose()
         {
-            base.Dispose(disposing);
             _pollerInterceptor.Dispose();
         }
 


### PR DESCRIPTION
In NUnit the constructor and Dispose(Async) methods are run once per _class_, whereas methods marked with `[SetUp]` or `[TearDown]` are run once per _test_.

In `PuppeteerBrowserBaseTest` we hence:
* Before each test: construct a new `Browser`
* After each test: close `Browser`
* At the last test: dispose the last created `Browser`

Unless I'm missing something, each `Browser` instance should be handled equally.
b957d9ba2b38d366963cc482ed3caf504248ed54 introduced this asymmetry but I  don't understand why.

If we want to keep this asymmetry, let's at least add a comment why we close all browser, but only dispose the last one.