### PR TITLE
Migrate to Nunit4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 ## Take screenshots
 
 <!-- snippet: ScreenshotAsync -->
-<a id='snippet-screenshotasync'></a>
+<a id='snippet-ScreenshotAsync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L53-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScreenshotAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
 <!-- snippet: SetViewportAsync -->
-<a id='snippet-setviewportasync'></a>
+<a id='snippet-SetViewportAsync'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -74,13 +74,13 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetViewportAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
 
 <!-- snippet: PdfAsync -->
-<a id='snippet-pdfasync'></a>
+<a id='snippet-PdfAsync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,32 +90,32 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-PdfAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
 <!-- snippet: SetContentAsync -->
-<a id='snippet-setcontentasync'></a>
+<a id='snippet-SetContentAsync'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetContentAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
 <!-- snippet: Evaluate -->
-<a id='snippet-evaluate'></a>
+<a id='snippet-Evaluate'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<dynamic>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.a);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L16-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L16-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-Evaluate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 ## Take screenshots
 
 <!-- snippet: ScreenshotAsync -->
-<a id='snippet-ScreenshotAsync'></a>
+<a id='snippet-screenshotasync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L53-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScreenshotAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
 <!-- snippet: SetViewportAsync -->
-<a id='snippet-SetViewportAsync'></a>
+<a id='snippet-setviewportasync'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -74,13 +74,13 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetViewportAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
 
 <!-- snippet: PdfAsync -->
-<a id='snippet-PdfAsync'></a>
+<a id='snippet-pdfasync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,32 +90,32 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-PdfAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
 <!-- snippet: SetContentAsync -->
-<a id='snippet-SetContentAsync'></a>
+<a id='snippet-setcontentasync'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetContentAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
 <!-- snippet: Evaluate -->
-<a id='snippet-Evaluate'></a>
+<a id='snippet-evaluate'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<dynamic>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.a);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L16-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-Evaluate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L16-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/docfx_project/examples/DownloadFetcher.Download.md
+++ b/docfx_project/examples/DownloadFetcher.Download.md
@@ -14,7 +14,7 @@ Once you have the version you want, you can download it using the `BrowserFetche
 
 ```cs
 <!-- snippet: CustomVersionsExample -->
-<a id='snippet-customversionsexample'></a>
+<a id='snippet-CustomVersionsExample'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-customversionsexample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-CustomVersionsExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/examples/DownloadFetcher.Download.md
+++ b/docfx_project/examples/DownloadFetcher.Download.md
@@ -14,7 +14,7 @@ Once you have the version you want, you can download it using the `BrowserFetche
 
 ```cs
 <!-- snippet: CustomVersionsExample -->
-<a id='snippet-CustomVersionsExample'></a>
+<a id='snippet-customversionsexample'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-CustomVersionsExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-customversionsexample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/examples/ReuseChrome.md
+++ b/docfx_project/examples/ReuseChrome.md
@@ -12,14 +12,14 @@ from a location where it was previously downloaded instead of from the default l
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
 <!-- snippet: ReuseChromeExample -->
-<a id='snippet-reusechromeexample'></a>
+<a id='snippet-ReuseChromeExample'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reusechromeexample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ReuseChromeExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/docfx_project/examples/ReuseChrome.md
+++ b/docfx_project/examples/ReuseChrome.md
@@ -12,14 +12,14 @@ from a location where it was previously downloaded instead of from the default l
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
 <!-- snippet: ReuseChromeExample -->
-<a id='snippet-ReuseChromeExample'></a>
+<a id='snippet-reusechromeexample'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ReuseChromeExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reusechromeexample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/lib/PuppeteerSharp.Nunit/PuppeteerSharp.Nunit.csproj
+++ b/lib/PuppeteerSharp.Nunit/PuppeteerSharp.Nunit.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-	  <PackageReference Include="NUnit" Version="3.13.3" />
+	  <PackageReference Include="NUnit" Version="4.1.0" />
 	</ItemGroup>
 	<ItemGroup>
 	  <EmbeddedResource Include="TestExpectations\TestExpectations.local.json" />

--- a/lib/PuppeteerSharp.Tests/AccessibilityTests/AccessibilityTests.cs
+++ b/lib/PuppeteerSharp.Tests/AccessibilityTests/AccessibilityTests.cs
@@ -104,7 +104,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             };
             await Page.FocusAsync("[placeholder='Empty input']");
             var snapshot = await Page.Accessibility.SnapshotAsync();
-            Assert.AreEqual(nodeToCheck, snapshot);
+            Assert.That(snapshot, Is.EqualTo(nodeToCheck));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "Accessibility", "should report uninteresting nodes")]
@@ -115,8 +115,12 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
 
             // This object has more children than in upstream.
             // Because upstream uses `toMatchObject` which stops going deeper if the element has not Children.
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                FindFocusedNode(await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+                {
+                    InterestingOnly = false
+                })),
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "textbox",
                     Name = "",
@@ -144,11 +148,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                             }
                         }
                     }
-                },
-                FindFocusedNode(await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
-                {
-                    InterestingOnly = false
-                })));
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "Accessibility", "get snapshots while the tree is re-calculated")]
@@ -188,7 +188,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             </html>");
 
             var button = await Page.QuerySelectorAsync("button");
-            Assert.AreEqual("Show", await GetAccessibleNameAsync(Page, button));
+            Assert.That(await GetAccessibleNameAsync(Page, button), Is.EqualTo("Show"));
             await button!.ClickAsync();
             await Page.WaitForSelectorAsync("aria/Hide");
         }
@@ -207,7 +207,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             await Page.SetContentAsync("<div tabIndex=-1 aria-roledescription='foo'>Hi</div>");
             var snapshot = await Page.Accessibility.SnapshotAsync();
             // See https://chromium-review.googlesource.com/c/chromium/src/+/3088862
-            Assert.Null(snapshot.Children[0].RoleDescription);
+            Assert.That(snapshot.Children[0].RoleDescription, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "Accessibility", "orientation")]
@@ -215,7 +215,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
         {
             await Page.SetContentAsync("<a href='' role='slider' aria-orientation='vertical'>11</a>");
             var snapshot = await Page.Accessibility.SnapshotAsync();
-            Assert.AreEqual("vertical", snapshot.Children[0].Orientation);
+            Assert.That(snapshot.Children[0].Orientation, Is.EqualTo("vertical"));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "Accessibility", "autocomplete")]
@@ -223,7 +223,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
         {
             await Page.SetContentAsync("<input type='number' aria-autocomplete='list' />");
             var snapshot = await Page.Accessibility.SnapshotAsync();
-            Assert.AreEqual("list", snapshot.Children[0].AutoComplete);
+            Assert.That(snapshot.Children[0].AutoComplete, Is.EqualTo("list"));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "Accessibility", "multiselectable")]
@@ -231,7 +231,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
         {
             await Page.SetContentAsync("<div role='grid' tabIndex=-1 aria-multiselectable=true>hey</div>");
             var snapshot = await Page.Accessibility.SnapshotAsync();
-            Assert.True(snapshot.Children[0].Multiselectable);
+            Assert.That(snapshot.Children[0].Multiselectable, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "Accessibility", "keyshortcuts")]
@@ -239,7 +239,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
         {
             await Page.SetContentAsync("<div role='grid' tabIndex=-1 aria-keyshortcuts='foo'>hey</div>");
             var snapshot = await Page.Accessibility.SnapshotAsync();
-            Assert.AreEqual("foo", snapshot.Children[0].KeyShortcuts);
+            Assert.That(snapshot.Children[0].KeyShortcuts, Is.EqualTo("foo"));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "filtering children of leaf nodes", "should not report text nodes inside controls")]
@@ -250,8 +250,9 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                 <div role='tab' aria-selected='true'><b>Tab1</b></div>
                 <div role='tab'>Tab2</div>
             </div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                await Page.Accessibility.SnapshotAsync(),
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "RootWebArea",
                     Name = "",
@@ -267,8 +268,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                             Name = "Tab2"
                         }
                     }
-                },
-                await Page.Accessibility.SnapshotAsync());
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "filtering children of leaf nodes", "rich text editable fields should have children")]
@@ -278,8 +278,9 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             <div contenteditable='true'>
                 Edit this image: <img src='fakeimage.png' alt='my fake image'>
             </div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                (await Page.Accessibility.SnapshotAsync()).Children[0],
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "generic",
                     Name = "",
@@ -295,8 +296,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                             Name = "my fake image"
                         }
                     }
-                },
-                (await Page.Accessibility.SnapshotAsync()).Children[0]);
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "filtering children of leaf nodes", "rich text editable fields with role should have children")]
@@ -306,8 +306,9 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             <div contenteditable='true' role='textbox'>
                 Edit this image: <img src='fakeimage.png' alt='my fake image'>
             </div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                (await Page.Accessibility.SnapshotAsync()).Children[0],
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "textbox",
                     Name = "",
@@ -320,23 +321,22 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                             Name = "Edit this image: "
                         },
                     }
-                },
-                (await Page.Accessibility.SnapshotAsync()).Children[0]);
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "plaintext contenteditable", "plain text field with role should not have children")]
         public async Task PlainTextFieldWithRoleShouldNotHaveChildren()
         {
             await Page.SetContentAsync("<div contenteditable='plaintext-only' role='textbox'>Edit this image:<img src='fakeimage.png' alt='my fake image'></div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                (await Page.Accessibility.SnapshotAsync()).Children[0],
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "textbox",
                     Name = "",
                     Value = "Edit this image:",
                     Multiline = true,
-                },
-                (await Page.Accessibility.SnapshotAsync()).Children[0]);
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "plaintext contenteditable", "plain text field with tabindex and without role should not have content")]
@@ -345,8 +345,8 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             await Page.SetContentAsync(
                 "<div contenteditable='plaintext-only'>Edit this image:<img src='fakeimage.png' alt='my fake image'></div>");
             var snapshot = await Page.Accessibility.SnapshotAsync();
-            Assert.AreEqual("generic", snapshot.Children[0].Role);
-            Assert.AreEqual(string.Empty, snapshot.Children[0].Name);
+            Assert.That(snapshot.Children[0].Role, Is.EqualTo("generic"));
+            Assert.That(snapshot.Children[0].Name, Is.EqualTo(string.Empty));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "filtering children of leaf nodes", "non editable textbox with role and tabIndex and label should not have children")]
@@ -357,14 +357,14 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                 this is the inner content
                 <img alt='yo' src='fakeimg.png'>
             </div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                (await Page.Accessibility.SnapshotAsync()).Children[0],
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "textbox",
                     Name = "my favorite textbox",
                     Value = "this is the inner content "
-                },
-                (await Page.Accessibility.SnapshotAsync()).Children[0]);
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "filtering children of leaf nodes", "checkbox with and tabIndex and label should not have children")]
@@ -375,14 +375,14 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                 this is the inner content
                 <img alt='yo' src='fakeimg.png'>
             </div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                (await Page.Accessibility.SnapshotAsync()).Children[0],
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "checkbox",
                     Name = "my favorite checkbox",
                     Checked = CheckedState.True
-                },
-                (await Page.Accessibility.SnapshotAsync()).Children[0]);
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "filtering children of leaf nodes", "checkbox without label should not have children")]
@@ -393,14 +393,14 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                 this is the inner content
                 <img alt='yo' src='fakeimg.png'>
             </div>");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                (await Page.Accessibility.SnapshotAsync()).Children[0],
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "checkbox",
                     Name = "this is the inner content yo",
                     Checked = CheckedState.True
-                },
-                (await Page.Accessibility.SnapshotAsync()).Children[0]);
+                }));
         }
 
         private SerializedAXNode FindFocusedNode(SerializedAXNode serializedAXNode)

--- a/lib/PuppeteerSharp.Tests/AccessibilityTests/RootOptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/AccessibilityTests/RootOptionTests.cs
@@ -13,13 +13,13 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             await Page.SetContentAsync("<button>My Button</button>");
 
             var button = await Page.QuerySelectorAsync("button");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = button }),
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "button",
                     Name = "My Button"
-                },
-                await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = button }));
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "root option", "should work an input")]
@@ -28,14 +28,14 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             await Page.SetContentAsync("<input title='My Input' value='My Value'>");
 
             var input = await Page.QuerySelectorAsync("input");
-            Assert.AreEqual(
-                new SerializedAXNode
+            Assert.That(
+                await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = input }),
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "textbox",
                     Name = "My Input",
                     Value = "My Value"
-                },
-                await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = input }));
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "root option", "should work a menu")]
@@ -76,7 +76,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                     }
             };
 
-            Assert.AreEqual(nodeToCheck, snapshot);
+            Assert.That(snapshot, Is.EqualTo(nodeToCheck));
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "root option", "should return null when the element is no longer in DOM")]
@@ -85,7 +85,7 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             await Page.SetContentAsync("<button>My Button</button>");
             var button = await Page.QuerySelectorAsync("button");
             await Page.EvaluateFunctionAsync("button => button.remove()", button);
-            Assert.Null(await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = button }));
+            Assert.That(await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = button }), Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("accessibility.spec", "root option", "should support the interestingOnly option")]
@@ -93,12 +93,17 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
         {
             await Page.SetContentAsync("<div><button>My Button</button></div>");
             var div = await Page.QuerySelectorAsync("div");
-            Assert.Null(await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+            Assert.That(await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
             {
                 Root = div
-            }));
-            Assert.AreEqual(
-                new SerializedAXNode
+            }), Is.Null);
+            Assert.That(
+                await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+                {
+                    Root = div,
+                    InterestingOnly = false
+                }),
+                Is.EqualTo(new SerializedAXNode
                 {
                     Role = "generic",
                     Name = "",
@@ -125,11 +130,6 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                             }
                         }
                     }
-                },
-                await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
-                {
-                    Root = div,
-                    InterestingOnly = false
                 }));
         }
     }

--- a/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/ParseAriaSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/ParseAriaSelectorTests.cs
@@ -27,11 +27,11 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
         {
             async Task ExpectFound(IElementHandle button)
             {
-                Assert.NotNull(button);
+                Assert.That(button, Is.Not.Null);
                 var id = await button.EvaluateFunctionAsync<string>(@"(button) => {
                     return button.id;
                 }");
-                Assert.AreEqual("btn", id);
+                Assert.That(id, Is.EqualTo("btn"));
             }
 
             var button = await Page.QuerySelectorAsync("aria/Submit button and some spaces[role=\"button\"]");
@@ -55,7 +55,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             button = await Page.QuerySelectorAsync("aria/ignored[name=\"Submit  button and some  spaces\"][role=\"button\"]");
             await ExpectFound(button);
             var ex = Assert.ThrowsAsync<PuppeteerException>(() => Page.QuerySelectorAsync("aria/smth[smth=\"true\"]"));
-            Assert.AreEqual("Unknown aria attribute \"smth\" in selector", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Unknown aria attribute \"smth\" in selector"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/QueryAllArrayTests.cs
+++ b/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/QueryAllArrayTests.cs
@@ -30,7 +30,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
                 .QuerySelectorAllHandleAsync("aria/[role=\"button\"]")
                 .EvaluateFunctionAsync<int>(@"buttons => buttons.reduce((acc, button) => acc + Number(button.textContent), 0)");
 
-            Assert.AreEqual(50005000, sum);
+            Assert.That(sum, Is.EqualTo(50005000));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/QueryAllTests.cs
+++ b/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/QueryAllTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             var divs = await Page.QuerySelectorAllAsync("aria/menu div");
             var ids = await Task.WhenAll(divs.Select(div => div.EvaluateFunctionAsync<string>("div => div.id")));
 
-            Assert.AreEqual("mnu1, mnu2", String.Join(", ", ids));
+            Assert.That(String.Join(", ", ids), Is.EqualTo("mnu1, mnu2"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/QueryOneTests.cs
+++ b/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/QueryOneTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             await Page.SetContentAsync("<div id='div'><button id='btn' role='button'>Submit</button></div>");
             var button = await Page.QuerySelectorAsync("aria/[role='button']");
             var id = await button.EvaluateFunctionAsync<string>("(button) => button.id");
-            Assert.AreEqual("btn", id);
+            Assert.That(id, Is.EqualTo("btn"));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "queryOne", "should find button by name and role")]
@@ -30,7 +30,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             await Page.SetContentAsync("<div id='div'><button id='btn' role='button'>Submit</button></div>");
             var button = await Page.QuerySelectorAsync("aria/Submit[role='button']");
             var id = await button.EvaluateFunctionAsync<string>("(button) => button.id");
-            Assert.AreEqual("btn", id);
+            Assert.That(id, Is.EqualTo("btn"));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "queryOne", "should find first matching element")]
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             ");
             var button = await Page.QuerySelectorAsync("aria/menu div");
             var id = await button.EvaluateFunctionAsync<string>("(button) => button.id");
-            Assert.AreEqual("mnu1", id);
+            Assert.That(id, Is.EqualTo("mnu1"));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "queryOne", "should find by name")]
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             ");
             var button = await Page.QuerySelectorAsync("aria/menu-label1");
             var id = await button.EvaluateFunctionAsync<string>("(button) => button.id");
-            Assert.AreEqual("mnu1", id);
+            Assert.That(id, Is.EqualTo("mnu1"));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "queryOne", "should find by name")]
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             ");
             var button = await Page.QuerySelectorAsync("aria/menu-label2");
             var id = await button.EvaluateFunctionAsync<string>("(button) => button.id");
-            Assert.AreEqual("mnu2", id);
+            Assert.That(id, Is.EqualTo("mnu2"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/WaitForSelectorAriaTests.cs
+++ b/lib/PuppeteerSharp.Tests/AriaQueryHandlerTests/WaitForSelectorAriaTests.cs
@@ -60,7 +60,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             await Page.EvaluateFunctionAsync(AddElement, "button");
             await Page.WaitForSelectorAsync("aria/[role=\"button\"]");
             var result = await Page.EvaluateExpressionAsync<int>("globalThis.ariaQuerySelector(2,8)");
-            Assert.AreEqual(10, result);
+            Assert.That(result, Is.EqualTo(10));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "waitForSelector (aria)", "should work with removed MutationObserver")]
@@ -71,8 +71,8 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             await Task.WhenAll(
                 handleTask,
                 Page.SetContentAsync("<h1>anything</h1>"));
-            Assert.NotNull(handleTask.Result);
-            Assert.AreEqual("anything", await Page.EvaluateFunctionAsync<string>("x => x.textContent", handleTask.Result));
+            Assert.That(handleTask.Result, Is.Not.Null);
+            Assert.That(await Page.EvaluateFunctionAsync<string>("x => x.textContent", handleTask.Result), Is.EqualTo("anything"));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "waitForSelector (aria)", "should resolve promise when node is added")]
@@ -87,7 +87,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             var tagName = await (
               await elementHandle.GetPropertyAsync("tagName")
             ).JsonValueAsync();
-            Assert.AreEqual("H1", tagName);
+            Assert.That(tagName, Is.EqualTo("H1"));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "waitForSelector (aria)", "should work when node is added through innerHTML")]
@@ -113,7 +113,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             await otherFrame.EvaluateFunctionAsync(AddElement, "button");
             await Page.EvaluateFunctionAsync(AddElement, "button");
             var elementHandle = await watchdog;
-            Assert.AreSame(elementHandle.Frame, Page.MainFrame);
+            Assert.That(Page.MainFrame, Is.SameAs(elementHandle.Frame));
         }
 
         [Test, Retry(2), PuppeteerTest("ariaqueryhandler.spec", "waitForSelector (aria)", "should run in specified frame")]
@@ -127,7 +127,7 @@ namespace PuppeteerSharp.Tests.AriaQueryHandlerTests
             await frame1.EvaluateFunctionAsync(AddElement, "button");
             await frame2.EvaluateFunctionAsync(AddElement, "button");
             var elementHandle = await waitForSelectorTask;
-            Assert.AreSame(elementHandle.Frame, frame2);
+            Assert.That(frame2, Is.SameAs(elementHandle.Frame));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/BFCacheTests/BFCacheTests.cs
+++ b/lib/PuppeteerSharp.Tests/BFCacheTests/BFCacheTests.cs
@@ -20,9 +20,9 @@ public class BFCacheTests : PuppeteerPageBaseTest
         await Page.GoToAsync(TestConstants.ServerUrl + "/cached/bfcache/index.html");
         await Task.WhenAll(Page.WaitForNavigationAsync(), Page.ClickAsync("a"));
 
-        StringAssert.Contains("target", Page.Url);
+        Assert.That(Page.Url, Does.Contain("target"));
         await Task.WhenAll(Page.WaitForNavigationAsync(), Page.GoBackAsync());
-        Assert.AreEqual("BFCachednext", await Page.EvaluateExpressionAsync<string>("document.body.innerText"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("BFCachednext"));
     }
 
     [Test, Retry(2), PuppeteerTest("bfcache.spec", "BFCache", "can navigate to a BFCached page containing an OOPIF and a worker")]
@@ -33,7 +33,7 @@ public class BFCacheTests : PuppeteerPageBaseTest
         Page.WorkerCreated += (_, e) => workerTcs.TrySetResult(e.Worker);
         await Page.GoToAsync(TestConstants.ServerUrl + "/cached/bfcache/worker-iframe-container.html");
         var worker1 = await workerTcs.Task.WithTimeout();
-        Assert.AreEqual(2, await worker1.EvaluateExpressionAsync<int>("1 + 1"));
+        Assert.That(await worker1.EvaluateExpressionAsync<int>("1 + 1"), Is.EqualTo(2));
         await Task.WhenAll(
             Page.WaitForNavigationAsync(),
             Page.ClickAsync("a"));
@@ -44,6 +44,6 @@ public class BFCacheTests : PuppeteerPageBaseTest
             Page.GoBackAsync()).WithTimeout();
 
         var worker2 = await workerTcs.Task.WithTimeout();
-        Assert.AreEqual(2, await worker2.EvaluateExpressionAsync<int>("1 + 1"));
+        Assert.That(await worker2.EvaluateExpressionAsync<int>("1 + 1"), Is.EqualTo(2));
     }
 }

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -105,7 +105,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await otherContext.CloseAsync();
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task AllEnumsdAreValid()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -105,6 +105,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await otherContext.CloseAsync();
         }
 
+        [Test]
         public async Task AllEnumsdAreValid()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         public async Task ShouldBePromptByDefault()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual("prompt", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext BrowserContext.overridePermissions", "should deny permission when not listed")]
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Context.OverridePermissionsAsync(TestConstants.EmptyPage, new OverridePermission[] { });
-            Assert.AreEqual("denied", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("denied"));
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext BrowserContext.overridePermissions", "should grant permission when listed")]
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             {
                 OverridePermission.Geolocation
             });
-            Assert.AreEqual("granted", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("granted"));
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext BrowserContext.overridePermissions", "should reset permissions")]
@@ -51,9 +51,9 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             {
                 OverridePermission.Geolocation
             });
-            Assert.AreEqual("granted", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("granted"));
             await Context.ClearPermissionOverridesAsync();
-            Assert.AreEqual("prompt", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext BrowserContext.overridePermissions", "should trigger permission onchange")]
@@ -69,20 +69,18 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
                     };
                 });
             }");
-            Assert.AreEqual(new string[] { "prompt" }, await Page.EvaluateExpressionAsync<string[]>("window.events"));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("window.events"), Is.EqualTo(new string[] { "prompt" }));
             await Context.OverridePermissionsAsync(TestConstants.EmptyPage, new OverridePermission[] { });
-            Assert.AreEqual(new string[] { "prompt", "denied" }, await Page.EvaluateExpressionAsync<string[]>("window.events"));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("window.events"), Is.EqualTo(new string[] { "prompt", "denied" }));
             await Context.OverridePermissionsAsync(TestConstants.EmptyPage, new OverridePermission[]
             {
                 OverridePermission.Geolocation
             });
-            Assert.AreEqual(
-                new string[] { "prompt", "denied", "granted" },
-                await Page.EvaluateExpressionAsync<string[]>("window.events"));
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string[]>("window.events"), Is.EqualTo(new string[] { "prompt", "denied", "granted" }));
             await Context.ClearPermissionOverridesAsync();
-            Assert.AreEqual(
-                new string[] { "prompt", "denied", "granted", "prompt" },
-                await Page.EvaluateExpressionAsync<string[]>("window.events"));
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string[]>("window.events"), Is.EqualTo(new string[] { "prompt", "denied", "granted", "prompt" }));
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext BrowserContext.overridePermissions", "should isolate permissions between browser contexts")]
@@ -92,17 +90,17 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             var otherContext = await Browser.CreateBrowserContextAsync();
             var otherPage = await otherContext.NewPageAsync();
             await otherPage.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual("prompt", await GetPermissionAsync(Page, "geolocation"));
-            Assert.AreEqual("prompt", await GetPermissionAsync(otherPage, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
+            Assert.That(await GetPermissionAsync(otherPage, "geolocation"), Is.EqualTo("prompt"));
 
             await Context.OverridePermissionsAsync(TestConstants.EmptyPage, new OverridePermission[] { });
             await otherContext.OverridePermissionsAsync(TestConstants.EmptyPage, new OverridePermission[] { OverridePermission.Geolocation });
-            Assert.AreEqual("denied", await GetPermissionAsync(Page, "geolocation"));
-            Assert.AreEqual("granted", await GetPermissionAsync(otherPage, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("denied"));
+            Assert.That(await GetPermissionAsync(otherPage, "geolocation"), Is.EqualTo("granted"));
 
             await Context.ClearPermissionOverridesAsync();
-            Assert.AreEqual("prompt", await GetPermissionAsync(Page, "geolocation"));
-            Assert.AreEqual("granted", await GetPermissionAsync(otherPage, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
+            Assert.That(await GetPermissionAsync(otherPage, "geolocation"), Is.EqualTo("granted"));
 
             await otherContext.CloseAsync();
         }
@@ -113,9 +111,9 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await Context.OverridePermissionsAsync(
                 TestConstants.EmptyPage,
                 Enum.GetValues(typeof(OverridePermission)).Cast<OverridePermission>().ToArray());
-            Assert.AreEqual("granted", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("granted"));
             await Context.ClearPermissionOverridesAsync();
-            Assert.AreEqual("prompt", await GetPermissionAsync(Page, "geolocation"));
+            Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -105,7 +105,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await otherContext.CloseAsync();
         }
 
-        [Test, Ignore("previously not marked as a test")]
+        [Test, Ignore("Fails on Firefox")]
         public async Task AllEnumsdAreValid()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -14,11 +14,11 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
             var defaultContext = Browser.BrowserContexts()[0];
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.False(defaultContext.IsIncognito);
+            Assert.That(defaultContext.IsIncognito, Is.False);
 #pragma warning restore CS0618 // Type or member is obsolete
             var exception = Assert.ThrowsAsync<PuppeteerException>(defaultContext.CloseAsync);
-            Assert.AreSame(defaultContext, Browser.DefaultContext);
-            StringAssert.Contains("cannot be closed", exception!.Message);
+            Assert.That(Browser.DefaultContext, Is.SameAs(defaultContext));
+            Assert.That(exception!.Message, Does.Contain("cannot be closed"));
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "should create new incognito context")]
@@ -27,12 +27,12 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
             var context = await Browser.CreateBrowserContextAsync();
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.True(context.IsIncognito);
+            Assert.That(context.IsIncognito, Is.True);
 #pragma warning restore CS0618 // Type or member is obsolete
-            Assert.AreEqual(2, Browser.BrowserContexts().Length);
-            Assert.Contains(context, Browser.BrowserContexts());
+            Assert.That(Browser.BrowserContexts(), Has.Length.EqualTo(2));
+            Assert.That(Browser.BrowserContexts(), Does.Contain(context));
             await context.CloseAsync();
-            Assert.True(context.IsClosed);
+            Assert.That(context.IsClosed, Is.True);
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
         }
 
@@ -43,10 +43,10 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
 
             var context = await Browser.CreateBrowserContextAsync();
             await context.NewPageAsync();
-            Assert.AreEqual(2, (await Browser.PagesAsync()).Length);
+            Assert.That((await Browser.PagesAsync()), Has.Length.EqualTo(2));
             Assert.That((await context.PagesAsync()), Has.Exactly(1).Items);
             await context.CloseAsync();
-            Assert.True(context.IsClosed);
+            Assert.That(context.IsClosed, Is.True);
             Assert.That((await Browser.PagesAsync()), Has.Exactly(1).Items);
         }
 
@@ -65,7 +65,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             );
 
             var popupTarget = await popupTargetCompletion.Task;
-            Assert.AreSame(context, popupTarget.BrowserContext);
+            Assert.That(popupTarget.BrowserContext, Is.SameAs(context));
             await context.CloseAsync();
         }
 
@@ -83,11 +83,11 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             // Just for half a second to get the last event
             await Task.Delay(500);
 
-            Assert.AreEqual(new[] {
+            Assert.That(events, Is.EqualTo(new[] {
                 $"CREATED: {TestConstants.AboutBlank}",
                 $"CHANGED: {TestConstants.EmptyPage}",
                 $"DESTROYED: {TestConstants.EmptyPage}"
-            }, events);
+            }));
             await context.CloseAsync();
         }
 
@@ -97,8 +97,8 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             // Create two incognito contexts.
             var context1 = await Browser.CreateBrowserContextAsync();
             var context2 = await Browser.CreateBrowserContextAsync();
-            Assert.IsEmpty(context1.Targets());
-            Assert.IsEmpty(context2.Targets());
+            Assert.That(context1.Targets(), Is.Empty);
+            Assert.That(context2.Targets(), Is.Empty);
 
             // Create a page in first incognito context.
             var page1 = await context1.NewPageAsync();
@@ -109,7 +109,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             }");
 
             Assert.That(context1.Targets(), Has.Exactly(1).Items);
-            Assert.IsEmpty(context2.Targets());
+            Assert.That(context2.Targets(), Is.Empty);
 
             // Create a page in second incognito context.
             var page2 = await context2.NewPageAsync();
@@ -120,20 +120,20 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             }");
 
             Assert.That(context1.Targets(), Has.Exactly(1).Items);
-            Assert.AreEqual(page1, await context1.Targets()[0].PageAsync());
+            Assert.That(await context1.Targets()[0].PageAsync(), Is.EqualTo(page1));
             Assert.That(context2.Targets(), Has.Exactly(1).Items);
-            Assert.AreEqual(page2, await context2.Targets()[0].PageAsync());
+            Assert.That(await context2.Targets()[0].PageAsync(), Is.EqualTo(page2));
 
             // Make sure pages don't share localstorage or cookies.
-            Assert.AreEqual("page1", await page1.EvaluateExpressionAsync<string>("localStorage.getItem('name')"));
-            Assert.AreEqual("name=page1", await page1.EvaluateExpressionAsync<string>("document.cookie"));
-            Assert.AreEqual("page2", await page2.EvaluateExpressionAsync<string>("localStorage.getItem('name')"));
-            Assert.AreEqual("name=page2", await page2.EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await page1.EvaluateExpressionAsync<string>("localStorage.getItem('name')"), Is.EqualTo("page1"));
+            Assert.That(await page1.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("name=page1"));
+            Assert.That(await page2.EvaluateExpressionAsync<string>("localStorage.getItem('name')"), Is.EqualTo("page2"));
+            Assert.That(await page2.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("name=page2"));
 
             // Cleanup contexts.
             await Task.WhenAll(context1.CloseAsync(), context2.CloseAsync());
-            Assert.True(context1.IsClosed);
-            Assert.True(context2.IsClosed);
+            Assert.That(context1.IsClosed, Is.True);
+            Assert.That(context2.IsClosed, Is.True);
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
         }
 
@@ -142,14 +142,14 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         {
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
             var context = await Browser.CreateBrowserContextAsync();
-            Assert.AreEqual(2, Browser.BrowserContexts().Length);
+            Assert.That(Browser.BrowserContexts(), Has.Length.EqualTo(2));
 
             var remoteBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
             {
                 BrowserWSEndpoint = Browser.WebSocketEndpoint
             });
             var contexts = remoteBrowser.BrowserContexts();
-            Assert.AreEqual(2, contexts.Length);
+            Assert.That(contexts, Has.Length.EqualTo(2));
             remoteBrowser.Disconnect();
             await context.CloseAsync();
         }
@@ -158,11 +158,11 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         public async Task ShouldProvideAContextId()
         {
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
-            Assert.Null(Browser.BrowserContexts()[0].Id);
+            Assert.That(Browser.BrowserContexts()[0].Id, Is.Null);
 
             var context = await Browser.CreateBrowserContextAsync();
-            Assert.AreEqual(2, Browser.BrowserContexts().Length);
-            Assert.NotNull(Browser.BrowserContexts()[1].Id);
+            Assert.That(Browser.BrowserContexts(), Has.Length.EqualTo(2));
+            Assert.That(Browser.BrowserContexts()[1].Id, Is.Not.Null);
             await context.CloseAsync();
         }
 
@@ -175,7 +175,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await page.GoToAsync(TestConstants.EmptyPage);
             var promiseTarget = await targetPromise;
             var targetPage = await promiseTarget.PageAsync();
-            Assert.AreEqual(targetPage, page);
+            Assert.That(page, Is.EqualTo(targetPage));
             await context.CloseAsync();
         }
 

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/DefaultBrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/DefaultBrowserContextTests.cs
@@ -25,15 +25,15 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
 
             await Page.EvaluateExpressionAsync("document.cookie = 'username=John Doe'");
             var cookie = (await Page.GetCookiesAsync()).First();
-            Assert.AreEqual("username", cookie.Name);
-            Assert.AreEqual("John Doe", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(16, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("username"));
+            Assert.That(cookie.Value, Is.EqualTo("John Doe"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(16));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("defaultbrowsercontext.spec", "DefaultBrowserContext", "page.setCookie() should work")]
@@ -48,15 +48,15 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             });
 
             var cookie = (await Page.GetCookiesAsync()).First();
-            Assert.AreEqual("username", cookie.Name);
-            Assert.AreEqual("John Doe", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(16, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("username"));
+            Assert.That(cookie.Value, Is.EqualTo("John Doe"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(16));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("defaultbrowsercontext.spec", "DefaultBrowserContext", "page.deleteCookie() should work")]
@@ -76,23 +76,23 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
                     Value = "2"
                 });
 
-            Assert.AreEqual("cookie1=1; cookie2=2", await Page.EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("cookie1=1; cookie2=2"));
             await Page.DeleteCookieAsync(new CookieParam
             {
                 Name = "cookie2"
             });
-            Assert.AreEqual("cookie1=1", await Page.EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("cookie1=1"));
 
             var cookie = (await Page.GetCookiesAsync()).First();
-            Assert.AreEqual("cookie1", cookie.Name);
-            Assert.AreEqual("1", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(8, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("cookie1"));
+            Assert.That(cookie.Value, Is.EqualTo("1"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(8));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/BrowserTests/BrowserVersionTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/BrowserVersionTests.cs
@@ -10,8 +10,8 @@ namespace PuppeteerSharp.Tests.BrowserTests
         public async Task ShouldReturnVersion()
         {
             var version = await Browser.GetVersionAsync();
-            Assert.IsNotEmpty(version);
-            StringAssert.Contains(PuppeteerTestAttribute.IsChrome ? "chrome" : "firefox", version.ToLower());
+            Assert.That(version, Is.Not.Empty);
+            Assert.That(version.ToLower(), Does.Contain(PuppeteerTestAttribute.IsChrome ? "chrome" : "firefox"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/BrowserTests/IsConnectedTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/IsConnectedTests.cs
@@ -17,9 +17,9 @@ namespace PuppeteerSharp.Tests.BrowserTests
             {
                 BrowserWSEndpoint = Browser.WebSocketEndpoint
             });
-            Assert.True(newBrowser.IsConnected);
+            Assert.That(newBrowser.IsConnected, Is.True);
             newBrowser.Disconnect();
-            Assert.False(newBrowser.IsConnected);
+            Assert.That(newBrowser.IsConnected, Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/BrowserTests/ProcessTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/ProcessTests.cs
@@ -12,7 +12,7 @@ namespace PuppeteerSharp.Tests.BrowserTests
         public void ShouldReturnProcessInstance()
         {
             var process = Browser.Process;
-            Assert.True(process.Id > 0);
+            Assert.That(process.Id, Is.GreaterThan(0));
         }
 
         [Test, Retry(2), PuppeteerTest("browser.spec", "Browser.process", "should not return child_process for remote browser")]
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.BrowserTests
             var browserWSEndpoint = Browser.WebSocketEndpoint;
             var remoteBrowser = await Puppeteer.ConnectAsync(
                 new ConnectOptions { BrowserWSEndpoint = browserWSEndpoint }, TestConstants.LoggerFactory);
-            Assert.Null(remoteBrowser.Process);
+            Assert.That(remoteBrowser.Process, Is.Null);
             remoteBrowser.Disconnect();
         }
     }

--- a/lib/PuppeteerSharp.Tests/BrowserTests/TargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/TargetTests.cs
@@ -12,6 +12,6 @@ namespace PuppeteerSharp.Tests.BrowserTests
 
         [Test, Retry(2), PuppeteerTest("browser.spec", "Browser.target", "should return browser target")]
         public void ShouldReturnBrowserTarget()
-            => Assert.AreEqual(TargetType.Browser, Browser.Target.Type);
+            => Assert.That(Browser.Target.Type, Is.EqualTo(TargetType.Browser));
     }
 }

--- a/lib/PuppeteerSharp.Tests/BrowserTests/UserAgentTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/UserAgentTests.cs
@@ -14,15 +14,15 @@ namespace PuppeteerSharp.Tests.BrowserTests
         public async Task ShouldIncludeWebKit()
         {
             var userAgent = await Browser.GetUserAgentAsync();
-            Assert.IsNotEmpty(userAgent);
+            Assert.That(userAgent, Is.Not.Empty);
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("WebKit", userAgent);
+                Assert.That(userAgent, Does.Contain("WebKit"));
             }
             else
             {
-                StringAssert.Contains("Gecko", userAgent);
+                Assert.That(userAgent, Does.Contain("Gecko"));
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -62,78 +62,74 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
         [Test, Retry(2), PuppeteerTest("chrome-data.spec", "Chrome", "should resolve download URLs")]
         public void ShouldResolveDownloadUrls()
         {
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/linux64/chrome-linux64.zip",
-                BrowserData.Chrome.ResolveDownloadUrl(Platform.Linux, "113.0.5672.0", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/mac-x64/chrome-mac-x64.zip",
-                BrowserData.Chrome.ResolveDownloadUrl(Platform.MacOS, "113.0.5672.0", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/mac-arm64/chrome-mac-arm64.zip",
-                BrowserData.Chrome.ResolveDownloadUrl(Platform.MacOSArm64, "113.0.5672.0", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/win32/chrome-win32.zip",
-                BrowserData.Chrome.ResolveDownloadUrl(Platform.Win32, "113.0.5672.0", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/win64/chrome-win64.zip",
-                BrowserData.Chrome.ResolveDownloadUrl(Platform.Win64, "113.0.5672.0", null));
+            Assert.That(
+                BrowserData.Chrome.ResolveDownloadUrl(Platform.Linux, "113.0.5672.0", null),
+                Is.EqualTo("https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/linux64/chrome-linux64.zip"));
+            Assert.That(
+                BrowserData.Chrome.ResolveDownloadUrl(Platform.MacOS, "113.0.5672.0", null),
+                Is.EqualTo("https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/mac-x64/chrome-mac-x64.zip"));
+            Assert.That(
+                BrowserData.Chrome.ResolveDownloadUrl(Platform.MacOSArm64, "113.0.5672.0", null),
+                Is.EqualTo("https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/mac-arm64/chrome-mac-arm64.zip"));
+            Assert.That(
+                BrowserData.Chrome.ResolveDownloadUrl(Platform.Win32, "113.0.5672.0", null),
+                Is.EqualTo("https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/win32/chrome-win32.zip"));
+            Assert.That(
+                BrowserData.Chrome.ResolveDownloadUrl(Platform.Win64, "113.0.5672.0", null),
+                Is.EqualTo("https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/win64/chrome-win64.zip"));
         }
 
         [Test, Retry(2), PuppeteerTest("chrome-data.spec", "Chrome", "should resolve executable paths")]
         public void ShouldResolveExecutablePath()
         {
-            Assert.AreEqual(
-                Path.Combine("chrome-linux64", "chrome"),
-                BrowserData.Chrome.RelativeExecutablePath(Platform.Linux, "12372323"));
+            Assert.That(
+                BrowserData.Chrome.RelativeExecutablePath(Platform.Linux, "12372323"),
+                Is.EqualTo(Path.Combine("chrome-linux64", "chrome")));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+                BrowserData.Chrome.RelativeExecutablePath(Platform.MacOS, "12372323"),
+                Is.EqualTo(Path.Combine(
                     "chrome-mac-x64",
                     "Google Chrome for Testing.app",
                     "Contents",
                     "MacOS",
                     "Google Chrome for Testing"
-                ),
-              BrowserData.Chrome.RelativeExecutablePath(Platform.MacOS, "12372323"));
+                )));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+                BrowserData.Chrome.RelativeExecutablePath(Platform.MacOSArm64, "12372323"),
+                Is.EqualTo(Path.Combine(
                     "chrome-mac-arm64",
                     "Google Chrome for Testing.app",
                     "Contents",
                     "MacOS",
                     "Google Chrome for Testing"
-                ),
-              BrowserData.Chrome.RelativeExecutablePath(Platform.MacOSArm64, "12372323"));
+                )));
 
-            Assert.AreEqual(
-              Path.Combine("chrome-win32", "chrome.exe"),
-              BrowserData.Chrome.RelativeExecutablePath(Platform.Win32, "12372323"));
+            Assert.That(
+                BrowserData.Chrome.RelativeExecutablePath(Platform.Win32, "12372323"),
+                Is.EqualTo(Path.Combine("chrome-win32", "chrome.exe")));
 
-            Assert.AreEqual(
-              BrowserData.Chrome.RelativeExecutablePath(Platform.Win64, "12372323"),
-              Path.Combine("chrome-win64", "chrome.exe"));
+            Assert.That(
+                Path.Combine("chrome-win64", "chrome.exe"),
+                Is.EqualTo(BrowserData.Chrome.RelativeExecutablePath(Platform.Win64, "12372323")));
         }
 
         // This has a custom name
         [Test, Retry(2), PuppeteerTest("chrome-data.spec", "Chrome", "should resolve system executable path (windows)")]
         public void ShouldResolveSystemExecutablePathWindows()
         {
-            Assert.AreEqual(
-                "C:\\Program Files\\Google\\Chrome Dev\\Application\\chrome.exe",
-                BrowserData.Chrome.ResolveSystemExecutablePath(
-                    Platform.Win32,
-                    ChromeReleaseChannel.Dev));
+            Assert.That(
+                BrowserData.Chrome.ResolveSystemExecutablePath(Platform.Win32, ChromeReleaseChannel.Dev),
+                Is.EqualTo("C:\\Program Files\\Google\\Chrome Dev\\Application\\chrome.exe"));
         }
 
         [Test, Retry(2), PuppeteerTest("chrome-data.spec", "Chrome", "should resolve system executable path")]
         public void ShouldResolveSystemExecutablePath()
         {
-            Assert.AreEqual(
-                "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
-                BrowserData.Chrome.ResolveSystemExecutablePath(
-                    Platform.MacOS,
-                    ChromeReleaseChannel.Beta));
+            Assert.That(
+                BrowserData.Chrome.ResolveSystemExecutablePath(Platform.MacOS, ChromeReleaseChannel.Beta),
+                Is.EqualTo("/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta"));
 
             var ex = Assert.Throws<PuppeteerException>(() =>
             {
@@ -142,7 +138,7 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
                     ChromeReleaseChannel.Canary);
             });
 
-            Assert.AreEqual("Canary is not supported", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Canary is not supported"));
         }
 
         [Test]

--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/CliTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/CliTests.cs
@@ -32,12 +32,12 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
             };
             await fetcher.DownloadAsync(BrowserData.Chrome.DefaultBuildId);
 
-            Assert.True(new FileInfo(Path.Combine(
+            Assert.That(new FileInfo(Path.Combine(
                 _cacheDir,
                 "Chrome",
                 $"Linux-{BrowserData.Chrome.DefaultBuildId}",
                 "chrome-linux64",
-                "chrome")).Exists);
+                "chrome")).Exists, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Browsers/Chromium/ChromiumDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chromium/ChromiumDataTests.cs
@@ -11,62 +11,62 @@ namespace PuppeteerSharp.Tests.Browsers.Chromium
         [Test, Retry(2), PuppeteerTest("chromium-data.spec", "Chromium", "should resolve download URLs")]
         public void ShouldResolveDownloadUrls()
         {
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1083080/chrome-linux.zip",
-                BrowserData.Chromium.ResolveDownloadUrl(Platform.Linux, "1083080", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chromium-browser-snapshots/Mac/1083080/chrome-mac.zip",
-                BrowserData.Chromium.ResolveDownloadUrl(Platform.MacOS, "1083080", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1083080/chrome-mac.zip",
-                BrowserData.Chromium.ResolveDownloadUrl(Platform.MacOSArm64, "1083080", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chromium-browser-snapshots/Win/1083080/chrome-win.zip",
-                BrowserData.Chromium.ResolveDownloadUrl(Platform.Win32, "1083080", null));
-            Assert.AreEqual(
-                "https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1083080/chrome-win.zip",
-                BrowserData.Chromium.ResolveDownloadUrl(Platform.Win64, "1083080", null));
+            Assert.That(
+                BrowserData.Chromium.ResolveDownloadUrl(Platform.Linux, "1083080", null),
+                Is.EqualTo("https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1083080/chrome-linux.zip"));
+            Assert.That(
+                BrowserData.Chromium.ResolveDownloadUrl(Platform.MacOS, "1083080", null),
+                Is.EqualTo("https://storage.googleapis.com/chromium-browser-snapshots/Mac/1083080/chrome-mac.zip"));
+            Assert.That(
+                BrowserData.Chromium.ResolveDownloadUrl(Platform.MacOSArm64, "1083080", null),
+                Is.EqualTo("https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1083080/chrome-mac.zip"));
+            Assert.That(
+                BrowserData.Chromium.ResolveDownloadUrl(Platform.Win32, "1083080", null),
+                Is.EqualTo("https://storage.googleapis.com/chromium-browser-snapshots/Win/1083080/chrome-win.zip"));
+            Assert.That(
+                BrowserData.Chromium.ResolveDownloadUrl(Platform.Win64, "1083080", null),
+                Is.EqualTo("https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1083080/chrome-win.zip"));
         }
 
         [Test, Retry(2), PuppeteerTest("chromium-data.spec", "Chromium", "should resolve executable paths")]
         public void ShouldResolveExecutablePath()
         {
-            Assert.AreEqual(
-                Path.Combine("chrome-linux", "chrome"),
-                BrowserData.Chromium.RelativeExecutablePath(Platform.Linux, "12372323"));
+            Assert.That(
+                BrowserData.Chromium.RelativeExecutablePath(Platform.Linux, "12372323"),
+                Is.EqualTo(Path.Combine("chrome-linux", "chrome")));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+              BrowserData.Chromium.RelativeExecutablePath(Platform.MacOS, "12372323"),
+              Is.EqualTo(Path.Combine(
                     "chrome-mac",
                     "Chromium.app",
                     "Contents",
                     "MacOS",
                     "Chromium"
-                ),
-              BrowserData.Chromium.RelativeExecutablePath(Platform.MacOS, "12372323"));
+                )));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+              BrowserData.Chromium.RelativeExecutablePath(Platform.MacOSArm64, "12372323"),
+              Is.EqualTo(Path.Combine(
                     "chrome-mac",
                     "Chromium.app",
                     "Contents",
                     "MacOS",
                     "Chromium"
-                ),
-              BrowserData.Chromium.RelativeExecutablePath(Platform.MacOSArm64, "12372323"));
+                )));
 
-            Assert.AreEqual(
+            Assert.That(
+              BrowserData.Chromium.RelativeExecutablePath(Platform.Win32, "12372323"),
+              Is.EqualTo(Path.Combine("chrome-win", "chrome.exe")));
+
+            Assert.That(
               Path.Combine("chrome-win", "chrome.exe"),
-              BrowserData.Chromium.RelativeExecutablePath(Platform.Win32, "12372323"));
-
-            Assert.AreEqual(
-              BrowserData.Chromium.RelativeExecutablePath(Platform.Win64, "12372323"),
-              Path.Combine("chrome-win", "chrome.exe"));
+              Is.EqualTo(BrowserData.Chromium.RelativeExecutablePath(Platform.Win64, "12372323")));
         }
 
         [Test]
         [Retry(2)]
         public async Task ShouldResolveBuildIdFromPlatform()
-            => Assert.True(int.TryParse(await BrowserData.Chromium.ResolveBuildIdAsync(Platform.MacOSArm64), out var _));
+            => Assert.That(int.TryParse(await BrowserData.Chromium.ResolveBuildIdAsync(Platform.MacOSArm64), out var _), Is.True);
     }
 }

--- a/lib/PuppeteerSharp.Tests/Browsers/Firefox/CliTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Firefox/CliTests.cs
@@ -32,12 +32,12 @@ namespace PuppeteerSharp.Tests.Browsers.Firefox
             };
             await fetcher.DownloadAsync(BrowserData.Chrome.DefaultBuildId);
 
-            Assert.True(new FileInfo(Path.Combine(
+            Assert.That(new FileInfo(Path.Combine(
                 _cacheDir,
                 "Chrome",
                 $"Linux-{BrowserData.Chrome.DefaultBuildId}",
                 "chrome-linux64",
-                "chrome")).Exists);
+                "chrome")).Exists, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Browsers/Firefox/FirefoxDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Firefox/FirefoxDataTests.cs
@@ -9,124 +9,124 @@ namespace PuppeteerSharp.Tests.Browsers.Firefox
         [Test, Retry(2), PuppeteerTest("firefox-data.spec", "Firefox", "should resolve URLs for Nightly")]
         public void ShouldResolveUrlsForNightly()
         {
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.linux-x86_64.tar.bz2",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "111.0a1", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.mac.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "111.0a1", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.mac.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "111.0a1", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.win32.zip",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "111.0a1", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.win64.zip",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "111.0a1", null));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "111.0a1", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.linux-x86_64.tar.bz2"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "111.0a1", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.mac.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "111.0a1", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.mac.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "111.0a1", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.win32.zip"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "111.0a1", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.win64.zip"));
         }
 
         [Test, Retry(2), PuppeteerTest("firefox-data.spec", "Firefox", "should resolve URLs for beta")]
         public void ShouldResolveUrlsForBeta()
         {
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/115.0b8/linux-x86_64/en-US/firefox-115.0b8.tar.bz2",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "beta_115.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "beta_115.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "beta_115.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/115.0b8/win32/en-US/Firefox Setup 115.0b8.exe",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "beta_115.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/115.0b8/win64/en-US/Firefox Setup 115.0b8.exe",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "beta_115.0b8", null));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "beta_115.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/115.0b8/linux-x86_64/en-US/firefox-115.0b8.tar.bz2"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "beta_115.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "beta_115.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "beta_115.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/115.0b8/win32/en-US/Firefox Setup 115.0b8.exe"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "beta_115.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/115.0b8/win64/en-US/Firefox Setup 115.0b8.exe"));
         }
 
         [Test, Retry(2), PuppeteerTest("firefox-data.spec", "Firefox", "should resolve URLs for stable")]
         public void ShouldResolveUrlsForStable()
         {
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/114.0/linux-x86_64/en-US/firefox-114.0.tar.bz2",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "stable_114.0", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/114.0/mac/en-US/Firefox 114.0.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "stable_114.0", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/114.0/mac/en-US/Firefox 114.0.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "stable_114.0", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/114.0/win32/en-US/Firefox Setup 114.0.exe",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "stable_114.0", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/firefox/releases/114.0/win64/en-US/Firefox Setup 114.0.exe",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "stable_114.0", null));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "stable_114.0", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/114.0/linux-x86_64/en-US/firefox-114.0.tar.bz2"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "stable_114.0", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/114.0/mac/en-US/Firefox 114.0.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "stable_114.0", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/114.0/mac/en-US/Firefox 114.0.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "stable_114.0", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/114.0/win32/en-US/Firefox Setup 114.0.exe"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "stable_114.0", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/firefox/releases/114.0/win64/en-US/Firefox Setup 114.0.exe"));
         }
 
         [Test, Retry(2), PuppeteerTest("firefox-data.spec", "Firefox", "should resolve URLs for devedition")]
         public void ShouldResolveUrlsForDevedition()
         {
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/devedition/releases/114.0b8/linux-x86_64/en-US/firefox-114.0b8.tar.bz2",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "devedition_114.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/devedition/releases/114.0b8/mac/en-US/Firefox 114.0b8.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "devedition_114.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/devedition/releases/114.0b8/mac/en-US/Firefox 114.0b8.dmg",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "devedition_114.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/devedition/releases/114.0b8/win32/en-US/Firefox Setup 114.0b8.exe",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "devedition_114.0b8", null));
-            Assert.AreEqual(
-                "https://archive.mozilla.org/pub/devedition/releases/114.0b8/win64/en-US/Firefox Setup 114.0b8.exe",
-                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "devedition_114.0b8", null));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Linux, "devedition_114.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/devedition/releases/114.0b8/linux-x86_64/en-US/firefox-114.0b8.tar.bz2"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOS, "devedition_114.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/devedition/releases/114.0b8/mac/en-US/Firefox 114.0b8.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.MacOSArm64, "devedition_114.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/devedition/releases/114.0b8/mac/en-US/Firefox 114.0b8.dmg"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win32, "devedition_114.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/devedition/releases/114.0b8/win32/en-US/Firefox Setup 114.0b8.exe"));
+            Assert.That(
+                BrowserData.Firefox.ResolveDownloadUrl(Platform.Win64, "devedition_114.0b8", null),
+                Is.EqualTo("https://archive.mozilla.org/pub/devedition/releases/114.0b8/win64/en-US/Firefox Setup 114.0b8.exe"));
         }
 
         [Test, Retry(2), PuppeteerTest("firefox-data.spec", "Firefox", "should resolve executable paths")]
         public void ShouldResolveExecutablePath()
         {
-            Assert.AreEqual(
-                Path.Combine("firefox", "firefox"),
-                BrowserData.Firefox.RelativeExecutablePath(Platform.Linux, "111.0a1"));
+            Assert.That(
+                BrowserData.Firefox.RelativeExecutablePath(Platform.Linux, "111.0a1"),
+                Is.EqualTo(Path.Combine("firefox", "firefox")));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+              BrowserData.Firefox.RelativeExecutablePath(Platform.MacOS, "111.0a1"),
+              Is.EqualTo(Path.Combine(
                     "Firefox Nightly.app",
                     "Contents",
                     "MacOS",
                     "firefox"
-                ),
-              BrowserData.Firefox.RelativeExecutablePath(Platform.MacOS, "111.0a1"));
+                )));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+              BrowserData.Firefox.RelativeExecutablePath(Platform.MacOSArm64, "111.0a1"),
+              Is.EqualTo(Path.Combine(
                     "Firefox Nightly.app",
                     "Contents",
                     "MacOS",
                     "firefox"
-                ),
-              BrowserData.Firefox.RelativeExecutablePath(Platform.MacOSArm64, "111.0a1"));
+                )));
 
-            Assert.AreEqual(
-                Path.Combine(
+            Assert.That(
+                BrowserData.Firefox.RelativeExecutablePath(Platform.MacOSArm64, "stable_111.0a1"),
+                Is.EqualTo(Path.Combine(
                     "Firefox.app",
                     "Contents",
                     "MacOS",
                     "firefox"
-                ),
-                BrowserData.Firefox.RelativeExecutablePath(Platform.MacOSArm64, "stable_111.0a1"));
+                )));
 
-            Assert.AreEqual(
+            Assert.That(
+              BrowserData.Firefox.RelativeExecutablePath(Platform.Win32, "111.0a1"),
+              Is.EqualTo(Path.Combine("firefox", "firefox.exe")));
+
+            Assert.That(
               Path.Combine("firefox", "firefox.exe"),
-              BrowserData.Firefox.RelativeExecutablePath(Platform.Win32, "111.0a1"));
-
-            Assert.AreEqual(
-              BrowserData.Firefox.RelativeExecutablePath(Platform.Win64, "111.0a1"),
-              Path.Combine("firefox", "firefox.exe"));
+              Is.EqualTo(BrowserData.Firefox.RelativeExecutablePath(Platform.Win64, "111.0a1")));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
+++ b/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
@@ -20,7 +20,7 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
               client.SendAsync("Runtime.evaluate", new RuntimeEvaluateRequest { Expression = "window.foo = 'bar'" })
             );
             var foo = await Page.EvaluateExpressionAsync<string>("window.foo");
-            Assert.AreEqual("bar", foo);
+            Assert.That(foo, Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should send events")]
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
                 Page.EvaluateExpressionAsync("//# sourceURL=foo.js")
             );
             // expect events to be dispatched.
-            Assert.AreEqual("foo.js", eventTask.Result["url"]!.Value<string>());
+            Assert.That(eventTask.Result["url"]!.Value<string>(), Is.EqualTo("foo.js"));
         }
 
         [Test, Retry(2), PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should be able to detach session")]
@@ -71,7 +71,7 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
                 Expression = "1 + 2",
                 ReturnByValue = true
             });
-            Assert.AreEqual(3, evalResponse["result"]!["value"]!.ToObject<int>());
+            Assert.That(evalResponse["result"]!["value"]!.ToObject<int>(), Is.EqualTo(3));
             await client.DetachAsync();
 
             var exception = Assert.ThrowsAsync<TargetClosedException>(()
@@ -80,7 +80,7 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
                     Expression = "3 + 1",
                     ReturnByValue = true
                 }));
-            StringAssert.Contains("Session closed.", exception!.Message);
+            Assert.That(exception!.Message, Does.Contain("Session closed."));
         }
 
         [Test, Retry(2), PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should not report created targets for custom CDP sessions")]
@@ -112,8 +112,8 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
             {
                 await TheSourceOfTheProblems();
             });
-            StringAssert.Contains("TheSourceOfTheProblems", exception!.StackTrace);
-            StringAssert.Contains("ThisCommand.DoesNotExist", exception.Message);
+            Assert.That(exception!.StackTrace, Does.Contain("TheSourceOfTheProblems"));
+            Assert.That(exception.Message, Does.Contain("ThisCommand.DoesNotExist"));
         }
 
         [Test, Retry(2), PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should respect custom timeout")]
@@ -135,11 +135,11 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
                         Timeout = 50
                     });
             });
-            StringAssert.Contains("Timeout of 50 ms exceeded", exception!.Message);
+            Assert.That(exception!.Message, Does.Contain("Timeout of 50 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should expose the underlying connection")]
         public async Task ShouldExposeTheUnderlyingConnection()
-            => Assert.NotNull(await Page.CreateCDPSessionAsync());
+            => Assert.That(await Page.CreateCDPSessionAsync(), Is.Not.Null);
     }
 }

--- a/lib/PuppeteerSharp.Tests/ChromeLauncherTests/GetFeaturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromeLauncherTests/GetFeaturesTests.cs
@@ -11,35 +11,35 @@ namespace PuppeteerSharp.Tests.ChromeLauncherTests
         public void ReturnsAnEmptyArrayWhenNoOptionsAreProvided()
         {
             var result = ChromeLauncher.GetFeatures("--foo", Array.Empty<string>());
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "getFeatures", "returns an empty array when no options match the flag")]
         public void ReturnsAnEmptyArrayWhenNoOptionsMatchTheFlag()
         {
             var result = ChromeLauncher.GetFeatures("--foo", new[] { "--bar", "--baz" });
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "getFeatures", "returns an array of values when options match the flag")]
         public void ReturnsAnArrayOfValuesWhenOptionsMatchTheFlag()
         {
             var result = ChromeLauncher.GetFeatures("--foo", new[] { "--foo=bar", "--foo=baz" });
-            Assert.AreEqual(new[] { "bar", "baz" }, result);
+            Assert.That(result, Is.EqualTo(new[] { "bar", "baz" }));
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "getFeatures", "does not handle whitespace")]
         public void DoesNotHandleWhitespace()
         {
             var result = ChromeLauncher.GetFeatures("--foo", new[] { "--foo bar", "--foo baz " });
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "getFeatures", "handles equals sign around the flag and value")]
         public void HandlesEqualsSignAroundTheFlagAndValue()
         {
             var result = ChromeLauncher.GetFeatures("--foo", new[] { "--foo=bar", "--foo=baz" });
-            Assert.AreEqual(new[] { "bar", "baz" }, result);
+            Assert.That(result, Is.EqualTo(new[] { "bar", "baz" }));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ChromeLauncherTests/RemoveMatchingFlagsTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromeLauncherTests/RemoveMatchingFlagsTests.cs
@@ -12,7 +12,7 @@ namespace PuppeteerSharp.Tests.ChromeLauncherTests
         {
             var a = Array.Empty<string>();
             var result = ChromeLauncher.RemoveMatchingFlags(a, "--foo");
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "removeMatchingFlags", "with one match")]
@@ -20,7 +20,7 @@ namespace PuppeteerSharp.Tests.ChromeLauncherTests
         {
             var a = new[] { "--foo=1", "--bar=baz" };
             var result = ChromeLauncher.RemoveMatchingFlags(a, "--foo");
-            Assert.AreEqual(new[] { "--bar=baz" }, result);
+            Assert.That(result, Is.EqualTo(new[] { "--bar=baz" }));
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "removeMatchingFlags", "with multiple matches")]
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.ChromeLauncherTests
         {
             var a = new[] { "--foo=1", "--bar=baz", "--foo=2" };
             var result = ChromeLauncher.RemoveMatchingFlags(a, "--foo");
-            Assert.AreEqual(new[] { "--bar=baz" }, result);
+            Assert.That(result, Is.EqualTo(new[] { "--bar=baz" }));
         }
 
         [Test, Retry(2), PuppeteerTest("ChromeLauncher.test.ts", "removeMatchingFlags", "with no matches")]
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.ChromeLauncherTests
         {
             var a = new[] { "--foo=1", "--bar=baz" };
             var result = ChromeLauncher.RemoveMatchingFlags(a, "--baz");
-            Assert.AreEqual(new[] { "--foo=1", "--bar=baz" }, result);
+            Assert.That(result, Is.EqualTo(new[] { "--foo=1", "--bar=baz" }));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ChromiumOnlyTests/BrowserUrlOptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromiumOnlyTests/BrowserUrlOptionTests.cs
@@ -20,12 +20,12 @@ namespace PuppeteerSharp.Tests.ChromiumSpecificTests
 
             var browser1 = await Puppeteer.ConnectAsync(new ConnectOptions { BrowserURL = browserURL });
             var page1 = await browser1.NewPageAsync();
-            Assert.AreEqual(56, await page1.EvaluateExpressionAsync<int>("7 * 8"));
+            Assert.That(await page1.EvaluateExpressionAsync<int>("7 * 8"), Is.EqualTo(56));
             browser1.Disconnect();
 
             var browser2 = await Puppeteer.ConnectAsync(new ConnectOptions { BrowserURL = browserURL + "/" });
             var page2 = await browser2.NewPageAsync();
-            Assert.AreEqual(56, await page2.EvaluateExpressionAsync<int>("7 * 8"));
+            Assert.That(await page2.EvaluateExpressionAsync<int>("7 * 8"), Is.EqualTo(56));
             browser2.Disconnect();
             await originalBrowser.CloseAsync();
         }

--- a/lib/PuppeteerSharp.Tests/ChromiumOnlyTests/PageTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromiumOnlyTests/PageTests.cs
@@ -33,7 +33,7 @@ namespace PuppeteerSharp.Tests.ChromiumSpecificTests
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/intervention");
 
-            StringAssert.Contains("feature/5718547946799104", interventionHeader);
+            Assert.That(interventionHeader, Does.Contain("feature/5718547946799104"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ClickTests/ClickTests.cs
+++ b/lib/PuppeteerSharp.Tests/ClickTests/ClickTests.cs
@@ -13,7 +13,7 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/button.html");
             await Page.ClickAsync("button");
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click svg")]
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.ClickTests
                 </svg>
             ");
             await Page.ClickAsync("circle");
-            Assert.AreEqual(42, await Page.EvaluateFunctionAsync<int>("() => window.__CLICKED"));
+            Assert.That(await Page.EvaluateFunctionAsync<int>("() => window.__CLICKED"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click the button if window.Node is removed")]
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.ClickTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/button.html");
             await Page.EvaluateExpressionAsync("delete window.Node");
             await Page.ClickAsync("button");
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click on a span with an inline element inside")]
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.ClickTests
                 <span onclick='javascript:window.CLICKED=42'></span>
             ");
             await Page.ClickAsync("span");
-            Assert.AreEqual(42, await Page.EvaluateFunctionAsync<int>("() => window.CLICKED"));
+            Assert.That(await Page.EvaluateFunctionAsync<int>("() => window.CLICKED"), Is.EqualTo(42));
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace PuppeteerSharp.Tests.ClickTests
             await Page.ClickAsync("button");
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/button.html");
             await Page.ClickAsync("button");
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click with disabled javascript")]
@@ -85,7 +85,7 @@ namespace PuppeteerSharp.Tests.ClickTests
                 Page.ClickAsync("a"),
                 Page.WaitForNavigationAsync()
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/wrappedlink.html#clicked", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/wrappedlink.html#clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should scroll and click with disabled javascript")]
@@ -99,7 +99,7 @@ namespace PuppeteerSharp.Tests.ClickTests
                 Page.ClickAsync("a"),
                 Page.WaitForNavigationAsync()
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/wrappedlink.html#clicked", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/wrappedlink.html#clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click when one of inline box children is outside of viewport")]
@@ -116,7 +116,7 @@ namespace PuppeteerSharp.Tests.ClickTests
             ");
 
             await Page.ClickAsync("span");
-            Assert.AreEqual(42, await Page.EvaluateFunctionAsync<int>("() => window.CLICKED"));
+            Assert.That(await Page.EvaluateFunctionAsync<int>("() => window.CLICKED"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should select the text by triple clicking")]
@@ -129,13 +129,13 @@ namespace PuppeteerSharp.Tests.ClickTests
             await Page.ClickAsync("textarea");
             await Page.ClickAsync("textarea", new ClickOptions { Count = 2 });
             await Page.ClickAsync("textarea", new ClickOptions { Count = 3 });
-            Assert.AreEqual(text, await Page.EvaluateFunctionAsync<string>(@"() => {
+            Assert.That(await Page.EvaluateFunctionAsync<string>(@"() => {
                 const textarea = document.querySelector('textarea');
                 return textarea.value.substring(
                     textarea.selectionStart,
                     textarea.selectionEnd
                 );
-            }"));
+            }"), Is.EqualTo(text));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click offscreen buttons")]
@@ -155,7 +155,7 @@ namespace PuppeteerSharp.Tests.ClickTests
             // It seems that the console event is coming a little bit late
             await Task.Delay(500);
 
-            Assert.AreEqual(new List<string>
+            Assert.That(messages, Is.EqualTo(new List<string>
             {
                 "button #0 clicked",
                 "button #1 clicked",
@@ -168,7 +168,7 @@ namespace PuppeteerSharp.Tests.ClickTests
                 "button #8 clicked",
                 "button #9 clicked",
                 "button #10 clicked"
-            }, messages);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click wrapped links")]
@@ -176,44 +176,46 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/wrappedlink.html");
             await Page.ClickAsync("a");
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("window.__clicked"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.__clicked"), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click on checkbox input and toggle")]
         public async Task ShouldClickOnCheckboxInputAndToggle()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/checkbox.html");
-            Assert.Null(await Page.EvaluateExpressionAsync("result.check"));
+            Assert.That(await Page.EvaluateExpressionAsync("result.check"), Is.Null);
             await Page.ClickAsync("input#agree");
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("result.check"));
-            Assert.AreEqual(new[] {
-                "mouseover",
-                "mouseenter",
-                "mousemove",
-                "mousedown",
-                "mouseup",
-                "click",
-                "input",
-                "change"
-            }, await Page.EvaluateExpressionAsync<string[]>("result.events"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("result.check"), Is.True);
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.events"),
+                Is.EqualTo(new[] {
+                    "mouseover",
+                    "mouseenter",
+                    "mousemove",
+                    "mousedown",
+                    "mouseup",
+                    "click",
+                    "input",
+                    "change"
+            }));
             await Page.ClickAsync("input#agree");
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("result.check"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("result.check"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click on checkbox label and toggle")]
         public async Task ShouldClickOnCheckboxLabelAndToggle()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/checkbox.html");
-            Assert.Null(await Page.EvaluateExpressionAsync("result.check"));
+            Assert.That(await Page.EvaluateExpressionAsync("result.check"), Is.Null);
             await Page.ClickAsync("label[for=\"agree\"]");
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("result.check"));
-            Assert.AreEqual(new[] {
-                "click",
-                "input",
-                "change"
-            }, await Page.EvaluateExpressionAsync<string[]>("result.events"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("result.check"), Is.True);
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.events"),
+                Is.EqualTo(new[] {
+                    "click",
+                    "input",
+                    "change"
+            }));
             await Page.ClickAsync("label[for=\"agree\"]");
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("result.check"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("result.check"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should fail to click a missing button")]
@@ -222,8 +224,8 @@ namespace PuppeteerSharp.Tests.ClickTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/button.html");
             var exception = Assert.ThrowsAsync<SelectorException>(()
                 => Page.ClickAsync("button.does-not-exist"));
-            Assert.AreEqual("No node found for selector: button.does-not-exist", exception.Message);
-            Assert.AreEqual("button.does-not-exist", exception.Selector);
+            Assert.That(exception.Message, Is.EqualTo("No node found for selector: button.does-not-exist"));
+            Assert.That(exception.Selector, Is.EqualTo("button.does-not-exist"));
         }
 
         // https://github.com/GoogleChrome/puppeteer/issues/161
@@ -241,9 +243,9 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.ClickAsync("#button-5");
-            Assert.AreEqual("clicked", await Page.EvaluateExpressionAsync<string>("document.querySelector(\"#button-5\").textContent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector(\"#button-5\").textContent"), Is.EqualTo("clicked"));
             await Page.ClickAsync("#button-80");
-            Assert.AreEqual("clicked", await Page.EvaluateExpressionAsync<string>("document.querySelector(\"#button-80\").textContent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector(\"#button-80\").textContent"), Is.EqualTo("clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should double click the button")]
@@ -259,8 +261,8 @@ namespace PuppeteerSharp.Tests.ClickTests
             }");
             var button = await Page.QuerySelectorAsync("button");
             await button.ClickAsync(new ClickOptions { Count = 2 });
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("double"));
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("double"), Is.True);
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click a partially obscured button")]
@@ -274,7 +276,7 @@ namespace PuppeteerSharp.Tests.ClickTests
                 button.style.left = '368px';
             }");
             await Page.ClickAsync("button");
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click a rotated button")]
@@ -282,7 +284,7 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/rotatedButton.html");
             await Page.ClickAsync("button");
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should fire contextmenu event on right click")]
@@ -290,7 +292,7 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.ClickAsync("#button-8", new ClickOptions { Button = MouseButton.Right });
-            Assert.AreEqual("context menu", await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"), Is.EqualTo("context menu"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should fire aux event on middle click")]
@@ -298,7 +300,7 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.ClickAsync("#button-8", new ClickOptions { Button = MouseButton.Middle });
-            Assert.AreEqual("aux click", await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"), Is.EqualTo("aux click"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should fire back click")]
@@ -306,7 +308,7 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.ClickAsync("#button-8", new ClickOptions { Button = MouseButton.Back });
-            Assert.AreEqual("back click", await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"), Is.EqualTo("back click"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should fire forward click")]
@@ -314,7 +316,7 @@ namespace PuppeteerSharp.Tests.ClickTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.ClickAsync("#button-8", new ClickOptions { Button = MouseButton.Forward });
-            Assert.AreEqual("forward click", await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('#button-8').textContent"), Is.EqualTo("forward click"));
         }
 
         // @see https://github.com/GoogleChrome/puppeteer/issues/206
@@ -335,7 +337,7 @@ namespace PuppeteerSharp.Tests.ClickTests
             var frame = Page.FirstChildFrame();
             var button = await frame.QuerySelectorAsync("button");
             await button.ClickAsync();
-            Assert.AreEqual("Clicked", await frame.EvaluateExpressionAsync<string>("window.result"));
+            Assert.That(await frame.EvaluateExpressionAsync<string>("window.result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click the button with fixed position inside an iframe")]
@@ -353,20 +355,20 @@ namespace PuppeteerSharp.Tests.ClickTests
             var frame = Page.FirstChildFrame();
             await frame.QuerySelectorAsync("button").EvaluateFunctionAsync("button => button.style.setProperty('position', 'fixed')");
             await frame.ClickAsync("button");
-            Assert.AreEqual("Clicked", await frame.EvaluateExpressionAsync<string>("window.result"));
+            Assert.That(await frame.EvaluateExpressionAsync<string>("window.result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("click.spec", "Page.click", "should click the button with deviceScaleFactor set")]
         public async Task ShouldClickTheButtonWithDeviceScaleFactorSet()
         {
             await Page.SetViewportAsync(new ViewPortOptions { Width = 400, Height = 400, DeviceScaleFactor = 5 });
-            Assert.AreEqual(5, await Page.EvaluateExpressionAsync<int>("window.devicePixelRatio"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.devicePixelRatio"), Is.EqualTo(5));
             await Page.SetContentAsync("<div style=\"width:100px;height:100px\">spacer</div>");
             await FrameUtils.AttachFrameAsync(Page, "button-test", TestConstants.ServerUrl + "/input/button.html");
             var frame = Page.FirstChildFrame();
             var button = await frame.QuerySelectorAsync("button");
             await button.ClickAsync();
-            Assert.AreEqual("Clicked", await frame.EvaluateExpressionAsync<string>("window.result"));
+            Assert.That(await frame.EvaluateExpressionAsync<string>("window.result"), Is.EqualTo("Clicked"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CookiesTests/CookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/CookiesTests.cs
@@ -11,28 +11,28 @@ namespace PuppeteerSharp.Tests.CookiesTests
         public async Task ShouldReturnNoCookiesInPristineBrowserContext()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.IsEmpty(await Page.GetCookiesAsync());
+            Assert.That(await Page.GetCookiesAsync(), Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should get a cookie")]
         public async Task ShouldGetACookie()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.IsEmpty(await Page.GetCookiesAsync());
+            Assert.That(await Page.GetCookiesAsync(), Is.Empty);
 
             await Page.EvaluateExpressionAsync("document.cookie = 'username=John Doe'");
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("username", cookie.Name);
-            Assert.AreEqual("John Doe", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(16, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("username"));
+            Assert.That(cookie.Value, Is.EqualTo("John Doe"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(16));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should properly report httpOnly cookie")]
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
-            Assert.True(cookies[0].HttpOnly);
+            Assert.That(cookies[0].HttpOnly, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should properly report \"Strict\" sameSite cookie")]
@@ -60,7 +60,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
-            Assert.AreEqual(SameSite.Strict, cookies[0].SameSite);
+            Assert.That(cookies[0].SameSite, Is.EqualTo(SameSite.Strict));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should properly report \"Lax\" sameSite cookie")]
@@ -74,14 +74,14 @@ namespace PuppeteerSharp.Tests.CookiesTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
-            Assert.AreEqual(SameSite.Lax, cookies[0].SameSite);
+            Assert.That(cookies[0].SameSite, Is.EqualTo(SameSite.Lax));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should get multiple cookies")]
         public async Task ShouldGetMultipleCookies()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.IsEmpty(await Page.GetCookiesAsync());
+            Assert.That(await Page.GetCookiesAsync(), Is.Empty);
 
             await Page.EvaluateFunctionAsync(@"() => {
                 document.cookie = 'username=John Doe';
@@ -91,26 +91,26 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = (await Page.GetCookiesAsync()).OrderBy(c => c.Name).ToList();
 
             var cookie = cookies[0];
-            Assert.AreEqual("password", cookie.Name);
-            Assert.AreEqual("1234", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(12, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("password"));
+            Assert.That(cookie.Value, Is.EqualTo("1234"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(12));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
 
             cookie = cookies[1];
-            Assert.AreEqual("username", cookie.Name);
-            Assert.AreEqual("John Doe", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(16, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("username"));
+            Assert.That(cookie.Value, Is.EqualTo("John Doe"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(16));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should get cookies from multiple urls")]
@@ -138,29 +138,29 @@ namespace PuppeteerSharp.Tests.CookiesTests
             );
             var cookies = (await Page.GetCookiesAsync("https://foo.com", "https://baz.com")).OrderBy(c => c.Name).ToList();
 
-            Assert.AreEqual(2, cookies.Count);
+            Assert.That(cookies, Has.Count.EqualTo(2));
 
             var cookie = cookies[0];
-            Assert.AreEqual("birdo", cookie.Name);
-            Assert.AreEqual("tweets", cookie.Value);
-            Assert.AreEqual("baz.com", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(11, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.True(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("birdo"));
+            Assert.That(cookie.Value, Is.EqualTo("tweets"));
+            Assert.That(cookie.Domain, Is.EqualTo("baz.com"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(11));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.True);
+            Assert.That(cookie.Session, Is.True);
 
             cookie = cookies[1];
-            Assert.AreEqual("doggo", cookie.Name);
-            Assert.AreEqual("woofs", cookie.Value);
-            Assert.AreEqual("foo.com", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(10, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.True(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("doggo"));
+            Assert.That(cookie.Value, Is.EqualTo("woofs"));
+            Assert.That(cookie.Domain, Is.EqualTo("foo.com"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(10));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.True);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should not get cookies from subdomain")]
@@ -172,7 +172,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Name = "doggo",
                 Value = "woofs"
             });
-            Assert.IsEmpty(await Page.GetCookiesAsync("https://sub_domain.base_domain.com"));
+            Assert.That(await Page.GetCookiesAsync("https://sub_domain.base_domain.com"), Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.cookies", "should get cookies from nested path")]
@@ -202,7 +202,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Value = "woofs"
             });
 
-            Assert.IsEmpty(await Page.GetCookiesAsync("https://foo.com/some_path_looks_like_nested"));
+            Assert.That(await Page.GetCookiesAsync("https://foo.com/some_path_looks_like_nested"), Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CookiesTests/DeleteCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/DeleteCookiesTests.cs
@@ -23,9 +23,9 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Name = "cookie3",
                 Value = "3"
             });
-            Assert.AreEqual("cookie1=1; cookie2=2; cookie3=3", await Page.EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("cookie1=1; cookie2=2; cookie3=3"));
             await Page.DeleteCookieAsync(new CookieParam { Name = "cookie2" });
-            Assert.AreEqual("cookie1=1; cookie3=3", await Page.EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("cookie1=1; cookie3=3"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -21,7 +20,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Name = "password",
                 Value = "123456"
             });
-            Assert.AreEqual("password=123456", await Page.EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("password=123456"));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should isolate cookies in browser contexts")]
@@ -50,10 +49,10 @@ namespace PuppeteerSharp.Tests.CookiesTests
 
             Assert.That(cookies1, Has.Exactly(1).Items);
             Assert.That(cookies2, Has.Exactly(1).Items);
-            Assert.AreEqual("page1cookie", cookies1[0].Name);
-            Assert.AreEqual("page1value", cookies1[0].Value);
-            Assert.AreEqual("page2cookie", cookies2[0].Name);
-            Assert.AreEqual("page2value", cookies2[0].Value);
+            Assert.That(cookies1[0].Name, Is.EqualTo("page1cookie"));
+            Assert.That(cookies1[0].Value, Is.EqualTo("page1value"));
+            Assert.That(cookies2[0].Name, Is.EqualTo("page2cookie"));
+            Assert.That(cookies2[0].Value, Is.EqualTo("page2value"));
 
             await anotherContext.CloseAsync();
         }
@@ -76,17 +75,16 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 }
             );
 
-            Assert.AreEqual(
-                new[]
-                {
-                    "foo=bar",
-                    "password=123456"
-                },
+            Assert.That(
                 await Page.EvaluateFunctionAsync<string[]>(@"() => {
                     const cookies = document.cookie.split(';');
                     return cookies.map(cookie => cookie.trim()).sort();
                 }")
-            );
+, Is.EqualTo(new[]
+                {
+                    "foo=bar",
+                    "password=123456"
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should have |expires| set to |-1| for session cookies")]
@@ -102,8 +100,8 @@ namespace PuppeteerSharp.Tests.CookiesTests
 
             var cookies = await Page.GetCookiesAsync();
 
-            Assert.True(cookies[0].Session);
-            Assert.AreEqual(-1, cookies[0].Expires);
+            Assert.That(cookies[0].Session, Is.True);
+            Assert.That(cookies[0].Expires, Is.EqualTo(-1));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set cookie with reasonable defaults")]
@@ -120,15 +118,15 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("password", cookie.Name);
-            Assert.AreEqual("123456", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(14, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("password"));
+            Assert.That(cookie.Value, Is.EqualTo("123456"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(14));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set cookie with all available properties")]
@@ -152,16 +150,16 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("password", cookie.Name);
-            Assert.AreEqual("123456", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(-1, cookie.Expires);
-            Assert.AreEqual(14, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
-            Assert.AreEqual(CookieSourceScheme.Unset, cookie.SourceScheme);
+            Assert.That(cookie.Name, Is.EqualTo("password"));
+            Assert.That(cookie.Value, Is.EqualTo("123456"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(14));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
+            Assert.That(cookie.SourceScheme, Is.EqualTo(CookieSourceScheme.Unset));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set a cookie with a path")]
@@ -177,15 +175,15 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("gridcookie", cookie.Name);
-            Assert.AreEqual("GRID", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/grid.html", cookie.Path);
-            Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(14, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("gridcookie"));
+            Assert.That(cookie.Value, Is.EqualTo("GRID"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/grid.html"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(14));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should not set a cookie on a blank page")]
@@ -194,7 +192,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             await Page.GoToAsync(TestConstants.AboutBlank);
 
             var exception = Assert.ThrowsAsync<MessageException>(async () => await Page.SetCookieAsync(new CookieParam { Name = "example-cookie", Value = "best" }));
-            StringAssert.Contains("At least one of the url and domain needs to be specified", exception.Message);
+            Assert.That(exception.Message, Does.Contain("At least one of the url and domain needs to be specified"));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should not set a cookie with blank page URL")]
@@ -212,7 +210,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Name = "example-cookie-blank",
                 Value = "best"
             }));
-            Assert.AreEqual("Blank page can not have cookie \"example-cookie-blank\"", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Blank page can not have cookie \"example-cookie-blank\""));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should not set a cookie on a data URL page")]
@@ -221,7 +219,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             await Page.GoToAsync("data:,Hello%2C%20World!");
             var exception = Assert.ThrowsAsync<MessageException>(async () => await Page.SetCookieAsync(new CookieParam { Name = "example-cookie", Value = "best" }));
 
-            StringAssert.Contains("At least one of the url and domain needs to be specified", exception.Message);
+            Assert.That(exception.Message, Does.Contain("At least one of the url and domain needs to be specified"));
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should default to setting secure cookie for HTTPS websites")]
@@ -240,7 +238,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = await Page.GetCookiesAsync(SecureUrl);
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.True(cookie.Secure);
+            Assert.That(cookie.Secure, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should be able to set insecure cookie for HTTP website")]
@@ -259,7 +257,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = await Page.GetCookiesAsync(SecureUrl);
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.False(cookie.Secure);
+            Assert.That(cookie.Secure, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should be able to set unsecure cookie for HTTP website")]
@@ -277,7 +275,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
             var cookies = await Page.GetCookiesAsync(SecureUrl);
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.False(cookie.Secure);
+            Assert.That(cookie.Secure, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set a cookie on a different domain")]
@@ -285,20 +283,20 @@ namespace PuppeteerSharp.Tests.CookiesTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             await Page.SetCookieAsync(new CookieParam { Name = "example-cookie", Value = "best", Url = "https://www.example.com" });
-            Assert.AreEqual(string.Empty, await Page.EvaluateExpressionAsync<string>("document.cookie"));
-            Assert.IsEmpty(await Page.GetCookiesAsync());
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo(string.Empty));
+            Assert.That(await Page.GetCookiesAsync(), Is.Empty);
             var cookies = await Page.GetCookiesAsync("https://www.example.com");
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("example-cookie", cookie.Name);
-            Assert.AreEqual("best", cookie.Value);
-            Assert.AreEqual("www.example.com", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(18, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.True(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("example-cookie"));
+            Assert.That(cookie.Value, Is.EqualTo("best"));
+            Assert.That(cookie.Domain, Is.EqualTo("www.example.com"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(18));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.True);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set cookies from a frame")]
@@ -316,33 +314,33 @@ namespace PuppeteerSharp.Tests.CookiesTests
                     return promise;
                 }", TestConstants.CrossProcessHttpPrefix);
             await Page.SetCookieAsync(new CookieParam { Name = "127-cookie", Value = "worst", Url = TestConstants.CrossProcessHttpPrefix });
-            Assert.AreEqual("localhost-cookie=best", await Page.EvaluateExpressionAsync<string>("document.cookie"));
-            Assert.AreEqual(string.Empty, await Page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("localhost-cookie=best"));
+            Assert.That(await Page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo(string.Empty));
             var cookies = await Page.GetCookiesAsync();
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("localhost-cookie", cookie.Name);
-            Assert.AreEqual("best", cookie.Value);
-            Assert.AreEqual("localhost", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(20, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("localhost-cookie"));
+            Assert.That(cookie.Value, Is.EqualTo("best"));
+            Assert.That(cookie.Domain, Is.EqualTo("localhost"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(20));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
 
             cookies = await Page.GetCookiesAsync(TestConstants.CrossProcessHttpPrefix);
             Assert.That(cookies, Has.Exactly(1).Items);
             cookie = cookies.First();
-            Assert.AreEqual("127-cookie", cookie.Name);
-            Assert.AreEqual("worst", cookie.Value);
-            Assert.AreEqual("127.0.0.1", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(15, cookie.Size);
-            Assert.False(cookie.HttpOnly);
-            Assert.False(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.Name, Is.EqualTo("127-cookie"));
+            Assert.That(cookie.Value, Is.EqualTo("worst"));
+            Assert.That(cookie.Domain, Is.EqualTo("127.0.0.1"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(15));
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.False);
+            Assert.That(cookie.Session, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set secure same-site cookies from a frame")]
@@ -371,25 +369,25 @@ namespace PuppeteerSharp.Tests.CookiesTests
                     Url = TestConstants.CrossProcessHttpsPrefix + "/grid.html",
                     SameSite = SameSite.None,
                 });
-            Assert.AreEqual("127-cookie=best", await page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.That(await page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("127-cookie=best"));
             var cookies = await page.GetCookiesAsync(TestConstants.CrossProcessHttpsPrefix + "/grid.html");
             Assert.That(cookies, Has.Exactly(1).Items);
             var cookie = cookies.First();
-            Assert.AreEqual("127-cookie", cookie.Name);
-            Assert.AreEqual("best", cookie.Value);
-            Assert.AreEqual("127.0.0.1", cookie.Domain);
-            Assert.AreEqual("/", cookie.Path);
-            Assert.AreEqual(cookie.Expires, -1);
-            Assert.AreEqual(14, cookie.Size);
+            Assert.That(cookie.Name, Is.EqualTo("127-cookie"));
+            Assert.That(cookie.Value, Is.EqualTo("best"));
+            Assert.That(cookie.Domain, Is.EqualTo("127.0.0.1"));
+            Assert.That(cookie.Path, Is.EqualTo("/"));
+            Assert.That(cookie.Expires, Is.EqualTo(-1));
+            Assert.That(cookie.Size, Is.EqualTo(14));
 
             // Puppeteer uses expectCookieEquals which excludes SameSite attribute
             if (TestConstants.IsChrome)
             {
-                Assert.AreEqual(SameSite.None, cookie.SameSite);
+                Assert.That(cookie.SameSite, Is.EqualTo(SameSite.None));
             }
-            Assert.False(cookie.HttpOnly);
-            Assert.True(cookie.Secure);
-            Assert.True(cookie.Session);
+            Assert.That(cookie.HttpOnly, Is.False);
+            Assert.That(cookie.Secure, Is.True);
+            Assert.That(cookie.Session, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CoverageTests/CSSCoverageTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/CSSCoverageTests.cs
@@ -22,17 +22,17 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/csscoverage/simple.html");
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
-            StringAssert.Contains("/csscoverage/simple.html", coverage[0].Url);
-            Assert.AreEqual(new CoverageEntryRange[]
+            Assert.That(coverage[0].Url, Does.Contain("/csscoverage/simple.html"));
+            Assert.That(coverage[0].Ranges, Is.EqualTo(new CoverageEntryRange[]
             {
                 new CoverageEntryRange
                 {
                     Start = 1,
                     End = 22
                 }
-            }, coverage[0].Ranges);
+            }));
             var range = coverage[0].Ranges[0];
-            Assert.AreEqual("div { color: green; }", coverage[0].Text.Substring(range.Start, range.End - range.Start));
+            Assert.That(coverage[0].Text.Substring(range.Start, range.End - range.Start), Is.EqualTo("div { color: green; }"));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should report sourceURLs")]
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Task.Delay(1000);
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
-            Assert.AreEqual("nicename.css", coverage[0].Url);
+            Assert.That(coverage[0].Url, Is.EqualTo("nicename.css"));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should report multiple stylesheets")]
@@ -53,10 +53,10 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.Coverage.StartCSSCoverageAsync();
             await Page.GoToAsync(TestConstants.ServerUrl + "/csscoverage/multiple.html");
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
-            Assert.AreEqual(2, coverage.Length);
+            Assert.That(coverage, Has.Length.EqualTo(2));
             var orderedList = coverage.OrderBy(c => c.Url);
-            StringAssert.Contains("/csscoverage/stylesheet1.css", orderedList.ElementAt(0).Url);
-            StringAssert.Contains("/csscoverage/stylesheet2.css", orderedList.ElementAt(1).Url);
+            Assert.That(orderedList.ElementAt(0).Url, Does.Contain("/csscoverage/stylesheet1.css"));
+            Assert.That(orderedList.ElementAt(1).Url, Does.Contain("/csscoverage/stylesheet2.css"));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should report stylesheets that have no coverage")]
@@ -67,8 +67,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
             var entry = coverage[0];
-            StringAssert.Contains("unused.css", entry.Url);
-            Assert.IsEmpty(entry.Ranges);
+            Assert.That(entry.Url, Does.Contain("unused.css"));
+            Assert.That(entry.Ranges, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should work with media queries")]
@@ -79,8 +79,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
             var entry = coverage[0];
-            StringAssert.Contains("/csscoverage/media.html", entry.Url);
-            Assert.AreEqual(new CoverageEntryRange[]
+            Assert.That(entry.Url, Does.Contain("/csscoverage/media.html"));
+            Assert.That(coverage[0].Ranges, Is.EqualTo(new CoverageEntryRange[]
             {
                 new CoverageEntryRange
                 {
@@ -92,7 +92,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
                     Start = 17,
                     End = 38
                 }
-            }, coverage[0].Ranges);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should work with complicated usecases")]
@@ -121,9 +121,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.Coverage.StartCSSCoverageAsync();
             await Page.GoToAsync(TestConstants.ServerUrl + "/csscoverage/involved.html");
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
-            Assert.AreEqual(
-                TestUtils.CompressText(involved),
-                Regex.Replace(TestUtils.CompressText(JsonConvert.SerializeObject(coverage)), @":\d{4}\/", ":<PORT>/"));
+            Assert.That(Regex.Replace(TestUtils.CompressText(JsonConvert.SerializeObject(coverage)), @":\d{4}\/", ":<PORT>/"),
+                Is.EqualTo(TestUtils.CompressText(involved)));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should ignore injected stylesheets")]
@@ -136,9 +135,9 @@ namespace PuppeteerSharp.Tests.CoverageTests
             });
             // trigger style recalc
             var margin = await Page.EvaluateExpressionAsync<string>("window.getComputedStyle(document.body).margin");
-            Assert.AreEqual("10px", margin);
+            Assert.That(margin, Is.EqualTo("10px"));
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
-            Assert.IsEmpty(coverage);
+            Assert.That(coverage, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should work with a recently loaded stylesheet")]

--- a/lib/PuppeteerSharp.Tests/CoverageTests/CSSResetOnNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/CSSResetOnNavigationTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.CSSCoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/csscoverage/multiple.html");
             await Page.GoToAsync(TestConstants.EmptyPage);
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
-            Assert.AreEqual(2, coverage.Length);
+            Assert.That(coverage, Has.Length.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs resetOnNavigation", "should NOT report scripts across navigations")]
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.CSSCoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/csscoverage/multiple.html");
             await Page.GoToAsync(TestConstants.EmptyPage);
             var coverage = await Page.Coverage.StopCSSCoverageAsync();
-            Assert.IsEmpty(coverage);
+            Assert.That(coverage, Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CoverageTests/IncludeRawScriptCoverageTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/IncludeRawScriptCoverageTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/jscoverage/simple.html", WaitUntilNavigation.Networkidle0);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
-            Assert.IsNull(coverage[0].RawScriptCoverage);
+            Assert.That(coverage[0].RawScriptCoverage, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage includeRawScriptCoverage", "should include rawScriptCoverage field when enabled")]
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/jscoverage/simple.html", WaitUntilNavigation.Networkidle0);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
-            Assert.IsNotNull(coverage[0].RawScriptCoverage);
+            Assert.That(coverage[0].RawScriptCoverage, Is.Not.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CoverageTests/JSCoverageTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/JSCoverageTests.cs
@@ -18,8 +18,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/jscoverage/simple.html", WaitUntilNavigation.Networkidle0);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
-            StringAssert.Contains("/jscoverage/simple.html", coverage[0].Url);
-            Assert.AreEqual(new CoverageEntryRange[]
+            Assert.That(coverage[0].Url, Does.Contain("/jscoverage/simple.html"));
+            Assert.That(coverage[0].Ranges, Is.EqualTo(new CoverageEntryRange[]
             {
                 new CoverageEntryRange
                 {
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
                     Start = 35,
                     End = 61
                 },
-            }, coverage[0].Ranges);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should report sourceURLs")]
@@ -43,7 +43,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Task.Delay(1000);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
-            Assert.AreEqual("nicename.js", coverage[0].Url);
+            Assert.That(coverage[0].Url, Is.EqualTo("nicename.js"));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should ignore eval() scripts by default")]
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Task.Delay(1000);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             var filtered = coverage.Where(entry => !entry.Url.StartsWith("debugger://"));
-            Assert.AreEqual(1, filtered.Count());
+            Assert.That(filtered.Count(), Is.EqualTo(1));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should ignore pptr internal scripts if reportAnonymousScripts is true")]
@@ -83,7 +83,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.EvaluateExpressionAsync("console.log('foo')");
             await Page.EvaluateFunctionAsync("() => console.log('bar')");
             var coverage = await Page.Coverage.StopJSCoverageAsync();
-            Assert.IsEmpty(coverage);
+            Assert.That(coverage, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should report multiple scripts")]
@@ -94,10 +94,10 @@ namespace PuppeteerSharp.Tests.CoverageTests
             // Prevent flaky tests.
             await Task.Delay(1000);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
-            Assert.AreEqual(2, coverage.Length);
+            Assert.That(coverage, Has.Length.EqualTo(2));
             var orderedList = coverage.OrderBy(c => c.Url);
-            StringAssert.Contains("/jscoverage/script1.js", orderedList.ElementAt(0).Url);
-            StringAssert.Contains("/jscoverage/script2.js", orderedList.ElementAt(1).Url);
+            Assert.That(orderedList.ElementAt(0).Url, Does.Contain("/jscoverage/script1.js"));
+            Assert.That(orderedList.ElementAt(1).Url, Does.Contain("/jscoverage/script2.js"));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should report right ranges")]
@@ -112,7 +112,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             var entry = coverage[0];
             Assert.That(entry.Ranges, Has.Exactly(1).Items);
             var range = entry.Ranges[0];
-            Assert.AreEqual("console.log('used!');", entry.Text.Substring(range.Start, range.End - range.Start));
+            Assert.That(entry.Text.Substring(range.Start, range.End - range.Start), Is.EqualTo("console.log('used!');"));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should report scripts that have no coverage")]
@@ -125,8 +125,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
             var coverage = await Page.Coverage.StopJSCoverageAsync();
             Assert.That(coverage, Has.Exactly(1).Items);
             var entry = coverage[0];
-            StringAssert.Contains("unused.html", entry.Url);
-            Assert.IsEmpty(entry.Ranges);
+            Assert.That(entry.Url, Does.Contain("unused.html"));
+            Assert.That(entry.Ranges, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should work with conditionals")]
@@ -166,9 +166,8 @@ namespace PuppeteerSharp.Tests.CoverageTests
             // Give the coverage some time.
             await Task.Delay(1000);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
-            Assert.AreEqual(
-                TestUtils.CompressText(involved),
-                Regex.Replace(TestUtils.CompressText(JsonConvert.SerializeObject(coverage)), @"\d{4}\/", "<PORT>/"));
+            Assert.That(Regex.Replace(TestUtils.CompressText(JsonConvert.SerializeObject(coverage)), @"\d{4}\/", "<PORT>/"),
+                Is.EqualTo(TestUtils.CompressText(involved)));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs JSCoverage", "should not hang when there is a debugger statement")]

--- a/lib/PuppeteerSharp.Tests/CoverageTests/JSResetOnNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/JSResetOnNavigationTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/jscoverage/multiple.html");
             await Page.GoToAsync(TestConstants.EmptyPage);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
-            Assert.AreEqual(2, coverage.Length);
+            Assert.That(coverage, Has.Length.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("coverage.spec", "Coverage specs resetOnNavigation", "should NOT report scripts across navigations when enabled")]
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Tests.CoverageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/jscoverage/multiple.html");
             await Page.GoToAsync(TestConstants.EmptyPage);
             var coverage = await Page.Coverage.StopJSCoverageAsync();
-            Assert.IsEmpty(coverage);
+            Assert.That(coverage, Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptDevicesTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptDevicesTests.cs
@@ -16,7 +16,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
             timeoutSettings,
             new DeviceAccessDeviceRequestPromptedResponse() { Id = "00000000000000000000000000000000" });
 
-        Assert.IsEmpty(prompt.Devices);
+        Assert.That(prompt.Devices, Is.Empty);
 
         var promptData = new DeviceAccessDeviceRequestPromptedResponse()
         {
@@ -36,7 +36,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
             Params = WaitForDevicePromptTests.ToJToken(promptData),
         });
 
-        Assert.AreEqual(1, prompt.Devices.Count);
+        Assert.That(prompt.Devices, Has.Count.EqualTo(1));
 
         promptData = new DeviceAccessDeviceRequestPromptedResponse()
         {
@@ -62,7 +62,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
             Params = WaitForDevicePromptTests.ToJToken(promptData),
         });
 
-        Assert.AreEqual(2, prompt.Devices.Count);
+        Assert.That(prompt.Devices, Has.Count.EqualTo(2));
     }
 
     [Test, Retry(2), PuppeteerTest("DeviceRequestPrompt.test.ts", "DeviceRequestPrompt.devices", "does not list devices from events of another prompt")]
@@ -83,7 +83,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
             Params = WaitForDevicePromptTests.ToJToken(promptData),
         });
 
-        Assert.IsEmpty(prompt.Devices);
+        Assert.That(prompt.Devices, Is.Empty);
 
         promptData = new DeviceAccessDeviceRequestPromptedResponse()
         {
@@ -107,6 +107,6 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
             Params = WaitForDevicePromptTests.ToJToken(promptData),
         });
 
-        Assert.IsEmpty(prompt.Devices);
+        Assert.That(prompt.Devices, Is.Empty);
     }
 }

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptDevicesTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptDevicesTests.cs
@@ -33,7 +33,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         Assert.That(prompt.Devices, Has.Count.EqualTo(1));
@@ -59,7 +59,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         Assert.That(prompt.Devices, Has.Count.EqualTo(2));
@@ -80,7 +80,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         Assert.That(prompt.Devices, Is.Empty);
@@ -104,7 +104,7 @@ public class DeviceRequestPromptDevicesTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         Assert.That(prompt.Devices, Is.Empty);

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptSelectTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptSelectTests.cs
@@ -34,7 +34,7 @@ public class DeviceRequestPromptSelectTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         var device = await deviceTask;
@@ -84,7 +84,7 @@ public class DeviceRequestPromptSelectTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         var device = await deviceTask;

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptSelectTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptSelectTests.cs
@@ -54,7 +54,7 @@ public class DeviceRequestPromptSelectTests : PuppeteerPageBaseTest
         var exception = Assert.ThrowsAsync<PuppeteerException>(() =>
             prompt.SelectAsync(new DeviceRequestPromptDevice("My Device 2", "0001")));
 
-        Assert.AreEqual("Cannot select unknown device!", exception!.Message);
+        Assert.That(exception!.Message, Is.EqualTo("Cannot select unknown device!"));
     }
 
     [Test, Retry(2), PuppeteerTest("DeviceRequestPrompt.test.ts", "DeviceRequestPrompt.select", "should fail when selecting prompt twice")]
@@ -91,6 +91,6 @@ public class DeviceRequestPromptSelectTests : PuppeteerPageBaseTest
         await prompt.SelectAsync(device);
 
         var exception = Assert.ThrowsAsync<PuppeteerException>(() => prompt.SelectAsync(device));
-        Assert.AreEqual("Cannot select DeviceRequestPrompt which is already handled!", exception!.Message);
+        Assert.That(exception!.Message, Is.EqualTo("Cannot select DeviceRequestPrompt which is already handled!"));
     }
 }

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptWaitForDeviceTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptWaitForDeviceTests.cs
@@ -35,7 +35,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         promptData = new DeviceAccessDeviceRequestPromptedResponse()
@@ -59,7 +59,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         var device = await promptTask;
@@ -120,7 +120,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         var device = await promptTask;
@@ -204,7 +204,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         promptData = new DeviceAccessDeviceRequestPromptedResponse()
@@ -222,7 +222,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         client.OnMessage(new ConnectionResponse()
         {
             Method = "DeviceAccess.deviceRequestPrompted",
-            Params = WaitForDevicePromptTests.ToJToken(promptData),
+            Params = promptData.ToJToken(),
         });
 
         await deviceTask;

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptWaitForDeviceTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/DeviceRequestPromptWaitForDeviceTests.cs
@@ -63,7 +63,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         });
 
         var device = await promptTask;
-        Assert.AreEqual("My Device 1", device.Name);
+        Assert.That(device.Name, Is.EqualTo("My Device 1"));
     }
 
     [Test, Retry(2), PuppeteerTest("DeviceRequestPrompt.test.ts", "DeviceRequestPrompt.waitForDevice", "should return first matching device from already known devices")]
@@ -124,7 +124,7 @@ public class DeviceRequestPromptWaitForDeviceTests : PuppeteerPageBaseTest
         });
 
         var device = await promptTask;
-        Assert.Contains(device, prompt.Devices.ToArray());
+        Assert.That(prompt.Devices.ToArray(), Does.Contain(device));
     }
 
     [Test, Retry(2), PuppeteerTest("DeviceRequestPrompt.test.ts", "DeviceRequestPrompt.waitForDevice", "should respect timeout")]

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/PromptDataConverter.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/PromptDataConverter.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json.Linq;
+using PuppeteerSharp.Cdp.Messaging;
+
+namespace PuppeteerSharp.Tests.DeviceRequestPromptTests;
+
+internal static class PromptDataConverter
+{
+    public static JToken ToJToken(this DeviceAccessDeviceRequestPromptedResponse promptData)
+    {
+        var jObject = new JObject { { "id", promptData.Id } };
+        var devices = new JArray();
+        foreach (var device in promptData.Devices)
+        {
+            var deviceObject = new JObject { { "name", device.Name }, { "id", device.Id } };
+            devices.Add(deviceObject);
+        }
+        jObject.Add("devices", devices);
+        return jObject;
+    }
+}

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/WaitForDevicePromptTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/WaitForDevicePromptTests.cs
@@ -146,7 +146,7 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
             });
 
             await Task.WhenAll(promptTask, promptTask2);
-            Assert.AreEqual(promptTask.Result, promptTask2.Result);
+            Assert.That(promptTask2.Result, Is.EqualTo(promptTask.Result));
         }
 
         internal static JToken ToJToken(DeviceAccessDeviceRequestPromptedResponse promptData)

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/WaitForDevicePromptTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/WaitForDevicePromptTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using PuppeteerSharp.Cdp.Messaging;
 using PuppeteerSharp.Nunit;
@@ -70,7 +69,7 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
             client.OnMessage(new ConnectionResponse()
             {
                 Method = "DeviceAccess.deviceRequestPrompted",
-                Params = ToJToken(promptData),
+                Params = promptData.ToJToken(),
             });
 
             await promptTask;
@@ -120,7 +119,7 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
             client.OnMessage(new ConnectionResponse()
             {
                 Method = "DeviceAccess.deviceRequestPrompted",
-                Params = ToJToken(promptData),
+                Params = promptData.ToJToken(),
             });
 
             await promptTask;
@@ -142,24 +141,11 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
             client.OnMessage(new ConnectionResponse()
             {
                 Method = "DeviceAccess.deviceRequestPrompted",
-                Params = ToJToken(promptData),
+                Params = promptData.ToJToken(),
             });
 
             await Task.WhenAll(promptTask, promptTask2);
             Assert.That(promptTask2.Result, Is.EqualTo(promptTask.Result));
-        }
-
-        internal static JToken ToJToken(DeviceAccessDeviceRequestPromptedResponse promptData)
-        {
-            var jObject = new JObject { { "id", promptData.Id } };
-            var devices = new JArray();
-            foreach (var device in promptData.Devices)
-            {
-                var deviceObject = new JObject { { "name", device.Name }, { "id", device.Id } };
-                devices.Add(deviceObject);
-            }
-            jObject.Add("devices", devices);
-            return jObject;
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/DevtoolsTests/DevtoolsTests.cs
+++ b/lib/PuppeteerSharp.Tests/DevtoolsTests/DevtoolsTests.cs
@@ -33,7 +33,7 @@ namespace PuppeteerSharp.Tests.DevtoolsTests
 
             var target = await targetTask;
             var page = await target.PageAsync();
-            Assert.True(await page.EvaluateExpressionAsync<bool>("Boolean(DevToolsAPI)"));
+            Assert.That(await page.EvaluateExpressionAsync<bool>("Boolean(DevToolsAPI)"), Is.True);
         }
 
         [Test, Retry(2),
@@ -56,9 +56,9 @@ namespace PuppeteerSharp.Tests.DevtoolsTests
             var devtoolsTargetTask = browser.WaitForTargetAsync(t => t.Type == TargetType.Other);
             var devtoolsTarget = await devtoolsTargetTask;
             await using var page = await devtoolsTarget.PageAsync();
-            Assert.AreEqual(6, await page.EvaluateFunctionAsync<int>("() => 2 * 3"));
+            Assert.That(await page.EvaluateFunctionAsync<int>("() => 2 * 3"), Is.EqualTo(6));
             var pages = await browser.PagesAsync();
-            Assert.True(pages.Contains(page));
+            Assert.That(pages, Does.Contain(page));
         }
 
         [Test, Retry(2), PuppeteerTest("devtools.spec", "DevTools", "target.page() should return Page when calling asPage on DevTools target")]
@@ -75,8 +75,8 @@ namespace PuppeteerSharp.Tests.DevtoolsTests
             await browser.NewPageAsync();
             var devtoolsTarget = await devtoolsTargetTask;
             await using var page = await devtoolsTarget.AsPageAsync();
-            Assert.AreEqual(6, await page.EvaluateFunctionAsync<int>("() => 2 * 3"));
-            Assert.False((await browser.PagesAsync()).Contains(page));
+            Assert.That(await page.EvaluateFunctionAsync<int>("() => 2 * 3"), Is.EqualTo(6));
+            Assert.That((await browser.PagesAsync()), Does.Not.Contain(page));
         }
 
     }

--- a/lib/PuppeteerSharp.Tests/DialogTests/DialogTests.cs
+++ b/lib/PuppeteerSharp.Tests/DialogTests/DialogTests.cs
@@ -18,9 +18,9 @@ namespace PuppeteerSharp.Tests.DialogTests
         {
             Page.Dialog += async (_, e) =>
             {
-                Assert.AreEqual(DialogType.Alert, e.Dialog.DialogType);
-                Assert.AreEqual(string.Empty, e.Dialog.DefaultValue);
-                Assert.AreEqual("yo", e.Dialog.Message);
+                Assert.That(e.Dialog.DialogType, Is.EqualTo(DialogType.Alert));
+                Assert.That(e.Dialog.DefaultValue, Is.EqualTo(string.Empty));
+                Assert.That(e.Dialog.Message, Is.EqualTo("yo"));
 
                 await e.Dialog.Accept();
             };
@@ -33,15 +33,15 @@ namespace PuppeteerSharp.Tests.DialogTests
         {
             Page.Dialog += async (_, e) =>
             {
-                Assert.AreEqual(DialogType.Prompt, e.Dialog.DialogType);
-                Assert.AreEqual("yes.", e.Dialog.DefaultValue);
-                Assert.AreEqual("question?", e.Dialog.Message);
+                Assert.That(e.Dialog.DialogType, Is.EqualTo(DialogType.Prompt));
+                Assert.That(e.Dialog.DefaultValue, Is.EqualTo("yes."));
+                Assert.That(e.Dialog.Message, Is.EqualTo("question?"));
 
                 await e.Dialog.Accept("answer!");
             };
 
             var result = await Page.EvaluateExpressionAsync<string>("prompt('question?', 'yes.')");
-            Assert.AreEqual("answer!", result);
+            Assert.That(result, Is.EqualTo("answer!"));
         }
 
         [Test, Retry(2), PuppeteerTest("dialog.spec", "Page.Events.Dialog", "should dismiss the prompt")]
@@ -53,7 +53,7 @@ namespace PuppeteerSharp.Tests.DialogTests
             };
 
             var result = await Page.EvaluateExpressionAsync<string>("prompt('question?')");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/DragAndDropTests/DragAndDropTests.cs
+++ b/lib/PuppeteerSharp.Tests/DragAndDropTests/DragAndDropTests.cs
@@ -16,11 +16,11 @@ namespace PuppeteerSharp.Tests.DragAndDropTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
             var draggable = await Page.QuerySelectorAsync("#drag");
-            Assert.NotNull(draggable);
+            Assert.That(draggable, Is.Not.Null);
             var dropzone = await Page.QuerySelectorAsync("#drop");
-            Assert.NotNull(dropzone);
+            Assert.That(dropzone, Is.Not.Null);
             await dropzone.DropAsync(draggable);
-            Assert.AreEqual(1234, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(1234));
         }
 
         [Test, Retry(2), PuppeteerTest("drag-and-drop.spec", "Drag n' Drop", "should drop using mouse")]
@@ -28,18 +28,18 @@ namespace PuppeteerSharp.Tests.DragAndDropTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
             var draggable = await Page.QuerySelectorAsync("#drag");
-            Assert.NotNull(draggable);
+            Assert.That(draggable, Is.Not.Null);
             var dropzone = await Page.QuerySelectorAsync("#drop");
-            Assert.NotNull(dropzone);
+            Assert.That(dropzone, Is.Not.Null);
 
             await draggable.HoverAsync();
             await Page.Mouse.DownAsync();
             await dropzone.HoverAsync();
 
-            Assert.AreEqual(123, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(123));
 
             await Page.Mouse.UpAsync();
-            Assert.AreEqual(1234, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(1234));
         }
 
         [Test, Retry(2), PuppeteerTest("drag-and-drop.spec", "Drag n' Drop", "should drag and drop")]
@@ -47,16 +47,16 @@ namespace PuppeteerSharp.Tests.DragAndDropTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
             var draggable = await Page.QuerySelectorAsync("#drag");
-            Assert.NotNull(draggable);
+            Assert.That(draggable, Is.Not.Null);
             var dropzone = await Page.QuerySelectorAsync("#drop");
-            Assert.NotNull(dropzone);
+            Assert.That(dropzone, Is.Not.Null);
 
 #pragma warning disable CS0618 // Type or member is obsolete
             await draggable.DragAsync(dropzone);
 #pragma warning restore CS0618 // Type or member is obsolete
             await dropzone.DropAsync(draggable);
 
-            Assert.AreEqual(1234, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(1234));
         }
 
         private Task<int> GetDragStateAsync()

--- a/lib/PuppeteerSharp.Tests/DragAndDropTests/LegacyDragAndDropTests.cs
+++ b/lib/PuppeteerSharp.Tests/DragAndDropTests/LegacyDragAndDropTests.cs
@@ -15,54 +15,54 @@ namespace PuppeteerSharp.Tests.DragAndDropTests
         public async Task ShouldEmitADragInterceptedEventWhenDragged()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
-            Assert.False(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.False);
             await Page.SetDragInterceptionAsync(true);
-            Assert.True(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.True);
             var draggable = await Page.QuerySelectorAsync("#drag");
             var data = await draggable.DragAsync(1, 1);
 
             Assert.That(data.Items, Has.Exactly(1).Items);
-            Assert.AreEqual(1, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(1));
         }
 
         [Test, Retry(2), PuppeteerTest("drag-and-drop.spec", "Legacy Drag n' Drop", "should emit a dragEnter")]
         public async Task ShouldEmitADragEnter()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
-            Assert.False(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.False);
             await Page.SetDragInterceptionAsync(true);
-            Assert.True(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.True);
             var draggable = await Page.QuerySelectorAsync("#drag");
             var data = await draggable.DragAsync(1, 1);
             var dropzone = await Page.QuerySelectorAsync("#drop");
             await dropzone.DragEnterAsync(data);
 
-            Assert.AreEqual(12, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(12));
         }
 
         [Test, Retry(2), PuppeteerTest("drag-and-drop.spec", "Legacy Drag n' Drop", "should emit a dragOver event")]
         public async Task ShouldEmitADragOver()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
-            Assert.False(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.False);
             await Page.SetDragInterceptionAsync(true);
-            Assert.True(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.True);
             var draggable = await Page.QuerySelectorAsync("#drag");
             var data = await draggable.DragAsync(1, 1);
             var dropzone = await Page.QuerySelectorAsync("#drop");
             await dropzone.DragEnterAsync(data);
             await dropzone.DragOverAsync(data);
 
-            Assert.AreEqual(123, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(123));
         }
 
         [Test, Retry(2), PuppeteerTest("drag-and-drop.spec", "Legacy Drag n' Drop", "can be dropped")]
         public async Task CanBeDropped()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
-            Assert.False(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.False);
             await Page.SetDragInterceptionAsync(true);
-            Assert.True(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.True);
             var draggable = await Page.QuerySelectorAsync("#drag");
             var data = await draggable.DragAsync(1, 1);
             var dropzone = await Page.QuerySelectorAsync("#drop");
@@ -70,21 +70,21 @@ namespace PuppeteerSharp.Tests.DragAndDropTests
             await dropzone.DragOverAsync(data);
             await dropzone.DropAsync(data);
 
-            Assert.AreEqual(12334, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(12334));
         }
 
         [Test, Retry(2), PuppeteerTest("drag-and-drop.spec", "Legacy Drag n' Drop", "can be dragged and dropped with a single function")]
         public async Task CanBeDraggedAndDroppedWithASingleFunction()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/drag-and-drop.html");
-            Assert.False(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.False);
             await Page.SetDragInterceptionAsync(true);
-            Assert.True(Page.IsDragInterceptionEnabled);
+            Assert.That(Page.IsDragInterceptionEnabled, Is.True);
             var draggable = await Page.QuerySelectorAsync("#drag");
             var dropzone = await Page.QuerySelectorAsync("#drop");
             await draggable.DragAndDropAsync(dropzone);
 
-            Assert.AreEqual(12334, await GetDragStateAsync());
+            Assert.That(await GetDragStateAsync(), Is.EqualTo(12334));
         }
 
         private Task<int> GetDragStateAsync()

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var elementHandle = await Page.QuerySelectorAsync(".box:nth-of-type(13)");
             var box = await elementHandle.BoundingBoxAsync();
-            Assert.AreEqual(new BoundingBox(100, 50, 50, 50), box);
+            Assert.That(box, Is.EqualTo(new BoundingBox(100, 50, 50, 50)));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.boundingBox", "should handle nested frames")]
@@ -37,11 +37,11 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
 
             if (TestConstants.IsChrome)
             {
-                Assert.AreEqual(new BoundingBox(28, 182, 264, 18), box);
+                Assert.That(box, Is.EqualTo(new BoundingBox(28, 182, 264, 18)));
             }
             else
             {
-                Assert.AreEqual(new BoundingBox(28, 182, 254, 18), box);
+                Assert.That(box, Is.EqualTo(new BoundingBox(28, 182, 254, 18)));
             }
         }
 
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
         {
             await Page.SetContentAsync("<div style='display:none'>hi</div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
-            Assert.Null(await elementHandle.BoundingBoxAsync());
+            Assert.That(await elementHandle.BoundingBoxAsync(), Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.boundingBox", "should force a layout")]
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var elementHandle = await Page.QuerySelectorAsync("div");
             await Page.EvaluateFunctionAsync("element => element.style.height = '200px'", elementHandle);
             var box = await elementHandle.BoundingBoxAsync();
-            Assert.AreEqual(new BoundingBox(8, 8, 100, 200), box);
+            Assert.That(box, Is.EqualTo(new BoundingBox(8, 8, 100, 200)));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.boundingBox", "should work with SVG nodes")]
@@ -80,7 +80,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
                 const rect = e.getBoundingClientRect();
                 return { x: rect.x, y: rect.y, width: rect.width, height: rect.height};
             }", element);
-            Assert.AreEqual(webBoundingBox, pptrBoundingBox);
+            Assert.That(pptrBoundingBox, Is.EqualTo(webBoundingBox));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoxModelTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoxModelTests.cs
@@ -42,28 +42,28 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
 
             // Step 3: query div's boxModel and assert box values.
             var box = await divHandle.BoxModelAsync();
-            Assert.AreEqual(6, box.Width);
-            Assert.AreEqual(7, box.Height);
-            Assert.AreEqual(new BoxModelPoint
+            Assert.That(box.Width, Is.EqualTo(6));
+            Assert.That(box.Height, Is.EqualTo(7));
+            Assert.That(box.Margin[0], Is.EqualTo(new BoxModelPoint
             {
                 X = 1 + 4, // frame.left + div.left
                 Y = 2 + 5
-            }, box.Margin[0]);
-            Assert.AreEqual(new BoxModelPoint
+            }));
+            Assert.That(box.Border[0], Is.EqualTo(new BoxModelPoint
             {
                 X = 1 + 4 + 3, // frame.left + div.left + div.margin-left
                 Y = 2 + 5
-            }, box.Border[0]);
-            Assert.AreEqual(new BoxModelPoint
+            }));
+            Assert.That(box.Padding[0], Is.EqualTo(new BoxModelPoint
             {
                 X = 1 + 4 + 3 + 1, // frame.left + div.left + div.marginLeft + div.borderLeft
                 Y = 2 + 5
-            }, box.Padding[0]);
-            Assert.AreEqual(new BoxModelPoint
+            }));
+            Assert.That(box.Content[0], Is.EqualTo(new BoxModelPoint
             {
                 X = 1 + 4 + 3 + 1 + 2, // frame.left + div.left + div.marginLeft + div.borderLeft + dif.paddingLeft
                 Y = 2 + 5
-            }, box.Content[0]);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.boxModel", "should return null for invisible elements")]
@@ -71,7 +71,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
         {
             await Page.SetContentAsync("<div style='display:none'>hi</div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
-            Assert.Null(await elementHandle.BoxModelAsync());
+            Assert.That(await elementHandle.BoxModelAsync(), Is.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/ClickTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/ClickTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/button.html");
             var button = await Page.QuerySelectorAsync("button");
             await button.ClickAsync();
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.click", "should work for Shadow DOM v1")]
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/shadow.html");
             var buttonHandle = (IElementHandle)await Page.EvaluateExpressionHandleAsync("button");
             await buttonHandle.ClickAsync();
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("clicked"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("clicked"), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.click", "should not work for TextNodes")]
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var button = await Page.QuerySelectorAsync("button");
             await Page.EvaluateFunctionAsync("button => button.remove()", button);
             var exception = Assert.ThrowsAsync<PuppeteerException>(async () => await button.ClickAsync());
-            Assert.AreEqual("Node is detached from document", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Node is detached from document"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.click", "should throw for hidden nodes")]
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var button = await Page.QuerySelectorAsync("button");
             await Page.EvaluateFunctionAsync("button => button.style.display = 'none'", button);
             var exception = Assert.ThrowsAsync<PuppeteerException>(async () => await button.ClickAsync());
-            Assert.AreEqual("Node is either not clickable or not an Element", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Node is either not clickable or not an Element"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.click", "should throw for recursively hidden nodes")]
@@ -64,7 +64,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var button = await Page.QuerySelectorAsync("button");
             await Page.EvaluateFunctionAsync("button => button.parentElement.style.display = 'none'", button);
             var exception = Assert.ThrowsAsync<PuppeteerException>(async () => await button.ClickAsync());
-            Assert.AreEqual("Node is either not clickable or not an Element", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Node is either not clickable or not an Element"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.click", "should throw for <br> elements")]
@@ -73,7 +73,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.SetContentAsync("hello<br>goodbye");
             var br = await Page.QuerySelectorAsync("br");
             var exception = Assert.ThrowsAsync<PuppeteerException>(async () => await br.ClickAsync());
-            Assert.AreEqual("Node is either not clickable or not an Element", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Node is either not clickable or not an Element"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.click", "should return Point data")]
@@ -103,12 +103,12 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await TestUtils.ShortWaitForCollectionToHaveAtLeastNElementsAsync(clicks, 2);
 
             // margin + middle point offset
-            Assert.AreEqual(45 + 60, clicks[0].X);
-            Assert.AreEqual(45 + 30, clicks[0].Y);
+            Assert.That(clicks[0].X, Is.EqualTo(45 + 60));
+            Assert.That(clicks[0].Y, Is.EqualTo(45 + 30));
 
             // margin + offset
-            Assert.AreEqual(30 + 10, clicks[1].X);
-            Assert.AreEqual(30 + 15, clicks[1].Y);
+            Assert.That(clicks[1].X, Is.EqualTo(30 + 10));
+            Assert.That(clicks[1].Y, Is.EqualTo(30 + 15));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
@@ -25,6 +25,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             Assert.That(frame, Is.EqualTo(Page.FirstChildFrame()));
         }
 
+        [Test]
         public async Task ShouldWorkHeadful()
         {
             await using var Browser = await Puppeteer.LaunchAsync(_headfulOptions);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             var elementHandle = await Page.QuerySelectorAsync("#frame1");
             var frame = await elementHandle.ContentFrameAsync();
-            Assert.AreEqual(Page.FirstChildFrame(), frame);
+            Assert.That(frame, Is.EqualTo(Page.FirstChildFrame()));
         }
 
         public async Task ShouldWorkHeadful()
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.GoToAsync($"{TestConstants.ServerUrl}/frame-example.html");
             var elementHandle = await Page.QuerySelectorAsync("iframe");
             var frame = await elementHandle.ContentFrameAsync();
-            Assert.AreEqual(Page.FirstChildFrame(), frame);
+            Assert.That(frame, Is.EqualTo(Page.FirstChildFrame()));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             Assert.That(frame, Is.EqualTo(Page.FirstChildFrame()));
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkHeadful()
         {
             await using var Browser = await Puppeteer.LaunchAsync(_headfulOptions);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             Assert.That(frame, Is.EqualTo(Page.FirstChildFrame()));
         }
 
-        [Test, Ignore("previously not marked as a test")]
+        [Test]
         public async Task ShouldWorkHeadful()
         {
             await using var Browser = await Puppeteer.LaunchAsync(_headfulOptions);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/CustomQueriesTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/CustomQueriesTests.cs
@@ -30,12 +30,12 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             });
 
             var element = await Page.QuerySelectorAsync("getById/foo");
-            Assert.AreEqual("foo", await Page.EvaluateFunctionAsync<string>(
+            Assert.That(await Page.EvaluateFunctionAsync<string>(
                 @"(el) => el.id",
-                element));
+                element), Is.EqualTo("foo"));
 
             var handlerNamesAfterRegistering = ((Browser)Browser).GetCustomQueryHandlerNames();
-            Assert.Contains("getById", handlerNamesAfterRegistering.ToArray());
+            Assert.That(handlerNamesAfterRegistering.ToArray(), Does.Contain("getById"));
 
             // Unregister.
             Browser.UnregisterCustomQueryHandler("getById");
@@ -46,11 +46,11 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             }
             catch (Exception ex)
             {
-                StringAssert.DoesNotContain($"Custom query handler name not set - throw expected", ex.Message);
+                Assert.That(ex.Message, Does.Not.Contain($"Custom query handler name not set - throw expected"));
             }
 
             var handlerNamesAfterUnregistering = ((Browser)Browser).GetCustomQueryHandlerNames();
-            Assert.False(handlerNamesAfterUnregistering.Contains("getById"));
+            Assert.That(handlerNamesAfterUnregistering, Does.Not.Contain("getById"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should throw with invalid query names")]
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
                 QueryOne = "(element, selector) => element.querySelector(`[id='${selector}']`)",
             }));
 
-            Assert.AreEqual("Custom query handler names may only contain [a-zA-Z]", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Custom query handler names may only contain [a-zA-Z]"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should work for multiple elements")]
@@ -79,7 +79,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
                 elements
                     .Select(el => el.EvaluateFunctionAsync<string>("(element) => element.className")));
 
-            Assert.AreEqual(new[] { "foo", "foo baz" }, classNames.ToArray());
+            Assert.That(classNames.ToArray(), Is.EqualTo(new[] { "foo", "foo baz" }));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should eval correctly")]
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var elements = await Page.QuerySelectorAllHandleAsync("getByClass/foo")
                 .EvaluateFunctionAsync<int>("(divs) =>  divs.length");
 
-            Assert.AreEqual(2, elements);
+            Assert.That(elements, Is.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should wait correctly with waitForSelector")]
@@ -112,7 +112,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
 
             var element = await waitFor;
 
-            Assert.NotNull(element);
+            Assert.That(element, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should wait correctly with waitForSelector on an element")]
@@ -129,14 +129,14 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
 
             var element = await waitFor;
 
-            Assert.NotNull(element);
+            Assert.That(element, Is.Not.Null);
 
             var innerWaitFor = element.WaitForSelectorAsync("getByClass/bar");
 
             await element.EvaluateFunctionAsync("(el) => el.innerHTML = '<div class=\"bar\">bar1</div>'");
 
             element = await innerWaitFor;
-            Assert.AreEqual("bar1", await element.EvaluateFunctionAsync<string>("(el) => el.innerText"));
+            Assert.That(await element.EvaluateFunctionAsync<string>("(el) => el.innerText"), Is.EqualTo("bar1"));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should work when both queryOne and queryAll are registered")]
@@ -151,9 +151,9 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             });
 
             var element = await Page.QuerySelectorAsync("getByClass/foo");
-            Assert.NotNull(element);
+            Assert.That(element, Is.Not.Null);
             var elements = await Page.QuerySelectorAllAsync("getByClass/foo");
-            Assert.AreEqual(3, elements.Length);
+            Assert.That(elements, Has.Length.EqualTo(3));
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs Custom queries", "should eval when both queryOne and queryAll are registered")]
@@ -170,12 +170,12 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var txtContent = await Page.QuerySelectorAsync("getByClass/foo")
                 .EvaluateFunctionAsync<string>("(div) =>  div.textContent");
 
-            Assert.AreEqual("text", txtContent);
+            Assert.That(txtContent, Is.EqualTo("text"));
 
             var txtContents = await Page.QuerySelectorAllHandleAsync("getByClass/foo")
                 .EvaluateFunctionAsync<string>("(divs) =>  divs.map((d) => d.textContent).join('')");
 
-            Assert.AreEqual("textcontent", txtContents);
+            Assert.That(txtContents, Is.EqualTo("textcontent"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/HoverTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/HoverTests.cs
@@ -17,8 +17,8 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             var button = await Page.QuerySelectorAsync("#button-6");
             await button.HoverAsync();
-            Assert.AreEqual("button-6", await Page.EvaluateExpressionAsync<string>(
-                "document.querySelector('button:hover').id"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>(
+                "document.querySelector('button:hover').id"), Is.EqualTo("button-6"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/IsIntersectingViewportTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/IsIntersectingViewportTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
                 var button = await Page.QuerySelectorAsync("#btn" + i);
                 // All but last button are visible.
                 var visible = i < 10;
-                Assert.AreEqual(visible, await button.IsIntersectingViewportAsync());
+                Assert.That(await button.IsIntersectingViewportAsync(), Is.EqualTo(visible));
             }
         }
 
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/offscreenbuttons.html");
             var button = await Page.QuerySelectorAsync("#btn11");
-            Assert.False(await button.IsIntersectingViewportAsync(0.001m));
+            Assert.That(await button.IsIntersectingViewportAsync(0.001m), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.isIntersectingViewport", "should work with threshold of 1")]
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/offscreenbuttons.html");
             var button = await Page.QuerySelectorAsync("#btn0");
-            Assert.True(await button.IsIntersectingViewportAsync(1));
+            Assert.That(await button.IsIntersectingViewportAsync(1), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.isIntersectingViewport", "should work with svg elements")]
@@ -42,18 +42,18 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             var visibleCircle = await Page.QuerySelectorAsync("circle");
             var visibleSvg = await Page.QuerySelectorAsync("svg");
 
-            Assert.True(await visibleCircle.IsIntersectingViewportAsync(1));
-            Assert.True(await visibleSvg.IsIntersectingViewportAsync(1));
-            Assert.True(await visibleCircle.IsIntersectingViewportAsync());
-            Assert.True(await visibleSvg.IsIntersectingViewportAsync());
+            Assert.That(await visibleCircle.IsIntersectingViewportAsync(1), Is.True);
+            Assert.That(await visibleSvg.IsIntersectingViewportAsync(1), Is.True);
+            Assert.That(await visibleCircle.IsIntersectingViewportAsync(), Is.True);
+            Assert.That(await visibleSvg.IsIntersectingViewportAsync(), Is.True);
 
             var invisibleCircle = await Page.QuerySelectorAsync("div circle");
             var invisibleSvg = await Page.QuerySelectorAsync("div svg");
 
-            Assert.False(await invisibleCircle.IsIntersectingViewportAsync(1));
-            Assert.False(await invisibleSvg.IsIntersectingViewportAsync(1));
-            Assert.False(await invisibleCircle.IsIntersectingViewportAsync());
-            Assert.False(await invisibleSvg.IsIntersectingViewportAsync());
+            Assert.That(await invisibleCircle.IsIntersectingViewportAsync(1), Is.False);
+            Assert.That(await invisibleSvg.IsIntersectingViewportAsync(1), Is.False);
+            Assert.That(await invisibleCircle.IsIntersectingViewportAsync(), Is.False);
+            Assert.That(await invisibleSvg.IsIntersectingViewportAsync(), Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/IsVisibleIsHiddenTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/IsVisibleIsHiddenTests.cs
@@ -15,12 +15,12 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
         {
             await Page.SetContentAsync("<div style='display: none'>text</div>");
             var element = await Page.WaitForSelectorAsync("div").ConfigureAwait(false);
-            Assert.False(await element.IsVisibleAsync());
-            Assert.True(await element.IsHiddenAsync());
+            Assert.That(await element.IsVisibleAsync(), Is.False);
+            Assert.That(await element.IsHiddenAsync(), Is.True);
 
             await element.EvaluateFunctionAsync("e => e.style.removeProperty('display')");
-            Assert.True(await element.IsVisibleAsync());
-            Assert.False(await element.IsHiddenAsync());
+            Assert.That(await element.IsVisibleAsync(), Is.True);
+            Assert.That(await element.IsHiddenAsync(), Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/EmulateMediaFeaturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/EmulateMediaFeaturesTests.cs
@@ -16,29 +16,29 @@ namespace PuppeteerSharp.Tests.EmulationTests
             await Page.EmulateMediaFeaturesAsync(new MediaFeatureValue[] {
                 new MediaFeatureValue { MediaFeature = MediaFeature.PrefersReducedMotion, Value = "reduce" },
             });
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: reduce)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: no-preference)').matches"));
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: reduce)').matches"), Is.True);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: no-preference)').matches"), Is.False);
             await Page.EmulateMediaFeaturesAsync(new MediaFeatureValue[] {
                 new MediaFeatureValue { MediaFeature = MediaFeature.PrefersColorScheme, Value = "light" },
             });
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: light)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: dark)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: no-preference)').matches"));
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: light)').matches"), Is.True);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: dark)').matches"), Is.False);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: no-preference)').matches"), Is.False);
             await Page.EmulateMediaFeaturesAsync(new MediaFeatureValue[] {
                 new MediaFeatureValue { MediaFeature = MediaFeature.PrefersColorScheme, Value = "dark" },
             });
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: dark)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: light)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: no-preference)').matches"));
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: dark)').matches"), Is.True);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: light)').matches"), Is.False);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: no-preference)').matches"), Is.False);
             await Page.EmulateMediaFeaturesAsync(new MediaFeatureValue[] {
                 new MediaFeatureValue { MediaFeature = MediaFeature.PrefersReducedMotion, Value = "reduce" },
                 new MediaFeatureValue { MediaFeature = MediaFeature.PrefersColorScheme, Value = "light" },
             });
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: reduce)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: no-preference)').matches"));
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: light)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: dark)').matches"));
-            Assert.False(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: no-preference)').matches"));
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: reduce)').matches"), Is.True);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-reduced-motion: no-preference)').matches"), Is.False);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: light)').matches"), Is.True);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: dark)').matches"), Is.False);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => matchMedia('(prefers-color-scheme: no-preference)').matches"), Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/EmulateMediaTypeTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/EmulateMediaTypeTests.cs
@@ -14,14 +14,14 @@ namespace PuppeteerSharp.Tests.EmulationTests
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.emulateMediaType", "should work")]
         public async Task ShouldWork()
         {
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("matchMedia('screen').matches"));
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("matchMedia('print').matches"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("matchMedia('screen').matches"), Is.True);
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("matchMedia('print').matches"), Is.False);
             await Page.EmulateMediaTypeAsync(MediaType.Print);
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("matchMedia('screen').matches"));
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("matchMedia('print').matches"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("matchMedia('screen').matches"), Is.False);
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("matchMedia('print').matches"), Is.True);
             await Page.EmulateMediaTypeAsync(MediaType.None);
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("matchMedia('screen').matches"));
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("matchMedia('print').matches"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("matchMedia('screen').matches"), Is.True);
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("matchMedia('print').matches"), Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/EmulateTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/EmulateTests.cs
@@ -12,8 +12,8 @@ namespace PuppeteerSharp.Tests.EmulationTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/mobile.html");
             await Page.EmulateAsync(TestConstants.IPhone);
 
-            Assert.AreEqual(375, await Page.EvaluateExpressionAsync<int>("window.innerWidth"));
-            StringAssert.Contains("iPhone", await Page.EvaluateExpressionAsync<string>("navigator.userAgent"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.innerWidth"), Is.EqualTo(375));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("navigator.userAgent"), Does.Contain("iPhone"));
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.emulate", "should support clicking")]
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Tests.EmulationTests
             var button = await Page.QuerySelectorAsync("button");
             await Page.EvaluateFunctionAsync("button => button.style.marginTop = '200px'", button);
             await button.ClickAsync();
-            Assert.AreEqual("Clicked", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Clicked"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/EmulateTimezoneTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/EmulateTimezoneTests.cs
@@ -16,24 +16,20 @@ namespace PuppeteerSharp.Tests.EmulationTests
         {
             await Page.EvaluateExpressionAsync("globalThis.date = new Date(1479579154987);");
             await Page.EmulateTimezoneAsync("America/Jamaica");
-            Assert.AreEqual(
-                "Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)",
-                await Page.EvaluateExpressionAsync<string>("date.toString()"));
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string>("date.toString()"), Is.EqualTo("Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)"));
 
             await Page.EmulateTimezoneAsync("Pacific/Honolulu");
-            Assert.AreEqual(
-                "Sat Nov 19 2016 08:12:34 GMT-1000 (Hawaii-Aleutian Standard Time)",
-                await Page.EvaluateExpressionAsync<string>("date.toString()"));
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string>("date.toString()"), Is.EqualTo("Sat Nov 19 2016 08:12:34 GMT-1000 (Hawaii-Aleutian Standard Time)"));
 
             await Page.EmulateTimezoneAsync("America/Buenos_Aires");
-            Assert.AreEqual(
-                "Sat Nov 19 2016 15:12:34 GMT-0300 (Argentina Standard Time)",
-                await Page.EvaluateExpressionAsync<string>("date.toString()"));
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string>("date.toString()"), Is.EqualTo("Sat Nov 19 2016 15:12:34 GMT-0300 (Argentina Standard Time)"));
 
             await Page.EmulateTimezoneAsync("Europe/Berlin");
-            Assert.AreEqual(
-                "Sat Nov 19 2016 19:12:34 GMT+0100 (Central European Standard Time)",
-                await Page.EvaluateExpressionAsync<string>("date.toString()"));
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string>("date.toString()"), Is.EqualTo("Sat Nov 19 2016 19:12:34 GMT+0100 (Central European Standard Time)"));
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.emulateTimezone", "should throw for invalid timezone IDs")]
@@ -41,11 +37,11 @@ namespace PuppeteerSharp.Tests.EmulationTests
         {
             var exception = Assert.ThrowsAsync<PuppeteerException>(
                 () => Page.EmulateTimezoneAsync("Foo/Bar"));
-            StringAssert.Contains("Invalid timezone ID: Foo/Bar", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Invalid timezone ID: Foo/Bar"));
 
             exception = Assert.ThrowsAsync<PuppeteerException>(
                 () => Page.EmulateTimezoneAsync("Baz/Qux"));
-            StringAssert.Contains("Invalid timezone ID: Baz/Qux", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Invalid timezone ID: Baz/Qux"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateNetworkConditionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateNetworkConditionsTests.cs
@@ -16,11 +16,11 @@ namespace PuppeteerSharp.Tests.EmulationTests
             var slow3G = Puppeteer.NetworkConditions[NetworkConditions.Slow3G];
             var fast3G = Puppeteer.NetworkConditions[NetworkConditions.Fast3G];
 
-            Assert.AreEqual("4g", await Page.EvaluateExpressionAsync<string>("window.navigator.connection.effectiveType").ConfigureAwait(false));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("window.navigator.connection.effectiveType").ConfigureAwait(false), Is.EqualTo("4g"));
             await Page.EmulateNetworkConditionsAsync(fast3G);
-            Assert.AreEqual("3g", await Page.EvaluateExpressionAsync<string>("window.navigator.connection.effectiveType").ConfigureAwait(false));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("window.navigator.connection.effectiveType").ConfigureAwait(false), Is.EqualTo("3g"));
             await Page.EmulateNetworkConditionsAsync(slow3G);
-            Assert.AreEqual("2g", await Page.EvaluateExpressionAsync<string>("window.navigator.connection.effectiveType").ConfigureAwait(false));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("window.navigator.connection.effectiveType").ConfigureAwait(false), Is.EqualTo("2g"));
             await Page.EmulateNetworkConditionsAsync(null);
         }
     }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateVisionDeficiencyTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateVisionDeficiencyTests.cs
@@ -18,31 +18,31 @@ namespace PuppeteerSharp.Tests.EmulationTests
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.None);
             var screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot), Is.True);
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.Achromatopsia);
             screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("vision-deficiency-achromatopsia.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("vision-deficiency-achromatopsia.png", screenshot), Is.True);
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.BlurredVision);
             screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("vision-deficiency-blurredVision.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("vision-deficiency-blurredVision.png", screenshot), Is.True);
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.Deuteranopia);
             screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("vision-deficiency-deuteranopia.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("vision-deficiency-deuteranopia.png", screenshot), Is.True);
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.Protanopia);
             screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("vision-deficiency-protanopia.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("vision-deficiency-protanopia.png", screenshot), Is.True);
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.Tritanopia);
             screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("vision-deficiency-tritanopia.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("vision-deficiency-tritanopia.png", screenshot), Is.True);
 
             await Page.EmulateVisionDeficiencyAsync(VisionDeficiency.None);
             screenshot = await Page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EmulationTests/PageViewPortTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/PageViewPortTests.cs
@@ -9,25 +9,25 @@ namespace PuppeteerSharp.Tests.EmulationTests
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should get the proper viewport size")]
         public async Task ShouldGetTheProperViewPortSize()
         {
-            Assert.AreEqual(800, Page.Viewport.Width);
-            Assert.AreEqual(600, Page.Viewport.Height);
+            Assert.That(Page.Viewport.Width, Is.EqualTo(800));
+            Assert.That(Page.Viewport.Height, Is.EqualTo(600));
 
             await Page.SetViewportAsync(new ViewPortOptions { Width = 123, Height = 456 });
 
-            Assert.AreEqual(123, Page.Viewport.Width);
-            Assert.AreEqual(456, Page.Viewport.Height);
+            Assert.That(Page.Viewport.Width, Is.EqualTo(123));
+            Assert.That(Page.Viewport.Height, Is.EqualTo(456));
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should support mobile emulation")]
         public async Task ShouldSupportMobileEmulation()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/mobile.html");
-            Assert.AreEqual(800, await Page.EvaluateExpressionAsync<int>("window.innerWidth"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.innerWidth"), Is.EqualTo(800));
 
             await Page.SetViewportAsync(TestConstants.IPhone.ViewPort);
-            Assert.AreEqual(375, await Page.EvaluateExpressionAsync<int>("window.innerWidth"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.innerWidth"), Is.EqualTo(375));
             await Page.SetViewportAsync(new ViewPortOptions { Width = 400, Height = 300 });
-            Assert.AreEqual(400, await Page.EvaluateExpressionAsync<int>("window.innerWidth"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.innerWidth"), Is.EqualTo(400));
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should support touch emulation")]
@@ -48,24 +48,24 @@ namespace PuppeteerSharp.Tests.EmulationTests
             }";
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/mobile.html");
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("'ontouchstart' in window"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("'ontouchstart' in window"), Is.False);
 
             await Page.SetViewportAsync(TestConstants.IPhone.ViewPort);
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("'ontouchstart' in window"));
-            Assert.AreEqual("Received touch", await Page.EvaluateFunctionAsync<string>(dispatchTouch));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("'ontouchstart' in window"), Is.True);
+            Assert.That(await Page.EvaluateFunctionAsync<string>(dispatchTouch), Is.EqualTo("Received touch"));
 
             await Page.SetViewportAsync(new ViewPortOptions { Width = 100, Height = 100 });
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("'ontouchstart' in window"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("'ontouchstart' in window"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should be detectable by Modernizr")]
         public async Task ShouldBeDetectableByModernizr()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/detect-touch.html");
-            Assert.AreEqual("NO", await Page.EvaluateExpressionAsync<string>("document.body.textContent.trim()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent.trim()"), Is.EqualTo("NO"));
             await Page.SetViewportAsync(TestConstants.IPhone.ViewPort);
             await Page.GoToAsync(TestConstants.ServerUrl + "/detect-touch.html");
-            Assert.AreEqual("YES", await Page.EvaluateExpressionAsync<string>("document.body.textContent.trim()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent.trim()"), Is.EqualTo("YES"));
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should detect touch when applying viewport with touches")]
@@ -82,18 +82,18 @@ namespace PuppeteerSharp.Tests.EmulationTests
             {
                 Url = TestConstants.ServerUrl + "/modernizr.js"
             });
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("() => globalThis.Modernizr.touchevents"));
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("() => globalThis.Modernizr.touchevents"), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should support landscape emulation")]
         public async Task ShouldSupportLandscapeEmulation()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/mobile.html");
-            Assert.AreEqual("portrait-primary", await Page.EvaluateExpressionAsync<string>("screen.orientation.type"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("screen.orientation.type"), Is.EqualTo("portrait-primary"));
             await Page.SetViewportAsync(TestConstants.IPhone6Landscape.ViewPort);
-            Assert.AreEqual("landscape-primary", await Page.EvaluateExpressionAsync<string>("screen.orientation.type"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("screen.orientation.type"), Is.EqualTo("landscape-primary"));
             await Page.SetViewportAsync(new ViewPortOptions { Width = 100, Height = 100 });
-            Assert.AreEqual("portrait-primary", await Page.EvaluateExpressionAsync<string>("screen.orientation.type"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("screen.orientation.type"), Is.EqualTo("portrait-primary"));
         }
 
         [Test, Retry(2), PuppeteerTest("emulation.spec", "Emulation Page.viewport", "should update media queries when resoltion changes")]
@@ -104,9 +104,9 @@ namespace PuppeteerSharp.Tests.EmulationTests
                 await Page.SetViewportAsync(new ViewPortOptions { Width = 800, Height = 600, DeviceScaleFactor = dpr });
 
                 await Page.GoToAsync(TestConstants.ServerUrl + "/resolution.html");
-                Assert.AreEqual(dpr, await GetFontSizeAsync());
+                Assert.That(await GetFontSizeAsync(), Is.EqualTo(dpr));
                 var screenshot = await Page.ScreenshotDataAsync(new ScreenshotOptions() { FullPage = false });
-                Assert.True(ScreenshotHelper.PixelMatch($"device-pixel-ratio{dpr}.png", screenshot));
+                Assert.That(ScreenshotHelper.PixelMatch($"device-pixel-ratio{dpr}.png", screenshot), Is.True);
             }
         }
 
@@ -118,7 +118,7 @@ namespace PuppeteerSharp.Tests.EmulationTests
                 await Page.SetViewportAsync(new ViewPortOptions { Width = 800, Height = 600, DeviceScaleFactor = dpr });
 
                 await Page.GoToAsync(TestConstants.ServerUrl + "/picture.html");
-                StringAssert.EndsWith($"logo-{dpr}x.png", await GetCurrentSrc());
+                Assert.That(await GetCurrentSrc(), Does.EndWith($"logo-{dpr}x.png"));
 
             }
         }

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/FrameEvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/FrameEvaluateTests.cs
@@ -12,7 +12,7 @@ namespace PuppeteerSharp.Tests.EvaluationTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            Assert.AreEqual(2, Page.Frames.Count());
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
 
             var frame1 = Page.MainFrame;
             var frame2 = Page.FirstChildFrame();
@@ -20,21 +20,21 @@ namespace PuppeteerSharp.Tests.EvaluationTests
             await frame1.EvaluateExpressionAsync("window.FOO = 'foo'");
             await frame2.EvaluateExpressionAsync("window.FOO = 'bar'");
 
-            Assert.AreEqual("foo", await frame1.EvaluateExpressionAsync<string>("window.FOO"));
-            Assert.AreEqual("bar", await frame2.EvaluateExpressionAsync<string>("window.FOO"));
+            Assert.That(await frame1.EvaluateExpressionAsync<string>("window.FOO"), Is.EqualTo("foo"));
+            Assert.That(await frame2.EvaluateExpressionAsync<string>("window.FOO"), Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Frame.evaluate", "should have correct execution contexts")]
         public async Task ShouldHaveCorrectExecutionContexts()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
-            Assert.AreEqual(2, Page.Frames.Count());
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
 
             var frame1 = Page.MainFrame;
             var frame2 = Page.FirstChildFrame();
 
-            Assert.AreEqual("", await frame1.EvaluateExpressionAsync<string>("document.body.textContent.trim()"));
-            Assert.AreEqual("Hi, I'm frame", await frame2.EvaluateExpressionAsync<string>("document.body.textContent.trim()"));
+            Assert.That(await frame1.EvaluateExpressionAsync<string>("document.body.textContent.trim()"), Is.EqualTo(""));
+            Assert.That(await frame2.EvaluateExpressionAsync<string>("document.body.textContent.trim()"), Is.EqualTo("Hi, I'm frame"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Frame.evaluate", "should execute after cross-site navigation")]
@@ -42,10 +42,10 @@ namespace PuppeteerSharp.Tests.EvaluationTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var mainFrame = Page.MainFrame;
-            StringAssert.Contains("localhost", await mainFrame.EvaluateExpressionAsync<string>("window.location.href"));
+            Assert.That(await mainFrame.EvaluateExpressionAsync<string>("window.location.href"), Does.Contain("localhost"));
 
             await Page.GoToAsync(TestConstants.CrossProcessHttpPrefix + "/empty.html");
-            StringAssert.Contains("127", await mainFrame.EvaluateExpressionAsync<string>("window.location.href"));
+            Assert.That(await mainFrame.EvaluateExpressionAsync<string>("window.location.href"), Does.Contain("127"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.EvaluationTests
                 window.injected = 123;
             }");
             await Page.GoToAsync(TestConstants.ServerUrl + "/tamperable.html");
-            Assert.AreEqual(123, await Page.EvaluateExpressionAsync<int>("window.result"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.result"), Is.EqualTo(123));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluateOnNewDocument", "should work with CSP")]
@@ -32,21 +32,21 @@ namespace PuppeteerSharp.Tests.EvaluationTests
                 window.injected = 123;
             }");
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(123, await Page.EvaluateExpressionAsync<int>("window.injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.injected"), Is.EqualTo(123));
 
             // Make sure CSP works.
             await Page.AddScriptTagAsync(new AddTagOptions
             {
                 Content = "window.e = 10;"
             }).ContinueWith(_ => Task.CompletedTask);
-            Assert.Null(await Page.EvaluateExpressionAsync("window.e"));
+            Assert.That(await Page.EvaluateExpressionAsync("window.e"), Is.Null);
         }
 
         public async Task ShouldWorkWithExpressions()
         {
             await Page.EvaluateExpressionOnNewDocumentAsync("window.injected = 123;");
             await Page.GoToAsync(TestConstants.ServerUrl + "/tamperable.html");
-            Assert.AreEqual(123, await Page.EvaluateExpressionAsync<int>("window.result"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.result"), Is.EqualTo(123));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.EvaluationTests
             Assert.That(await Page.EvaluateExpressionAsync("window.e"), Is.Null);
         }
 
-        [Test, Ignore("previously not marked as a test")]
+        [Test, Ignore("Inconsistent results on Firefox")]
         public async Task ShouldWorkWithExpressions()
         {
             await Page.EvaluateExpressionOnNewDocumentAsync("window.injected = 123;");

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.EvaluationTests
             Assert.That(await Page.EvaluateExpressionAsync("window.e"), Is.Null);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkWithExpressions()
         {
             await Page.EvaluateExpressionOnNewDocumentAsync("window.injected = 123;");

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateOnNewDocumentTests.cs
@@ -42,6 +42,7 @@ namespace PuppeteerSharp.Tests.EvaluationTests
             Assert.That(await Page.EvaluateExpressionAsync("window.e"), Is.Null);
         }
 
+        [Test]
         public async Task ShouldWorkWithExpressions()
         {
             await Page.EvaluateExpressionOnNewDocumentAsync("window.injected = 123;");

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateTests.cs
@@ -312,6 +312,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(exception.Message, Does.Contain("Error in promise"));
         }
 
+        [Test]
         public async Task ShouldWorkWithDifferentSerializerSettings()
         {
             var result = await Page.EvaluateFunctionAsync<ComplexObjectTestClass>("() => { return { foo: 'bar' }}");
@@ -346,6 +347,9 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(text, Is.EqualTo("42"));
         }
 
+#pragma warning disable NUnit2021 // Incompatible types for EqualTo constraint
+        [Test]
+        [Ignore("I'm not sure how this ever worked?")]
         public async Task ShouldWorkWithoutGenerics()
         {
             Assert.That(await Page.EvaluateExpressionAsync("var obj = {}; obj;"), Is.Not.Null);
@@ -366,6 +370,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(await Page.EvaluateExpressionAsync("11111111111111"), Is.EqualTo(11111111111111));
             Assert.That(await Page.EvaluateExpressionAsync("1.1"), Is.EqualTo(1.1));
         }
+#pragma warning restore NUnit2021 // Incompatible types for EqualTo constraint
 
         public class ComplexObjectTestClass
         {

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateTests.cs
@@ -312,7 +312,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(exception.Message, Does.Contain("Error in promise"));
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkWithDifferentSerializerSettings()
         {
             var result = await Page.EvaluateFunctionAsync<ComplexObjectTestClass>("() => { return { foo: 'bar' }}");

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/PageEvaluateTests.cs
@@ -24,14 +24,14 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task BasicIntFunctionEvaluationTest(string script, object expected)
         {
             var result = await Page.EvaluateFunctionAsync<int>(script);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should transfer BigInt")]
         public async Task ShouldTransferBigInt()
         {
             var result = await Page.EvaluateFunctionAsync<BigInteger>("a => a", new BigInteger(42));
-            Assert.AreEqual(new BigInteger(42), result);
+            Assert.That(result, Is.EqualTo(new BigInteger(42)));
         }
 
         [Test]
@@ -47,44 +47,44 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task BasicTransferTest(object transferObject)
         {
             var result = await Page.EvaluateFunctionAsync<object>("a => a", transferObject);
-            Assert.AreEqual(transferObject, result);
+            Assert.That(result, Is.EqualTo(transferObject));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should transfer arrays")]
         public async Task ShouldTransferArrays()
         {
             var result = await Page.EvaluateFunctionAsync<int[]>("a => a", new int[] { 1, 2, 3 });
-            Assert.AreEqual(new int[] { 1, 2, 3 }, result);
+            Assert.That(result, Is.EqualTo(new int[] { 1, 2, 3 }));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should transfer arrays as arrays, not objects")]
         public async Task ShouldTransferArraysAsArraysNotObjects()
         {
             var result = await Page.EvaluateFunctionAsync<bool>("a => Array.isArray(a)", new int[] { 1, 2, 3 });
-            Assert.True(result);
+            Assert.That(result, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should modify global environment")]
         public async Task ShouldModifyGlobalEnvironment()
         {
             await Page.EvaluateFunctionAsync("() => window.globalVar = 123");
-            Assert.AreEqual(123, await Page.EvaluateFunctionAsync<int>("() => window.globalVar"));
+            Assert.That(await Page.EvaluateFunctionAsync<int>("() => window.globalVar"), Is.EqualTo(123));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should evaluate in the page context")]
         public async Task ShouldEvaluateInThePageContext()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/global-var.html");
-            Assert.AreEqual(123, await Page.EvaluateFunctionAsync<int>("() => window.globalVar"));
+            Assert.That(await Page.EvaluateFunctionAsync<int>("() => window.globalVar"), Is.EqualTo(123));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should return undefined for objects with symbols")]
         public async Task ShouldReturnUndefinedForObjectsWithSymbols()
-            => Assert.Null(await Page.EvaluateFunctionAsync<object>("() => [Symbol('foo4')]"));
+            => Assert.That(await Page.EvaluateFunctionAsync<object>("() => [Symbol('foo4')]"), Is.Null);
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should work with unicode chars")]
         public async Task ShouldWorkWithUnicodeChars()
-            => Assert.AreEqual(42, await Page.EvaluateFunctionAsync<int>("a => a['中文字符']", new Dictionary<string, int> { ["中文字符"] = 42 }));
+            => Assert.That(await Page.EvaluateFunctionAsync<int>("a => a['中文字符']", new Dictionary<string, int> { ["中文字符"] = 42 }), Is.EqualTo(42));
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should throw when evaluation triggers reload")]
         public void ShouldThrowWhenEvaluationTriggersReload()
@@ -97,7 +97,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 }");
             });
 
-            StringAssert.Contains("Protocol error", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Protocol error"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should work right after framenavigated")]
@@ -111,7 +111,7 @@ namespace PuppeteerSharp.Tests.PageTests
             };
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(42, await frameEvaluation);
+            Assert.That(await frameEvaluation, Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should work from-inside an exposed function")]
@@ -124,7 +124,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var result = await Page.EvaluateFunctionAsync<int>(@"async function() {
                 return await callController(9, 3);
             }");
-            Assert.AreEqual(27, result);
+            Assert.That(result, Is.EqualTo(27));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should reject promise with exception")]
@@ -135,7 +135,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 return Page.EvaluateFunctionAsync("() => not_existing_object.property");
             });
 
-            StringAssert.Contains("not_existing_object", exception.Message);
+            Assert.That(exception.Message, Does.Contain("not_existing_object"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should support thrown strings as error messages")]
@@ -143,7 +143,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(
                 () => Page.EvaluateExpressionAsync("throw 'qwerty'"));
-            StringAssert.Contains("qwerty", exception.Message);
+            Assert.That(exception.Message, Does.Contain("qwerty"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should support thrown numbers as error messages")]
@@ -151,7 +151,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(
                             () => Page.EvaluateExpressionAsync("throw 100500"));
-            StringAssert.Contains("100500", exception.Message);
+            Assert.That(exception.Message, Does.Contain("100500"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should return complex objects")]
@@ -162,14 +162,14 @@ namespace PuppeteerSharp.Tests.PageTests
                 foo = "bar!"
             };
             var result = await Page.EvaluateFunctionAsync("a => a", obj);
-            Assert.AreEqual("bar!", result.foo.ToString());
+            Assert.That(result.foo.ToString(), Is.EqualTo("bar!"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should return BigInt")]
         public async Task ShouldReturnBigInt()
         {
             var result = await Page.EvaluateFunctionAsync<object>("() => BigInt(42)");
-            Assert.AreEqual(new BigInteger(42), result);
+            Assert.That(result, Is.EqualTo(new BigInteger(42)));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task BasicEvaluationTest(string script, object expected)
         {
             var result = await Page.EvaluateFunctionAsync<object>(script);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should accept \"undefined\" as one of multiple parameters")]
@@ -195,12 +195,12 @@ namespace PuppeteerSharp.Tests.PageTests
                 "(a, b) => Object.is(a, null) && Object.is(b, 'foo')",
                 null,
                 "foo");
-            Assert.True(result);
+            Assert.That(result, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should return undefined for non-serializable objects")]
         public async Task ShouldReturnNullForNonSerializableObjects()
-            => Assert.Null(await Page.EvaluateFunctionAsync("() => window"));
+            => Assert.That(await Page.EvaluateFunctionAsync("() => window"), Is.Null);
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should fail for circular object")]
         public async Task ShouldFailForCircularObject()
@@ -212,7 +212,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 return a;
             }");
 
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should be able to throw a tricky error")]
@@ -226,7 +226,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 throw new Error(errorText);
             }", errorText));
-            StringAssert.Contains(errorText, exception.Message);
+            Assert.That(exception.Message, Does.Contain(errorText));
         }
 
         [Test]
@@ -240,7 +240,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task BasicIntExressionEvaluationTest(string script, object expected)
         {
             var result = await Page.EvaluateExpressionAsync<int>(script);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should accept element handle as an argument")]
@@ -249,7 +249,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.SetContentAsync("<section>42</section>");
             var element = await Page.QuerySelectorAsync("section");
             var text = await Page.EvaluateFunctionAsync<string>("e => e.textContent", element);
-            Assert.AreEqual("42", text);
+            Assert.That(text, Is.EqualTo("42"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should throw if underlying element was disposed")]
@@ -257,11 +257,11 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.SetContentAsync("<section>39</section>");
             var element = await Page.QuerySelectorAsync("section");
-            Assert.NotNull(element);
+            Assert.That(element, Is.Not.Null);
             await element.DisposeAsync();
             var exception = Assert.ThrowsAsync<PuppeteerException>(()
                 => Page.EvaluateFunctionAsync<string>("e => e.textContent", element));
-            StringAssert.Contains("JSHandle is disposed", exception.Message);
+            Assert.That(exception.Message, Does.Contain("JSHandle is disposed"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should throw if elementHandles are from other frames")]
@@ -271,16 +271,16 @@ namespace PuppeteerSharp.Tests.PageTests
             var bodyHandle = await Page.FirstChildFrame().QuerySelectorAsync("body");
             var exception = Assert.ThrowsAsync<PuppeteerException>(()
                 => Page.EvaluateFunctionAsync<string>("body => body.innerHTML", bodyHandle));
-            StringAssert.Contains("JSHandles can be evaluated only in the context they were created", exception.Message);
+            Assert.That(exception.Message, Does.Contain("JSHandles can be evaluated only in the context they were created"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should simulate a user gesture")]
         public async Task ShouldSimulateAUserGesture()
-            => Assert.True(await Page.EvaluateFunctionAsync<bool>(@"() => {
+            => Assert.That(await Page.EvaluateFunctionAsync<bool>(@"() => {
                 document.body.appendChild(document.createTextNode('test'));
                 document.execCommand('selectAll');
                 return document.execCommand('copy');
-            }"));
+            }"), Is.True);
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should not throw an error when evaluation does a navigation")]
         public async Task ShouldNotThrowAnErrorWhenEvaluationDoesANavigation()
@@ -291,14 +291,14 @@ namespace PuppeteerSharp.Tests.PageTests
                 window.location = '/empty.html';
                 return [42];
             }");
-            Assert.AreEqual(new[] { 42 }, result);
+            Assert.That(result, Is.EqualTo(new[] { 42 }));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should transfer 100Mb of data from page to node.js")]
         public async Task ShouldTransfer100MbOfDataFromPage()
         {
             var a = await Page.EvaluateFunctionAsync<string>("() => Array(100 * 1024 * 1024 + 1).join('a')");
-            Assert.AreEqual(100 * 1024 * 1024, a.Length);
+            Assert.That(a, Has.Length.EqualTo(100 * 1024 * 1024));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should throw error with detailed information on exception inside promise ")]
@@ -309,32 +309,32 @@ namespace PuppeteerSharp.Tests.PageTests
                     @"() => new Promise(() => {
                         throw new Error('Error in promise');
                     })"));
-            StringAssert.Contains("Error in promise", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Error in promise"));
         }
 
         public async Task ShouldWorkWithDifferentSerializerSettings()
         {
             var result = await Page.EvaluateFunctionAsync<ComplexObjectTestClass>("() => { return { foo: 'bar' }}");
-            Assert.AreEqual("bar", result.Foo);
+            Assert.That(result.Foo, Is.EqualTo("bar"));
 
             result = (await Page.EvaluateFunctionAsync<JToken>("() => { return { Foo: 'bar' }}"))
                 .ToObject<ComplexObjectTestClass>(new JsonSerializerSettings());
-            Assert.AreEqual("bar", result.Foo);
+            Assert.That(result.Foo, Is.EqualTo("bar"));
 
             result = await Page.EvaluateExpressionAsync<ComplexObjectTestClass>("var obj = { foo: 'bar' }; obj;");
-            Assert.AreEqual("bar", result.Foo);
+            Assert.That(result.Foo, Is.EqualTo("bar"));
 
             result = (await Page.EvaluateExpressionAsync<JToken>("var obj = { Foo: 'bar' }; obj;"))
                 .ToObject<ComplexObjectTestClass>(new JsonSerializerSettings());
-            Assert.AreEqual("bar", result.Foo);
+            Assert.That(result.Foo, Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should properly serialize null fields")]
         public async Task ShouldProperlySerializeNullFields()
         {
             var result = await Page.EvaluateFunctionAsync<Dictionary<string, object>>("() => ({a: null})");
-            Assert.True(result.ContainsKey("a"));
-            Assert.Null(result["a"]);
+            Assert.That(result.ContainsKey("a"), Is.True);
+            Assert.That(result["a"], Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should accept element handle as an argument")]
@@ -343,28 +343,28 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.SetContentAsync("<section>42</section>");
             var element = await Page.QuerySelectorAsync("section");
             var text = await Page.EvaluateFunctionAsync<string>("(e) => e.textContent", element);
-            Assert.AreEqual("42", text);
+            Assert.That(text, Is.EqualTo("42"));
         }
 
         public async Task ShouldWorkWithoutGenerics()
         {
-            Assert.NotNull(await Page.EvaluateExpressionAsync("var obj = {}; obj;"));
-            Assert.NotNull(await Page.EvaluateExpressionAsync("[]"));
-            Assert.NotNull(await Page.EvaluateExpressionAsync("''"));
+            Assert.That(await Page.EvaluateExpressionAsync("var obj = {}; obj;"), Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync("[]"), Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync("''"), Is.Not.Null);
 
             var objectPopulated = await Page.EvaluateExpressionAsync("var obj = {a:1}; obj;");
-            Assert.NotNull(objectPopulated);
-            Assert.AreEqual(1, objectPopulated["a"]);
+            Assert.That(objectPopulated, Is.Not.Null);
+            Assert.That(objectPopulated["a"], Is.EqualTo(1));
 
             var arrayPopulated = await Page.EvaluateExpressionAsync("[1]");
-            Assert.IsInstanceOf<JArray>(arrayPopulated);
-            Assert.AreEqual(1, ((JArray)arrayPopulated)[0]);
+            Assert.That(arrayPopulated, Is.InstanceOf<JArray>());
+            Assert.That(((JArray)arrayPopulated)[0], Is.EqualTo(1));
 
-            Assert.AreEqual("1", await Page.EvaluateExpressionAsync("'1'"));
-            Assert.AreEqual(1, await Page.EvaluateExpressionAsync("1"));
-            Assert.AreEqual(11111111, await Page.EvaluateExpressionAsync("11111111"));
-            Assert.AreEqual(11111111111111, await Page.EvaluateExpressionAsync("11111111111111"));
-            Assert.AreEqual(1.1, await Page.EvaluateExpressionAsync("1.1"));
+            Assert.That(await Page.EvaluateExpressionAsync("'1'"), Is.EqualTo("1"));
+            Assert.That(await Page.EvaluateExpressionAsync("1"), Is.EqualTo(1));
+            Assert.That(await Page.EvaluateExpressionAsync("11111111"), Is.EqualTo(11111111));
+            Assert.That(await Page.EvaluateExpressionAsync("11111111111111"), Is.EqualTo(11111111111111));
+            Assert.That(await Page.EvaluateExpressionAsync("1.1"), Is.EqualTo(1.1));
         }
 
         public class ComplexObjectTestClass

--- a/lib/PuppeteerSharp.Tests/EvaluationTests/RemoveScriptToEvaluateOnNewDocumentTests.cs
+++ b/lib/PuppeteerSharp.Tests/EvaluationTests/RemoveScriptToEvaluateOnNewDocumentTests.cs
@@ -12,12 +12,12 @@ namespace PuppeteerSharp.Tests.EvaluationTests
             var id = await Page.EvaluateFunctionOnNewDocumentAsync("() => globalThis.injected = 123");
             await Page.GoToAsync(TestConstants.ServerUrl + "/tamperable.html");
             var result = await Page.EvaluateFunctionAsync<int>("async () => globalThis.result");
-            Assert.AreEqual(123, result);
+            Assert.That(result, Is.EqualTo(123));
 
             await Page.RemoveScriptToEvaluateOnNewDocumentAsync(id.Identifier);
 
             await Page.ReloadAsync();
-            Assert.IsNull(await Page.EvaluateFunctionAsync("() => globalThis.result ?? null"));
+            Assert.That(await Page.EvaluateFunctionAsync("() => globalThis.result ?? null"), Is.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ExtensionsTests/ExtensionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/ExtensionsTests/ExtensionsTests.cs
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.Tests.ExtensionsTests
             await using (await browserWithExtension.NewPageAsync())
             {
                 var backgroundPageTarget = await browserWithExtension.WaitForTargetAsync(t => t.Type == TargetType.BackgroundPage);
-                Assert.NotNull(backgroundPageTarget);
+                Assert.That(backgroundPageTarget, Is.Not.Null);
             }
         }
 
@@ -53,7 +53,7 @@ namespace PuppeteerSharp.Tests.ExtensionsTests
                 TestConstants.LoggerFactory);
             var serviceWorkTarget = await browserWithExtension.WaitForTargetAsync(t => t.Type == TargetType.ServiceWorker);
             await using var page = await browserWithExtension.NewPageAsync();
-            Assert.NotNull(serviceWorkTarget);
+            Assert.That(serviceWorkTarget, Is.Not.Null);
 
         }
 
@@ -65,8 +65,8 @@ namespace PuppeteerSharp.Tests.ExtensionsTests
                 TestConstants.LoggerFactory);
             var backgroundPageTarget = await browserWithExtension.WaitForTargetAsync(t => t.Type == TargetType.BackgroundPage);
             await using var page = await backgroundPageTarget.PageAsync();
-            Assert.AreEqual(6, await page.EvaluateFunctionAsync<int>("() => 2 * 3"));
-            Assert.AreEqual(42, await page.EvaluateFunctionAsync<int>("() => window.MAGIC"));
+            Assert.That(await page.EvaluateFunctionAsync<int>("() => 2 * 3"), Is.EqualTo(6));
+            Assert.That(await page.EvaluateFunctionAsync<int>("() => window.MAGIC"), Is.EqualTo(42));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.FixturesTests
             process.Start();
             process.BeginErrorReadLine();
             process.WaitForExit();
-            Assert.True(success);
+            Assert.That(success, Is.True);
         }
 
         public async Task ShouldCloseTheBrowserWhenTheConnectedProcessCloses()
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests.FixturesTests
             KillProcess(chromiumLauncher.Process.Id);
 
             await browserClosedTaskWrapper.Task;
-            Assert.True(browser.IsClosed);
+            Assert.That(browser.IsClosed, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("fixtures.spec", "Fixtures", "should close the browser when the node process closes")]
@@ -77,7 +77,7 @@ namespace PuppeteerSharp.Tests.FixturesTests
             KillProcess(browser.Process.Id);
 
             await browserClosedTaskWrapper.Task;
-            Assert.True(browser.IsClosed);
+            Assert.That(browser.IsClosed, Is.True);
         }
 
         private void KillProcess(int pid)

--- a/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.FixturesTests
             Assert.That(success, Is.True);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldCloseTheBrowserWhenTheConnectedProcessCloses()
         {
             var browserClosedTaskWrapper = new TaskCompletionSource<bool>();

--- a/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
+++ b/lib/PuppeteerSharp.Tests/FixturesTests/FixturesTests.cs
@@ -31,6 +31,7 @@ namespace PuppeteerSharp.Tests.FixturesTests
             Assert.That(success, Is.True);
         }
 
+        [Test]
         public async Task ShouldCloseTheBrowserWhenTheConnectedProcessCloses()
         {
             var browserClosedTaskWrapper = new TaskCompletionSource<bool>();

--- a/lib/PuppeteerSharp.Tests/FrameTests/EvaluateHandleTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/EvaluateHandleTests.cs
@@ -16,7 +16,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var windowHandle = await Page.MainFrame.EvaluateExpressionHandleAsync("window");
-            Assert.NotNull(windowHandle);
+            Assert.That(windowHandle, Is.Not.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameEvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameEvaluateTests.cs
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             var exception = Assert.ThrowsAsync<PuppeteerException>(
                 () => frame.EvaluateExpressionAsync("5 * 8"));
-            StringAssert.Contains("Execution Context is not available in detached frame", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Execution Context is not available in detached frame"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
@@ -12,9 +12,8 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldHandleNestedFrames()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
-            Assert.AreEqual(
-                TestConstants.NestedFramesDumpResult,
-                await FrameUtils.DumpFramesAsync(Page.MainFrame));
+            Assert.That(await FrameUtils.DumpFramesAsync(Page.MainFrame),
+                Is.EqualTo(TestConstants.NestedFramesDumpResult));
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should send events when frames are manipulated dynamically")]
@@ -29,7 +28,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", "./Assets/frame.html");
 
             Assert.That(attachedFrames, Has.Exactly(1).Items);
-            StringAssert.Contains("/Assets/frame.html", attachedFrames[0].Url);
+            Assert.That(attachedFrames[0].Url, Does.Contain("/Assets/frame.html"));
 
             // validate frame navigated events
             var navigatedFrames = new List<IFrame>();
@@ -37,7 +36,7 @@ namespace PuppeteerSharp.Tests.FrameTests
 
             await FrameUtils.NavigateFrameAsync(Page, "frame1", "./empty.html");
             Assert.That(navigatedFrames, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.EmptyPage, navigatedFrames[0].Url);
+            Assert.That(navigatedFrames[0].Url, Is.EqualTo(TestConstants.EmptyPage));
 
             // validate frame detached events
             var detachedFrames = new List<IFrame>();
@@ -45,7 +44,7 @@ namespace PuppeteerSharp.Tests.FrameTests
 
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             Assert.That(detachedFrames, Has.Exactly(1).Items);
-            Assert.True(detachedFrames[0].Detached);
+            Assert.That(detachedFrames[0].Detached, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should send \"framenavigated\" when navigating on anchor URLs")]
@@ -58,15 +57,15 @@ namespace PuppeteerSharp.Tests.FrameTests
                 Page.GoToAsync(TestConstants.EmptyPage + "#foo"),
                 frameNavigated.Task
             );
-            Assert.AreEqual(TestConstants.EmptyPage + "#foo", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage + "#foo"));
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should support url fragment")]
         public async Task ShouldReturnUrlFragmentAsPartOfUrl()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame-url-fragment.html");
-            Assert.AreEqual(2, Page.Frames.Length);
-            Assert.AreEqual(TestConstants.ServerUrl + "/frames/frame.html?param=value#fragment", Page.FirstChildFrame().Url);
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
+            Assert.That(Page.FirstChildFrame().Url, Is.EqualTo(TestConstants.ServerUrl + "/frames/frame.html?param=value#fragment"));
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should persist mainFrame on cross-process navigation")]
@@ -75,7 +74,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             var mainFrame = Page.MainFrame;
             await Page.GoToAsync(TestConstants.CrossProcessUrl + "/empty.html");
-            Assert.AreEqual(mainFrame, Page.MainFrame);
+            Assert.That(Page.MainFrame, Is.EqualTo(mainFrame));
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should not send attach/detach events for main frame")]
@@ -86,7 +85,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             Page.FrameDetached += (_, _) => hasEvents = true;
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.False(hasEvents);
+            Assert.That(hasEvents, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should detach child frames on navigation")]
@@ -101,17 +100,17 @@ namespace PuppeteerSharp.Tests.FrameTests
             Page.FrameNavigated += (_, e) => navigatedFrames.Add(e.Frame);
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
-            Assert.AreEqual(4, attachedFrames.Count);
-            Assert.IsEmpty(detachedFrames);
-            Assert.AreEqual(5, navigatedFrames.Count);
+            Assert.That(attachedFrames, Has.Count.EqualTo(4));
+            Assert.That(detachedFrames, Is.Empty);
+            Assert.That(navigatedFrames, Has.Count.EqualTo(5));
 
             attachedFrames.Clear();
             detachedFrames.Clear();
             navigatedFrames.Clear();
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.IsEmpty(attachedFrames);
-            Assert.AreEqual(4, detachedFrames.Count);
+            Assert.That(attachedFrames, Is.Empty);
+            Assert.That(detachedFrames, Has.Count.EqualTo(4));
             Assert.That(navigatedFrames, Has.Exactly(1).Items);
         }
 
@@ -121,7 +120,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/frameset.html");
             var frame = await Page.WaitForFrameAsync(frame => frame.Url.EndsWith("/frames/frame.html"));
             var div = await frame.WaitForSelectorAsync("div");
-            Assert.NotNull(div);
+            Assert.That(div, Is.Not.Null);
             await div.ClickAsync();
         }
 
@@ -136,7 +135,7 @@ namespace PuppeteerSharp.Tests.FrameTests
                 document.body.shadowRoot.appendChild(frame);
                 await new Promise(x => frame.onload = x);
             }", TestConstants.EmptyPage);
-            Assert.AreEqual(2, Page.Frames.Length);
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
             Assert.That(Page.Frames.Where(frame => frame.Url == TestConstants.EmptyPage), Has.Exactly(1).Items);
         }
 
@@ -147,7 +146,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage);
 
             Assert.That(Page.Frames.Where(frame => frame.ParentFrame == null), Has.Exactly(1).Items);
-            Assert.AreEqual(2, Page.Frames.Count(f => f.ParentFrame == Page.MainFrame));
+            Assert.That(Page.Frames.Count(f => f.ParentFrame == Page.MainFrame), Is.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should report different frame instance when frame re-attaches")]
@@ -158,13 +157,13 @@ namespace PuppeteerSharp.Tests.FrameTests
                 window.frame = document.querySelector('#frame1');
                 window.frame.remove();
             }");
-            Assert.True(frame1.Detached);
+            Assert.That(frame1.Detached, Is.True);
             var frame2Tcs = new TaskCompletionSource<IFrame>();
             Page.FrameAttached += (_, e) => frame2Tcs.TrySetResult(e.Frame);
             await Page.EvaluateExpressionAsync("document.body.appendChild(window.frame)");
             var frame2 = await frame2Tcs.Task;
-            Assert.False(frame2.Detached);
-            Assert.AreNotSame(frame1, frame2);
+            Assert.That(frame2.Detached, Is.False);
+            Assert.That(frame2, Is.Not.SameAs(frame1));
         }
 
         [Test, Retry(2), PuppeteerTest("frame.spec", "Frame specs Frame Management", "should support framesets")]
@@ -180,17 +179,17 @@ namespace PuppeteerSharp.Tests.FrameTests
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/frameset.html");
 
-            Assert.AreEqual(4, attachedFrames.Count);
-            Assert.IsEmpty(detachedFrames);
-            Assert.AreEqual(5, navigatedFrames.Count);
+            Assert.That(attachedFrames, Has.Count.EqualTo(4));
+            Assert.That(detachedFrames, Is.Empty);
+            Assert.That(navigatedFrames, Has.Count.EqualTo(5));
 
             attachedFrames.Clear();
             detachedFrames.Clear();
             navigatedFrames.Clear();
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.IsEmpty(attachedFrames);
-            Assert.AreEqual(4, detachedFrames.Count);
+            Assert.That(attachedFrames, Is.Empty);
+            Assert.That(detachedFrames, Has.Count.EqualTo(4));
             Assert.That(navigatedFrames, Has.Exactly(1).Items);
         }
     }

--- a/lib/PuppeteerSharp.Tests/HeadfulTests/HeadfulTests.cs
+++ b/lib/PuppeteerSharp.Tests/HeadfulTests/HeadfulTests.cs
@@ -33,7 +33,7 @@ namespace PuppeteerSharp.Tests.HeadfulTests
             {
                 var headlessPage = await headlessBrowser.NewPageAsync();
                 await headlessPage.GoToAsync(TestConstants.EmptyPage);
-                Assert.AreEqual("foo=true", await headlessPage.EvaluateExpressionAsync<string>("document.cookie"));
+                Assert.That(await headlessPage.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("foo=true"));
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/IdleOverrideTests/IdleOverrideTests.cs
+++ b/lib/PuppeteerSharp.Tests/IdleOverrideTests/IdleOverrideTests.cs
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.IdleOverrideTests
         private async Task VerifyStateAsync(string expectedState)
         {
             var actualState = await GetIdleStateAsync();
-            Assert.AreEqual(expectedState, actualState);
+            Assert.That(actualState, Is.EqualTo(expectedState));
         }
 
         [Test, Retry(2), PuppeteerTest("idle_override.spec", "Emulate idle state", "changing idle state emulation causes change of the IdleDetector state")]

--- a/lib/PuppeteerSharp.Tests/IgnoreHttpsErrorsTests/IgnoreHttpsErrorsTests.cs
+++ b/lib/PuppeteerSharp.Tests/IgnoreHttpsErrorsTests/IgnoreHttpsErrorsTests.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.IgnoreHttpsErrorsTests
         public async Task ShouldWork()
         {
             var response = await Page.GoToAsync($"{TestConstants.HttpsPrefix}/empty.html");
-            Assert.True(response.Ok);
+            Assert.That(response.Ok, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("ignorehttpserrors.spec", "ignoreHTTPSErrors", "should work with request interception")]
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.IgnoreHttpsErrorsTests
             await Page.SetRequestInterceptionAsync(true);
             Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("ignorehttpserrors.spec", "ignoreHTTPSErrors", "should work with mixed content")]
@@ -45,11 +45,11 @@ namespace PuppeteerSharp.Tests.IgnoreHttpsErrorsTests
             {
                 WaitUntil = new[] { WaitUntilNavigation.Load }
             });
-            Assert.AreEqual(2, Page.Frames.Length);
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
             // Make sure blocked iframe has functional execution context
             // @see https://github.com/GoogleChrome/puppeteer/issues/2709
-            Assert.AreEqual(3, await Page.MainFrame.EvaluateExpressionAsync<int>("1 + 2"));
-            Assert.AreEqual(5, await Page.FirstChildFrame().EvaluateExpressionAsync<int>("2 + 3"));
+            Assert.That(await Page.MainFrame.EvaluateExpressionAsync<int>("1 + 2"), Is.EqualTo(3));
+            Assert.That(await Page.FirstChildFrame().EvaluateExpressionAsync<int>("2 + 3"), Is.EqualTo(5));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/IgnoreHttpsErrorsTests/ResponseSecurityDetailsTests.cs
+++ b/lib/PuppeteerSharp.Tests/IgnoreHttpsErrorsTests/ResponseSecurityDetailsTests.cs
@@ -25,16 +25,16 @@ namespace PuppeteerSharp.Tests.IgnoreHttpsErrorsTests
             // We don't need to test that here.
 
             var response = await Page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.NotNull(response.SecurityDetails);
-            StringAssert.Contains("TLS", response.SecurityDetails.Protocol);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.SecurityDetails, Is.Not.Null);
+            Assert.That(response.SecurityDetails.Protocol, Does.Contain("TLS"));
         }
 
         [Test, Retry(2), PuppeteerTest("ignorehttpserrors.spec", "Response.securityDetails", "should be |null| for non-secure requests")]
         public async Task ShouldBeNullForNonSecureRequests()
         {
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.Null(response.SecurityDetails);
+            Assert.That(response.SecurityDetails, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("ignorehttpserrors.spec", "Response.securityDetails", "Network redirects should report SecurityDetails")]
@@ -57,11 +57,10 @@ namespace PuppeteerSharp.Tests.IgnoreHttpsErrorsTests
 
             var response = responseTask.Result;
 
-            Assert.AreEqual(2, responses.Count);
-            Assert.AreEqual(HttpStatusCode.Found, responses[0].Status);
-            Assert.AreEqual(
-                TestUtils.CurateProtocol(requestTask.Result.ToString()),
-                TestUtils.CurateProtocol(response.SecurityDetails.Protocol));
+            Assert.That(responses, Has.Count.EqualTo(2));
+            Assert.That(responses[0].Status, Is.EqualTo(HttpStatusCode.Found));
+            Assert.That(TestUtils.CurateProtocol(response.SecurityDetails.Protocol),
+                Is.EqualTo(TestUtils.CurateProtocol(requestTask.Result.ToString())));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/InjectedTests/InjectedTests.cs
+++ b/lib/PuppeteerSharp.Tests/InjectedTests/InjectedTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.InjectedTests
                         return typeof PuppeteerUtil === 'object';
                       }",
                       new LazyArg(async context => await context.GetPuppeteerUtilAsync().ConfigureAwait(false)));
-            Assert.True(result);
+            Assert.That(result, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("injected.spec", "createFunction tests", "should work")]
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.InjectedTests
                 }",
                 new LazyArg(async context => await context.GetPuppeteerUtilAsync().ConfigureAwait(false)),
                 "() => 4");
-            Assert.AreEqual(4, result);
+            Assert.That(result, Is.EqualTo(4));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserAcceptTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserAcceptTests.cs
@@ -29,10 +29,10 @@ namespace PuppeteerSharp.Tests.InputTests
                 waitForTask.Result.AcceptAsync(TestConstants.FileToUpload),
                 metricsTcs.Task);
 
-            Assert.AreEqual(1, await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<int>("input => input.files.length"));
-            Assert.AreEqual(
-                "file-to-upload.txt",
-                await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<string>("input => input.files[0].name"));
+            Assert.That(await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<int>("input => input.files.length"), Is.EqualTo(1));
+            Assert.That(
+                await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<string>("input => input.files[0].name"),
+                Is.EqualTo("file-to-upload.txt"));
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "FileChooser.accept", "should be able to read selected file")]
@@ -41,8 +41,7 @@ namespace PuppeteerSharp.Tests.InputTests
             await Page.SetContentAsync("<input type=file>");
             _ = Page.WaitForFileChooserAsync().ContinueWith(t => t.Result.AcceptAsync(TestConstants.FileToUpload));
 
-            Assert.AreEqual(
-                "contents of the file",
+            Assert.That(
                 await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<string>(@"async picker =>
                 {
                     picker.click();
@@ -51,7 +50,7 @@ namespace PuppeteerSharp.Tests.InputTests
                     const promise = new Promise(fulfill => reader.onload = fulfill);
                     reader.readAsText(picker.files[0]);
                     return promise.then(() => reader.result);
-                }"));
+                }"), Is.EqualTo("contents of the file"));
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "FileChooser.accept", "should be able to reset selected files with empty file list")]
@@ -60,25 +59,23 @@ namespace PuppeteerSharp.Tests.InputTests
             await Page.SetContentAsync("<input type=file>");
             _ = Page.WaitForFileChooserAsync().ContinueWith(t => t.Result.AcceptAsync(TestConstants.FileToUpload));
 
-            Assert.AreEqual(
-                1,
+            Assert.That(
                 await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<int>(@"async picker =>
                 {
                 picker.click();
                 await new Promise(x => picker.oninput = x);
                 return picker.files.length;
-            }"));
+            }"), Is.EqualTo(1));
 
             _ = Page.WaitForFileChooserAsync().ContinueWith(t => t.Result.AcceptAsync());
 
-            Assert.AreEqual(
-                0,
+            Assert.That(
                 await Page.QuerySelectorAsync("input").EvaluateFunctionAsync<int>(@"async picker =>
                 {
                 picker.click();
                 await new Promise(x => picker.oninput = x);
                 return picker.files.length;
-            }"));
+            }"), Is.EqualTo(0));
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "FileChooser.accept", "should not accept multiple files for single-file input")]
@@ -122,7 +119,7 @@ namespace PuppeteerSharp.Tests.InputTests
             var fileChooser = waitForTask.Result;
             await fileChooser.AcceptAsync();
             var ex = Assert.ThrowsAsync<PuppeteerException>(() => waitForTask.Result.AcceptAsync());
-            Assert.AreEqual("Cannot accept FileChooser which is already handled!", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Cannot accept FileChooser which is already handled!"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserCancelTests.cs
@@ -47,7 +47,7 @@ namespace PuppeteerSharp.Tests.InputTests
             await fileChooser.CancelAsync();
 
             var ex = Assert.ThrowsAsync<PuppeteerException>(() => fileChooser.CancelAsync());
-            Assert.AreEqual("Cannot accept FileChooser which is already handled!", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Cannot accept FileChooser which is already handled!"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/InputTests/FileChooserIsMultipleTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/FileChooserIsMultipleTests.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 waitForTask,
                 Page.ClickAsync("input"));
 
-            Assert.False(waitForTask.Result.IsMultiple);
+            Assert.That(waitForTask.Result.IsMultiple, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "FileChooser.isMultiple", "should work for \"multiple\"")]
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 waitForTask,
                 Page.ClickAsync("input"));
 
-            Assert.True(waitForTask.Result.IsMultiple);
+            Assert.That(waitForTask.Result.IsMultiple, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "FileChooser.isMultiple", "should work for \"webkitdirectory\"")]
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 waitForTask,
                 Page.ClickAsync("input"));
 
-            Assert.True(waitForTask.Result.IsMultiple);
+            Assert.That(waitForTask.Result.IsMultiple, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/InputTests/InputTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/InputTests.cs
@@ -19,13 +19,13 @@ namespace PuppeteerSharp.Tests.InputTests
             var filePath = TestConstants.FileToUpload;
             var input = await Page.QuerySelectorAsync("input");
             await input.UploadFileAsync(filePath);
-            Assert.AreEqual("file-to-upload.txt", await Page.EvaluateFunctionAsync<string>("e => e.files[0].name", input));
-            Assert.AreEqual("contents of the file", await Page.EvaluateFunctionAsync<string>(@"e => {
+            Assert.That(await Page.EvaluateFunctionAsync<string>("e => e.files[0].name", input), Is.EqualTo("file-to-upload.txt"));
+            Assert.That(await Page.EvaluateFunctionAsync<string>(@"e => {
                 const reader = new FileReader();
                 const promise = new Promise(fulfill => reader.onload = fulfill);
                 reader.readAsText(e.files[0]);
                 return promise.then(() => reader.result);
-            }", input));
+            }", input), Is.EqualTo("contents of the file"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/InputTests/PageWaitForFileChooserTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/PageWaitForFileChooserTests.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 waitForTask,
                 Page.ClickAsync("input"));
 
-            Assert.NotNull(waitForTask.Result);
+            Assert.That(waitForTask.Result, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "Page.waitForFileChooser", "should work when file input is not attached to DOM")]
@@ -39,7 +39,7 @@ namespace PuppeteerSharp.Tests.InputTests
                     el.click();
                 }"));
 
-            Assert.NotNull(waitForTask.Result);
+            Assert.That(waitForTask.Result, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "Page.waitForFileChooser", "should respect timeout")]
@@ -81,7 +81,7 @@ namespace PuppeteerSharp.Tests.InputTests
                     el.type = 'file';
                     el.click();
                 }, 50)"));
-            Assert.NotNull(waitForTask.Result);
+            Assert.That(waitForTask.Result, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("input.spec", "Page.waitForFileChooser", "should return the same file chooser when there are many watchdogs simultaneously")]
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.InputTests
                 fileChooserTask1,
                 fileChooserTask2,
                 Page.QuerySelectorAsync("input").EvaluateFunctionAsync("input => input.click()"));
-            Assert.AreSame(fileChooserTask1.Result, fileChooserTask2.Result);
+            Assert.That(fileChooserTask2.Result, Is.SameAs(fileChooserTask1.Result));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue 2251.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue 2251.cs
@@ -13,9 +13,9 @@ namespace PuppeteerSharp.Tests.Issues
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             // Test case
-            Assert.IsEmpty(await Page.QuerySelectorAllAsync("xpath///one-app-nav-bar-item-root/button[count(.//*[contains(@icon-name, 'close')]) > 0]"));
+            Assert.That(await Page.QuerySelectorAllAsync("xpath///one-app-nav-bar-item-root/button[count(.//*[contains(@icon-name, 'close')]) > 0]"), Is.Empty);
             // check that the Xpath really works
-            Assert.IsNotEmpty(await Page.QuerySelectorAllAsync("xpath///img"));
+            Assert.That(await Page.QuerySelectorAllAsync("xpath///img"), Is.Not.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0100.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0100.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.Issues
             {
                 await page.GoToAsync("https://darksky.net/forecast/51.2211,4.3997/si12/en");
                 var pdf = await page.PdfDataAsync();
-                Assert.NotNull(pdf);
+                Assert.That(pdf, Is.Not.Null);
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0343.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0343.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.Issues
                 Expires = longExpiresValue
             });
             var cookies = await Page.GetCookiesAsync();
-            Assert.AreEqual(longExpiresValue, cookies.First(c => c.Name == "password").Expires);
+            Assert.That(cookies.First(c => c.Name == "password").Expires, Is.EqualTo(longExpiresValue));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0616.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0616.cs
@@ -36,8 +36,8 @@ namespace PuppeteerSharp.Tests.Issues
             });
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
 
-            Assert.AreEqual(TestConstants.ServerUrl + "/grid.html", response.Url);
-            Assert.AreEqual("foo", await response.TextAsync());
+            Assert.That(response.Url, Is.EqualTo(TestConstants.ServerUrl + "/grid.html"));
+            Assert.That(await response.TextAsync(), Is.EqualTo("foo"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue0764.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0764.cs
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.Issues
             await Task.WhenAll(
                 Page.GoToAsync(TestConstants.ServerUrl + "/grid.html"),
                 tcs.Task);
-            Assert.True(ScreenshotHelper.PixelMatch("0.png", await tcs.Task));
+            Assert.That(ScreenshotHelper.PixelMatch("0.png", await tcs.Task), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/Issues/Issue1354.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue1354.cs
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.Issues
 
                 // Deep inside an existing mostly sync app...
                 var content = page.GetContentAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-                StringAssert.Contains("REPLACE", content);
+                Assert.That(content, Does.Contain("REPLACE"));
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/AsElementTests.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/AsElementTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         {
             var aHandle = await Page.EvaluateExpressionHandleAsync("document.body");
             var element = aHandle as IElementHandle;
-            Assert.NotNull(element);
+            Assert.That(element, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.asElement", "should return null for non-elements")]
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         {
             var aHandle = await Page.EvaluateExpressionHandleAsync("2");
             var element = aHandle as IElementHandle;
-            Assert.Null(element);
+            Assert.That(element, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.asElement", "should return ElementHandle for TextNodes")]
@@ -32,8 +32,8 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             await Page.SetContentAsync("<div>ee!</div>");
             var aHandle = await Page.EvaluateExpressionHandleAsync("document.querySelector('div').firstChild");
             var element = aHandle as IElementHandle;
-            Assert.NotNull(element);
-            Assert.True(await Page.EvaluateFunctionAsync<bool>("e => e.nodeType === HTMLElement.TEXT_NODE", element));
+            Assert.That(element, Is.Not.Null);
+            Assert.That(await Page.EvaluateFunctionAsync<bool>("e => e.nodeType === HTMLElement.TEXT_NODE", element), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/ClickablePointTests.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/ClickablePointTests.cs
@@ -29,14 +29,14 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             var clickablePoint = await divHandle.ClickablePointAsync();
 
             // margin + middle point offset
-            Assert.AreEqual(45 + 60, clickablePoint.X);
-            Assert.AreEqual(45 + 30, clickablePoint.Y);
+            Assert.That(clickablePoint.X, Is.EqualTo(45 + 60));
+            Assert.That(clickablePoint.Y, Is.EqualTo(45 + 30));
 
             clickablePoint = await divHandle.ClickablePointAsync(new Offset { X = 10, Y = 15 });
 
             // margin + offset
-            Assert.AreEqual(30 + 10, clickablePoint.X);
-            Assert.AreEqual(30 + 15, clickablePoint.Y);
+            Assert.That(clickablePoint.X, Is.EqualTo(30 + 10));
+            Assert.That(clickablePoint.Y, Is.EqualTo(30 + 15));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.clickablePoint", "should work for iframes")]
@@ -56,14 +56,14 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             var clickablePoint = await divHandle.ClickablePointAsync();
 
             // iframe pos + margin + middle point offset
-            Assert.AreEqual(20 + 45 + 60, clickablePoint.X);
-            Assert.AreEqual(20 + 45 + 30, clickablePoint.Y);
+            Assert.That(clickablePoint.X, Is.EqualTo(20 + 45 + 60));
+            Assert.That(clickablePoint.Y, Is.EqualTo(20 + 45 + 30));
 
             clickablePoint = await divHandle.ClickablePointAsync(new Offset { X = 10, Y = 15 });
 
             // iframe pos + margin + offset
-            Assert.AreEqual(20 + 30 + 10, clickablePoint.X);
-            Assert.AreEqual(20 + 30 + 15, clickablePoint.Y);
+            Assert.That(clickablePoint.X, Is.EqualTo(20 + 30 + 10));
+            Assert.That(clickablePoint.Y, Is.EqualTo(20 + 30 + 15));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/GetPropertiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/GetPropertiesTests.cs
@@ -18,8 +18,8 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             })");
             var properties = await aHandle.GetPropertiesAsync();
             properties.TryGetValue("foo", out var foo);
-            Assert.NotNull(foo);
-            Assert.AreEqual("bar", await foo.JsonValueAsync<string>());
+            Assert.That(foo, Is.Not.Null);
+            Assert.That(await foo.JsonValueAsync<string>(), Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.getProperties", "should return even non-own properties")]
@@ -40,8 +40,8 @@ namespace PuppeteerSharp.Tests.JSHandleTests
               return new B();
             }");
             var properties = await aHandle.GetPropertiesAsync();
-            Assert.AreEqual("1", await properties["a"].JsonValueAsync<string>());
-            Assert.AreEqual("2", await properties["b"].JsonValueAsync<string>());
+            Assert.That(await properties["a"].JsonValueAsync<string>(), Is.EqualTo("1"));
+            Assert.That(await properties["b"].JsonValueAsync<string>(), Is.EqualTo("2"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/GetPropertyTests.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/GetPropertyTests.cs
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
               three: 3
             })");
             var twoHandle = await aHandle.GetPropertyAsync("two");
-            Assert.AreEqual(2, await twoHandle.JsonValueAsync<int>());
+            Assert.That(await twoHandle.JsonValueAsync<int>(), Is.EqualTo(2));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/JsonValueTests.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/JsonValueTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         {
             var aHandle = await Page.EvaluateExpressionHandleAsync("({ foo: 'bar'})");
             var json = await aHandle.JsonValueAsync();
-            Assert.AreEqual(JObject.Parse("{ foo: 'bar' }"), json);
+            Assert.That(json, Is.EqualTo(JObject.Parse("{ foo: 'bar' }")));
         }
 
         [Test, Retry(2),
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         {
             var aHandle = await Page.EvaluateFunctionHandleAsync("() => ['a', 'b']");
             var json = await aHandle.JsonValueAsync<string[]>();
-            Assert.AreEqual(new[] { "a", "b" }, json);
+            Assert.That(json, Is.EqualTo(new[] { "a", "b" }));
         }
 
         [Test, Retry(2),
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         {
             var aHandle = await Page.EvaluateFunctionHandleAsync("() => 'foo'");
             var json = await aHandle.JsonValueAsync<string>();
-            Assert.AreEqual("foo", json);
+            Assert.That(json, Is.EqualTo("foo"));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.jsonValue", "should work with dates")]
@@ -43,7 +43,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         {
             var dateHandle = await Page.EvaluateExpressionHandleAsync("new Date('2017-09-26T00:00:00.000Z')");
             var date = await dateHandle.JsonValueAsync<DateTime>();
-            Assert.AreEqual(new DateTime(2017, 9, 26), date);
+            Assert.That(date, Is.EqualTo(new DateTime(2017, 9, 26)));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.jsonValue", "should not throw for circular objects")]

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/PageEvaluateHandle.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/PageEvaluateHandle.cs
@@ -12,7 +12,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle Page.evaluateHandle", "should work")]
         public async Task ShouldWork()
-            => Assert.NotNull(await Page.EvaluateFunctionHandleAsync("() => window"));
+            => Assert.That(await Page.EvaluateFunctionHandleAsync("() => window"), Is.Not.Null);
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle Page.evaluateHandle", "should accept object handle as an argument")]
         public async Task ShouldAcceptObjectHandleAsAnArgument()
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             var text = await Page.EvaluateFunctionAsync<string>(
                 "(e) => e.userAgent",
                 navigatorHandle);
-            StringAssert.Contains("Mozilla", text);
+            Assert.That(text, Does.Contain("Mozilla"));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle Page.evaluateHandle", "should accept object handle to primitive types")]
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             var isFive = await Page.EvaluateFunctionAsync<bool>(
                 "(e) => Object.is(e, 5)",
                 aHandle);
-            Assert.True(isFive);
+            Assert.That(isFive, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle Page.evaluateHandle", "should warn on nested object handles")]
@@ -40,16 +40,16 @@ namespace PuppeteerSharp.Tests.JSHandleTests
             var aHandle = await Page.EvaluateFunctionHandleAsync("() => document.body");
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(() =>
                 Page.EvaluateFunctionHandleAsync("(opts) => opts.elem.querySelector('p')", new { aHandle }));
-            StringAssert.Contains("Are you passing a nested JSHandle?", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Are you passing a nested JSHandle?"));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle Page.evaluateHandle", "should accept object handle to unserializable value")]
         public async Task ShouldAcceptObjectHandleToUnserializableValue()
         {
             var aHandle = await Page.EvaluateFunctionHandleAsync("() => Infinity");
-            Assert.True(await Page.EvaluateFunctionAsync<bool>(
+            Assert.That(await Page.EvaluateFunctionAsync<bool>(
                 "(e) => Object.is(e, Infinity)",
-                aHandle));
+                aHandle), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle Page.evaluateHandle", "should use the same JS wrappers")]
@@ -59,9 +59,9 @@ namespace PuppeteerSharp.Tests.JSHandleTests
                 globalThis.FOO = 123;
                 return window;
             }");
-            Assert.AreEqual(123, await Page.EvaluateFunctionAsync<int>(
+            Assert.That(await Page.EvaluateFunctionAsync<int>(
                 "(e) => e.FOO",
-                aHandle));
+                aHandle), Is.EqualTo(123));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/JSHandleTests/ToStringTests.cs
+++ b/lib/PuppeteerSharp.Tests/JSHandleTests/ToStringTests.cs
@@ -14,39 +14,39 @@ namespace PuppeteerSharp.Tests.JSHandleTests
         public async Task ShouldWorkForPrimitives()
         {
             var numberHandle = await Page.EvaluateExpressionHandleAsync("2");
-            Assert.AreEqual("JSHandle:2", numberHandle.ToString());
+            Assert.That(numberHandle.ToString(), Is.EqualTo("JSHandle:2"));
             var stringHandle = await Page.EvaluateExpressionHandleAsync("'a'");
-            Assert.AreEqual("JSHandle:a", stringHandle.ToString());
+            Assert.That(stringHandle.ToString(), Is.EqualTo("JSHandle:a"));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.toString", "should work for complicated objects")]
         public async Task ShouldWorkForComplicatedObjects()
         {
             var aHandle = await Page.EvaluateExpressionHandleAsync("window");
-            Assert.AreEqual("JSHandle@object", aHandle.ToString());
+            Assert.That(aHandle.ToString(), Is.EqualTo("JSHandle@object"));
         }
 
         [Test, Retry(2), PuppeteerTest("jshandle.spec", "JSHandle JSHandle.toString", "should work with different subtypes")]
         public async Task ShouldWorkWithDifferentSubtypes()
         {
-            Assert.AreEqual("JSHandle@function", (await Page.EvaluateExpressionHandleAsync("(function(){})")).ToString());
-            Assert.AreEqual("JSHandle:12", (await Page.EvaluateExpressionHandleAsync("12")).ToString());
-            Assert.AreEqual("JSHandle:True", (await Page.EvaluateExpressionHandleAsync("true")).ToString());
-            Assert.AreEqual("JSHandle:undefined", (await Page.EvaluateExpressionHandleAsync("undefined")).ToString());
-            Assert.AreEqual("JSHandle:foo", (await Page.EvaluateExpressionHandleAsync("'foo'")).ToString());
-            Assert.AreEqual("JSHandle@symbol", (await Page.EvaluateExpressionHandleAsync("Symbol()")).ToString());
-            Assert.AreEqual("JSHandle@map", (await Page.EvaluateExpressionHandleAsync("new Map()")).ToString());
-            Assert.AreEqual("JSHandle@set", (await Page.EvaluateExpressionHandleAsync("new Set()")).ToString());
-            Assert.AreEqual("JSHandle@array", (await Page.EvaluateExpressionHandleAsync("[]")).ToString());
-            Assert.AreEqual("JSHandle:null", (await Page.EvaluateExpressionHandleAsync("null")).ToString());
-            Assert.AreEqual("JSHandle@regexp", (await Page.EvaluateExpressionHandleAsync("/foo/")).ToString());
-            Assert.AreEqual("JSHandle@node", (await Page.EvaluateExpressionHandleAsync("document.body")).ToString());
-            Assert.AreEqual("JSHandle@date", (await Page.EvaluateExpressionHandleAsync("new Date()")).ToString());
-            Assert.AreEqual("JSHandle@weakmap", (await Page.EvaluateExpressionHandleAsync("new WeakMap()")).ToString());
-            Assert.AreEqual("JSHandle@weakset", (await Page.EvaluateExpressionHandleAsync("new WeakSet()")).ToString());
-            Assert.AreEqual("JSHandle@error", (await Page.EvaluateExpressionHandleAsync("new Error()")).ToString());
-            Assert.AreEqual("JSHandle@typedarray", (await Page.EvaluateExpressionHandleAsync("new Int32Array()")).ToString());
-            Assert.AreEqual("JSHandle@proxy", (await Page.EvaluateExpressionHandleAsync("new Proxy({}, {})")).ToString());
+            Assert.That((await Page.EvaluateExpressionHandleAsync("(function(){})")).ToString(), Is.EqualTo("JSHandle@function"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("12")).ToString(), Is.EqualTo("JSHandle:12"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("true")).ToString(), Is.EqualTo("JSHandle:True"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("undefined")).ToString(), Is.EqualTo("JSHandle:undefined"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("'foo'")).ToString(), Is.EqualTo("JSHandle:foo"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("Symbol()")).ToString(), Is.EqualTo("JSHandle@symbol"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new Map()")).ToString(), Is.EqualTo("JSHandle@map"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new Set()")).ToString(), Is.EqualTo("JSHandle@set"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("[]")).ToString(), Is.EqualTo("JSHandle@array"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("null")).ToString(), Is.EqualTo("JSHandle:null"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("/foo/")).ToString(), Is.EqualTo("JSHandle@regexp"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("document.body")).ToString(), Is.EqualTo("JSHandle@node"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new Date()")).ToString(), Is.EqualTo("JSHandle@date"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new WeakMap()")).ToString(), Is.EqualTo("JSHandle@weakmap"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new WeakSet()")).ToString(), Is.EqualTo("JSHandle@weakset"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new Error()")).ToString(), Is.EqualTo("JSHandle@error"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new Int32Array()")).ToString(), Is.EqualTo("JSHandle@typedarray"));
+            Assert.That((await Page.EvaluateExpressionHandleAsync("new Proxy({}, {})")).ToString(), Is.EqualTo("JSHandle@proxy"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/KeyboardTests/KeyboardTests.cs
+++ b/lib/PuppeteerSharp.Tests/KeyboardTests/KeyboardTests.cs
@@ -20,7 +20,7 @@ namespace PuppeteerSharp.Tests.KeyboardTests
 
             var textarea = await Page.QuerySelectorAsync("textarea");
             await textarea.TypeAsync("Type in this text!");
-            Assert.AreEqual("Type in this text!", await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo("Type in this text!"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should move with the arrow keys")]
@@ -28,14 +28,14 @@ namespace PuppeteerSharp.Tests.KeyboardTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/textarea.html");
             await Page.TypeAsync("textarea", "Hello World!");
-            Assert.AreEqual("Hello World!", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("Hello World!"));
             for (var i = 0; i < "World!".Length; i++)
             {
                 _ = Page.Keyboard.PressAsync("ArrowLeft");
             }
 
             await Page.Keyboard.TypeAsync("inserted ");
-            Assert.AreEqual("Hello inserted World!", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("Hello inserted World!"));
             _ = Page.Keyboard.DownAsync("Shift");
             for (var i = 0; i < "inserted ".Length; i++)
             {
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.KeyboardTests
 
             _ = Page.Keyboard.UpAsync("Shift");
             await Page.Keyboard.PressAsync("Backspace");
-            Assert.AreEqual("Hello World!", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("Hello World!"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should send a character with ElementHandle.press")]
@@ -53,12 +53,12 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/textarea.html");
             var textarea = await Page.QuerySelectorAsync("textarea");
             await textarea.PressAsync("a");
-            Assert.AreEqual("a", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("a"));
 
             await Page.EvaluateExpressionAsync("window.addEventListener('keydown', e => e.preventDefault(), true)");
 
             await textarea.PressAsync("b");
-            Assert.AreEqual("a", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("a"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "ElementHandle.press should not support |text| option")]
@@ -67,7 +67,7 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/textarea.html");
             var textarea = await Page.QuerySelectorAsync("textarea");
             await textarea.PressAsync("a", new PressOptions { Text = "ё" });
-            Assert.AreEqual("a", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("a"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should send a character with sendCharacter")]
@@ -76,10 +76,10 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/textarea.html");
             await Page.FocusAsync("textarea");
             await Page.Keyboard.SendCharacterAsync("嗨");
-            Assert.AreEqual("嗨", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("嗨"));
             await Page.EvaluateExpressionAsync("window.addEventListener('keydown', e => e.preventDefault(), true)");
             await Page.Keyboard.SendCharacterAsync("a");
-            Assert.AreEqual("嗨a", await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('textarea').value"), Is.EqualTo("嗨a"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should report shiftKey")]
@@ -91,22 +91,22 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             foreach (var modifier in codeForKey)
             {
                 await keyboard.DownAsync(modifier.Key);
-                Assert.AreEqual($"Keydown: {modifier.Key} {modifier.Key}Left {modifier.Value} [{modifier.Key}]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+                Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo($"Keydown: {modifier.Key} {modifier.Key}Left {modifier.Value} [{modifier.Key}]"));
                 await keyboard.DownAsync("!");
                 // Shift+! will generate a keypress
                 if (modifier.Key == "Shift")
                 {
-                    Assert.AreEqual($"Keydown: ! Digit1 49 [{modifier.Key}]\nKeypress: ! Digit1 33 33 [{modifier.Key}]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+                    Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo($"Keydown: ! Digit1 49 [{modifier.Key}]\nKeypress: ! Digit1 33 33 [{modifier.Key}]"));
                 }
                 else
                 {
-                    Assert.AreEqual($"Keydown: ! Digit1 49 [{modifier.Key}]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+                    Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo($"Keydown: ! Digit1 49 [{modifier.Key}]"));
                 }
 
                 await keyboard.UpAsync("!");
-                Assert.AreEqual($"Keyup: ! Digit1 49 [{modifier.Key}]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+                Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo($"Keyup: ! Digit1 49 [{modifier.Key}]"));
                 await keyboard.UpAsync(modifier.Key);
-                Assert.AreEqual($"Keyup: {modifier.Key} {modifier.Key}Left {modifier.Value} []", await Page.EvaluateExpressionAsync<string>("getResult()"));
+                Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo($"Keyup: {modifier.Key} {modifier.Key}Left {modifier.Value} []"));
             }
         }
 
@@ -116,17 +116,17 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/keyboard.html");
             var keyboard = Page.Keyboard;
             await keyboard.DownAsync("Control");
-            Assert.AreEqual("Keydown: Control ControlLeft 17 [Control]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo("Keydown: Control ControlLeft 17 [Control]"));
             await keyboard.DownAsync("Alt");
-            Assert.AreEqual("Keydown: Alt AltLeft 18 [Alt Control]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo("Keydown: Alt AltLeft 18 [Alt Control]"));
             await keyboard.DownAsync(";");
-            Assert.AreEqual("Keydown: ; Semicolon 186 [Alt Control]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo("Keydown: ; Semicolon 186 [Alt Control]"));
             await keyboard.UpAsync(";");
-            Assert.AreEqual("Keyup: ; Semicolon 186 [Alt Control]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo("Keyup: ; Semicolon 186 [Alt Control]"));
             await keyboard.UpAsync("Control");
-            Assert.AreEqual("Keyup: Control ControlLeft 17 [Alt]", await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo("Keyup: Control ControlLeft 17 [Alt]"));
             await keyboard.UpAsync("Alt");
-            Assert.AreEqual("Keyup: Alt AltLeft 18 []", await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"), Is.EqualTo("Keyup: Alt AltLeft 18 []"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should send proper codes while typing")]
@@ -134,15 +134,17 @@ namespace PuppeteerSharp.Tests.KeyboardTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/keyboard.html");
             await Page.Keyboard.TypeAsync("!");
-            Assert.AreEqual(string.Join("\n", new[] {
-                "Keydown: ! Digit1 49 []",
-                "Keypress: ! Digit1 33 33 []",
-                "Keyup: ! Digit1 49 []" }), await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"),
+                Is.EqualTo(string.Join("\n", new[] {
+                    "Keydown: ! Digit1 49 []",
+                    "Keypress: ! Digit1 33 33 []",
+                    "Keyup: ! Digit1 49 []" })));
             await Page.Keyboard.TypeAsync("^");
-            Assert.AreEqual(string.Join("\n", new[] {
-                "Keydown: ^ Digit6 54 []",
-                "Keypress: ^ Digit6 94 94 []",
-                "Keyup: ^ Digit6 54 []" }), await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"),
+                Is.EqualTo(string.Join("\n", new[] {
+                    "Keydown: ^ Digit6 54 []",
+                    "Keypress: ^ Digit6 94 94 []",
+                    "Keyup: ^ Digit6 54 []" })));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should send proper codes while typing with shift")]
@@ -152,11 +154,12 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             var keyboard = Page.Keyboard;
             await keyboard.DownAsync("Shift");
             await Page.Keyboard.TypeAsync("~");
-            Assert.AreEqual(string.Join("\n", new[] {
-                "Keydown: Shift ShiftLeft 16 [Shift]",
-                "Keydown: ~ Backquote 192 [Shift]", // 192 is ` keyCode
-                "Keypress: ~ Backquote 126 126 [Shift]", // 126 is ~ charCode
-                "Keyup: ~ Backquote 192 [Shift]" }), await Page.EvaluateExpressionAsync<string>("getResult()"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("getResult()"),
+                Is.EqualTo(string.Join("\n", new[] {
+                    "Keydown: Shift ShiftLeft 16 [Shift]",
+                    "Keydown: ~ Backquote 192 [Shift]", // 192 is ` keyCode
+                    "Keypress: ~ Backquote 126 126 [Shift]", // 126 is ~ charCode
+                    "Keyup: ~ Backquote 192 [Shift]" })));
             await keyboard.UpAsync("Shift");
         }
 
@@ -176,7 +179,7 @@ namespace PuppeteerSharp.Tests.KeyboardTests
               }, false);
             }");
             await Page.Keyboard.TypeAsync("Hello World!");
-            Assert.AreEqual("He Wrd!", await Page.EvaluateExpressionAsync<string>("textarea.value"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("textarea.value"), Is.EqualTo("He Wrd!"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should specify repeat property")]
@@ -186,18 +189,18 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             await Page.FocusAsync("textarea");
             await Page.EvaluateExpressionAsync("document.querySelector('textarea').addEventListener('keydown', e => window.lastEvent = e, true)");
             await Page.Keyboard.DownAsync("a");
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"), Is.False);
             await Page.Keyboard.PressAsync("a");
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"), Is.True);
 
             await Page.Keyboard.DownAsync("b");
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"), Is.False);
             await Page.Keyboard.DownAsync("b");
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"), Is.True);
 
             await Page.Keyboard.UpAsync("a");
             await Page.Keyboard.DownAsync("a");
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.lastEvent.repeat"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should type all kinds of characters")]
@@ -207,7 +210,7 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             await Page.FocusAsync("textarea");
             const string text = "This text goes onto two lines.\nThis character is 嗨.";
             await Page.Keyboard.TypeAsync(text);
-            Assert.AreEqual(text, await Page.EvaluateExpressionAsync<string>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("result"), Is.EqualTo(text));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should specify location")]
@@ -220,16 +223,16 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             var textarea = await Page.QuerySelectorAsync("textarea");
 
             await textarea.PressAsync("Digit5");
-            Assert.AreEqual(0, await Page.EvaluateExpressionAsync<int>("keyLocation"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("keyLocation"), Is.EqualTo(0));
 
             await textarea.PressAsync("ControlLeft");
-            Assert.AreEqual(1, await Page.EvaluateExpressionAsync<int>("keyLocation"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("keyLocation"), Is.EqualTo(1));
 
             await textarea.PressAsync("ControlRight");
-            Assert.AreEqual(2, await Page.EvaluateExpressionAsync<int>("keyLocation"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("keyLocation"), Is.EqualTo(2));
 
             await textarea.PressAsync("NumpadSubtract");
-            Assert.AreEqual(3, await Page.EvaluateExpressionAsync<int>("keyLocation"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("keyLocation"), Is.EqualTo(3));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should throw on unknown keys")]
@@ -247,9 +250,9 @@ namespace PuppeteerSharp.Tests.KeyboardTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/textarea.html");
             await Page.TypeAsync("textarea", "👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5");
-            Assert.AreEqual(
-                "👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5",
-                await Page.QuerySelectorAsync("textarea").EvaluateFunctionAsync<string>("t => t.value"));
+            Assert.That(
+                await Page.QuerySelectorAsync("textarea").EvaluateFunctionAsync<string>("t => t.value"),
+                Is.EqualTo("👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should type emoji into an iframe")]
@@ -260,9 +263,9 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             var frame = Page.FirstChildFrame();
             var textarea = await frame.QuerySelectorAsync("textarea");
             await textarea.TypeAsync("👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5");
-            Assert.AreEqual(
-                "👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5",
-                await frame.QuerySelectorAsync("textarea").EvaluateFunctionAsync<string>("t => t.value"));
+            Assert.That(
+                await frame.QuerySelectorAsync("textarea").EvaluateFunctionAsync<string>("t => t.value"),
+                Is.EqualTo("👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5"));
         }
 
         [Test, Retry(2), PuppeteerTest("keyboard.spec", "Keyboard", "should press the metaKey")]
@@ -280,9 +283,9 @@ namespace PuppeteerSharp.Tests.KeyboardTests
             const int code = 1;
             const int metaKey = 2;
             var result = await Page.EvaluateExpressionAsync<object[]>("result");
-            Assert.AreEqual("Meta", result[key]);
-            Assert.AreEqual("MetaLeft", result[code]);
-            Assert.AreEqual(true, result[metaKey]);
+            Assert.That(result[key], Is.EqualTo("Meta"));
+            Assert.That(result[code], Is.EqualTo("MetaLeft"));
+            Assert.That(result[metaKey], Is.EqualTo(true));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LaunchOptionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/LaunchOptionsTests.cs
@@ -11,8 +11,8 @@ namespace PuppeteerSharp.Tests
                 Devtools = true
             };
 
-            Assert.True(options.Devtools);
-            Assert.False(options.Headless);
+            Assert.That(options.Devtools, Is.True);
+            Assert.That(options.Headless, Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserCloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserCloseTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using PuppeteerSharp.Nunit;
 
 namespace PuppeteerSharp.Tests.LauncherTests
@@ -18,12 +19,12 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await browser.CloseAsync();
 
             var exception = Assert.ThrowsAsync<TargetClosedException>(() => requestTask);
-            StringAssert.Contains("Target closed", exception.Message);
-            StringAssert.DoesNotContain("Timeout", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Target closed"));
+            Assert.That(exception.Message, Does.Not.Contain("Timeout"));
 
             exception = Assert.ThrowsAsync<TargetClosedException>(() => responseTask);
-            StringAssert.Contains("Target closed", exception.Message);
-            StringAssert.DoesNotContain("Timeout", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Target closed"));
+            Assert.That(exception.Message, Does.Not.Contain("Timeout"));
         }
 
         [Test]
@@ -34,10 +35,10 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var browser = await launcher.LaunchAsync(options);
 
             var tempUserDataDir = ((Browser)browser).Launcher.TempUserDataDir;
-            DirectoryAssert.Exists(tempUserDataDir.Path);
+            Assert.That(tempUserDataDir.Path, Does.Exist);
 
             await browser.DisposeAsync();
-            DirectoryAssert.DoesNotExist(tempUserDataDir.Path);
+            Assert.That(tempUserDataDir.Path, Does.Not.Exist);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserDisconnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserDisconnectTests.cs
@@ -25,12 +25,12 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await Server.WaitForRequest("/one-style.css");
             remote.Disconnect();
             var exception = Assert.ThrowsAsync<NavigationException>(() => navigationTask);
-            Assert.True(
+            Assert.That(
                 new[]
                 {
                     "Navigating frame was detached",
                     "Protocol error(Page.navigate): Target closed. (Connection disposed)",
-                }.Any(value => exception!.Message.Contains(value)));
+                }.Any(value => exception!.Message.Contains(value)), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Browser.disconnect", "should reject waitForSelector when browser closes")]
@@ -47,7 +47,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             var watchdog = page.WaitForSelectorAsync("div", new WaitForSelectorOptions { Timeout = 60000 });
             remote.Disconnect();
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(() => watchdog);
-            Assert.True(exception!.Message.Contains("Session closed"));
+            Assert.That(exception!.Message, Does.Contain("Session closed"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserEventsDisconnectedTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserEventsDisconnectedTests.cs
@@ -29,9 +29,9 @@ namespace PuppeteerSharp.Tests.LauncherTests
             remoteBrowser2.Disconnect();
             await remoteBrowser2Disconnected;
 
-            Assert.AreEqual(0, disconnectedOriginal);
-            Assert.AreEqual(0, disconnectedRemote1);
-            Assert.AreEqual(1, disconnectedRemote2);
+            Assert.That(disconnectedOriginal, Is.EqualTo(0));
+            Assert.That(disconnectedRemote1, Is.EqualTo(0));
+            Assert.That(disconnectedRemote2, Is.EqualTo(1));
 
             var remoteBrowser1Disconnected = WaitForBrowserDisconnect(remoteBrowser1);
             var originalBrowserDisconnected = WaitForBrowserDisconnect(originalBrowser);
@@ -42,9 +42,9 @@ namespace PuppeteerSharp.Tests.LauncherTests
                 originalBrowserDisconnected
             );
 
-            Assert.AreEqual(1, disconnectedOriginal);
-            Assert.AreEqual(1, disconnectedRemote1);
-            Assert.AreEqual(1, disconnectedRemote2);
+            Assert.That(disconnectedOriginal, Is.EqualTo(1));
+            Assert.That(disconnectedRemote1, Is.EqualTo(1));
+            Assert.That(disconnectedRemote2, Is.EqualTo(1));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserTargetEventsTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserTargetEventsTests.cs
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await page.CloseAsync();
             // Wait for half a second to ensure that all events have been processed
             await Task.Delay(500);
-            Assert.AreEqual(new[] { "CREATED", "CHANGED", "DESTROYED" }, events);
+            Assert.That(events, Is.EqualTo(new[] { "CREATED", "CHANGED", "DESTROYED" }));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -105,7 +105,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await browser.CloseAsync();
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldBeAbleToSetBrowserPropertiesUsingConnectOptions()
         {
             var initActionExecuted = false;
@@ -196,7 +196,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await browserTwo.CloseAsync();
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldSupportCustomWebSocket()
         {
             var customSocketCreated = false;
@@ -216,7 +216,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             }
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldSupportCustomTransport()
         {
             var customTransportCreated = false;

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -21,13 +21,13 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using (var page = await browser.NewPageAsync())
             {
                 var response = await page.EvaluateExpressionAsync<int>("7 * 8");
-                Assert.AreEqual(56, response);
+                Assert.That(response, Is.EqualTo(56));
             }
 
             await using (var originalPage = await Browser.NewPageAsync())
             {
                 var response = await originalPage.EvaluateExpressionAsync<int>("7 * 6");
-                Assert.AreEqual(42, response);
+                Assert.That(response, Is.EqualTo(42));
             }
         }
 
@@ -67,11 +67,10 @@ namespace PuppeteerSharp.Tests.LauncherTests
                 responseTask).WithTimeout(Puppeteer.DefaultTimeout);
 
             var response = responseTask.Result;
-            Assert.True(response.Ok);
-            Assert.NotNull(response.SecurityDetails);
-            Assert.AreEqual(
-                TestUtils.CurateProtocol(requestTask.Result.ToString()),
-                TestUtils.CurateProtocol(response.SecurityDetails.Protocol));
+            Assert.That(response.Ok, Is.True);
+            Assert.That(response.SecurityDetails, Is.Not.Null);
+            Assert.That(TestUtils.CurateProtocol(response.SecurityDetails.Protocol),
+                Is.EqualTo(TestUtils.CurateProtocol(requestTask.Result.ToString())));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.connect", "should support targetFilter option")]
@@ -92,13 +91,13 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             var pages = await remoteBrowser.PagesAsync();
 
-            Assert.AreEqual(
-                new[]
+            Assert.That(
+                pages.Select(p => p.Url).OrderBy(t => t),
+                Is.EqualTo(new[]
                 {
                     "about:blank",
                     TestConstants.EmptyPage
-                },
-                pages.Select(p => p.Url).OrderBy(t => t));
+                }));
 
             await page2.CloseAsync();
             await page1.CloseAsync();
@@ -119,7 +118,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             };
             var browser = await Puppeteer.ConnectAsync(options, TestConstants.LoggerFactory);
 
-            Assert.True(initActionExecuted);
+            Assert.That(initActionExecuted, Is.True);
 
             await browser.CloseAsync();
         }
@@ -141,11 +140,11 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var browser = await Puppeteer.ConnectAsync(options, TestConstants.LoggerFactory);
             var pages = (await browser.PagesAsync()).ToList();
             var restoredPage = pages.FirstOrDefault(x => x.Url == url);
-            Assert.NotNull(restoredPage);
+            Assert.That(restoredPage, Is.Not.Null);
             var frameDump = await FrameUtils.DumpFramesAsync(restoredPage.MainFrame);
-            Assert.AreEqual(TestConstants.NestedFramesDumpResult, frameDump);
+            Assert.That(frameDump, Is.EqualTo(TestConstants.NestedFramesDumpResult));
             var response = await restoredPage.EvaluateExpressionAsync<int>("7 * 8");
-            Assert.AreEqual(56, response);
+            Assert.That(response, Is.EqualTo(56));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.connect", "should be able to connect to the same page simultaneously")]
@@ -169,8 +168,8 @@ namespace PuppeteerSharp.Tests.LauncherTests
             var page1 = tcs.Task.Result;
             var page2 = page2Task.Result;
 
-            Assert.AreEqual(56, await page1.EvaluateExpressionAsync<int>("7 * 8"));
-            Assert.AreEqual(42, await page2.EvaluateExpressionAsync<int>("7 * 6"));
+            Assert.That(await page1.EvaluateExpressionAsync<int>("7 * 8"), Is.EqualTo(56));
+            Assert.That(await page2.EvaluateExpressionAsync<int>("7 * 6"), Is.EqualTo(42));
             await browserOne.CloseAsync();
         }
 
@@ -211,7 +210,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             await using (await Puppeteer.ConnectAsync(options, TestConstants.LoggerFactory))
             {
-                Assert.True(customSocketCreated);
+                Assert.That(customSocketCreated, Is.True);
             }
         }
 
@@ -230,7 +229,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             await using (await Puppeteer.ConnectAsync(options, TestConstants.LoggerFactory))
             {
-                Assert.True(customTransportCreated);
+                Assert.That(customTransportCreated, Is.True);
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -105,6 +105,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await browser.CloseAsync();
         }
 
+        [Test]
         public async Task ShouldBeAbleToSetBrowserPropertiesUsingConnectOptions()
         {
             var initActionExecuted = false;
@@ -195,6 +196,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await browserTwo.CloseAsync();
         }
 
+        [Test]
         public async Task ShouldSupportCustomWebSocket()
         {
             var customSocketCreated = false;
@@ -214,6 +216,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             }
         }
 
+        [Test]
         public async Task ShouldSupportCustomTransport()
         {
             var customTransportCreated = false;

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
@@ -210,6 +210,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             Assert.That(launcher.Process.HasExited, Is.True);
         }
 
+        [Test]
         public async Task ChromeShouldBeClosedOnDispose()
         {
             var options = TestConstants.DefaultBrowserOptions();
@@ -226,6 +227,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             Assert.That(launcher.Process.HasExited, Is.True);
         }
 
+        [Test]
         public async Task ShouldNotOpenTwoChromesUsingTheSameLauncher()
         {
             var launcher = new Launcher(TestConstants.LoggerFactory);

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
             await using var page = await browser.NewPageAsync();
             var response = await page.GoToAsync("https://www.github.com");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should reject all promises when browser is closed")]
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             var neverResolves = page.EvaluateFunctionHandleAsync("() => new Promise(r => {})");
             await browser.CloseAsync();
             var exception = Assert.ThrowsAsync<TargetClosedException>(() => neverResolves);
-            StringAssert.Contains("Protocol error", exception!.Message);
+            Assert.That(exception!.Message, Does.Contain("Protocol error"));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should reject if executable path is invalid")]
@@ -57,9 +57,9 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             var launcher = new Launcher(TestConstants.LoggerFactory);
             await using var browser = await launcher.LaunchAsync(options);
-            Assert.True(Directory.GetFiles(userDataDir.Path).Length > 0);
+            Assert.That(Directory.GetFiles(userDataDir.Path), Is.Not.Empty);
             await browser.CloseAsync();
-            Assert.True(Directory.GetFiles(userDataDir.Path).Length > 0);
+            Assert.That(Directory.GetFiles(userDataDir.Path), Is.Not.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "userDataDir argument")]
@@ -81,9 +81,9 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var browser = await launcher.LaunchAsync(options);
             // Open a page to make sure its functional.
             await browser.NewPageAsync();
-            Assert.True(Directory.GetFiles(userDataDir.Path).Length > 0);
+            Assert.That(Directory.GetFiles(userDataDir.Path), Is.Not.Empty);
             await browser.CloseAsync();
-            Assert.True(Directory.GetFiles(userDataDir.Path).Length > 0);
+            Assert.That(Directory.GetFiles(userDataDir.Path), Is.Not.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "userDataDir option should restore state")]
@@ -113,7 +113,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             {
                 var page2 = await browser2.NewPageAsync();
                 await page2.GoToAsync(TestConstants.EmptyPage);
-                Assert.AreEqual("hello", await page2.EvaluateExpressionAsync<string>("localStorage.hey"));
+                Assert.That(await page2.EvaluateExpressionAsync<string>("localStorage.hey"), Is.EqualTo("hello"));
             }
         }
 
@@ -139,14 +139,14 @@ namespace PuppeteerSharp.Tests.LauncherTests
             {
                 var page2 = await browser2.NewPageAsync();
                 await page2.GoToAsync(TestConstants.EmptyPage);
-                Assert.AreEqual("doSomethingOnlyOnce=true", await page2.EvaluateExpressionAsync<string>("document.cookie"));
+                Assert.That(await page2.EvaluateExpressionAsync<string>("document.cookie"), Is.EqualTo("doSomethingOnlyOnce=true"));
             }
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should return the default arguments")]
         public void ShouldReturnTheDefaultArguments()
         {
-            Assert.Contains("--headless=new", Puppeteer.GetDefaultArgs(new LaunchOptions() { Headless = true }));
+            Assert.That(Puppeteer.GetDefaultArgs(new LaunchOptions() { Headless = true }), Does.Contain("--headless=new"));
             Assert.That(Puppeteer.GetDefaultArgs(new LaunchOptions
             {
                 Headless = false
@@ -154,34 +154,34 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             if (TestConstants.IsChrome)
             {
-                Assert.Contains("--no-first-run", Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()));
-                Assert.Contains("--user-data-dir=\"foo\"", Puppeteer.GetDefaultArgs(new LaunchOptions
+                Assert.That(Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()), Does.Contain("--no-first-run"));
+                Assert.That(Puppeteer.GetDefaultArgs(new LaunchOptions
                 {
                     UserDataDir = "foo"
-                }));
+                }), Does.Contain("--user-data-dir=\"foo\""));
             }
             else
             {
-                Assert.Contains("--no-remote", Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()));
+                Assert.That(Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()), Does.Contain("--no-remote"));
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    Assert.Contains("--foreground", Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()));
+                    Assert.That(Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()), Does.Contain("--foreground"));
                 }
                 else
                 {
                     Assert.That(Puppeteer.GetDefaultArgs(TestConstants.DefaultBrowserOptions()), Does.Not.Contain("--foreground"));
                 }
-                Assert.Contains("--profile", Puppeteer.GetDefaultArgs(new LaunchOptions
+                Assert.That(Puppeteer.GetDefaultArgs(new LaunchOptions
                 {
                     UserDataDir = "foo",
                     Browser = TestConstants.IsChrome ? SupportedBrowser.Chrome : SupportedBrowser.Firefox,
-                }));
-                Assert.Contains("\"foo\"", Puppeteer.GetDefaultArgs(new LaunchOptions
+                }), Does.Contain("--profile"));
+                Assert.That(Puppeteer.GetDefaultArgs(new LaunchOptions
                 {
                     UserDataDir = "foo",
                     Browser = TestConstants.IsChrome ? SupportedBrowser.Chrome : SupportedBrowser.Firefox,
-                }));
+                }), Does.Contain("\"foo\""));
             }
         }
 
@@ -195,7 +195,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var browser = await launcher.LaunchAsync(options);
             await using var page = await browser.NewPageAsync();
             var response = await page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
 
             if (useDisposeAsync)
             {
@@ -207,7 +207,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
                 await browser.CloseAsync();
             }
 
-            Assert.True(launcher.Process.HasExited);
+            Assert.That(launcher.Process.HasExited, Is.True);
         }
 
         public async Task ChromeShouldBeClosedOnDispose()
@@ -219,11 +219,11 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using (var page = await browser.NewPageAsync())
             {
                 var response = await page.GoToAsync(TestConstants.EmptyPage);
-                Assert.AreEqual(HttpStatusCode.OK, response.Status);
+                Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
             }
 
-            Assert.True(await launcher.Process.WaitForExitAsync(TimeSpan.FromSeconds(10)));
-            Assert.True(launcher.Process.HasExited);
+            Assert.That(await launcher.Process.WaitForExitAsync(TimeSpan.FromSeconds(10)), Is.True);
+            Assert.That(launcher.Process.HasExited, Is.True);
         }
 
         public async Task ShouldNotOpenTwoChromesUsingTheSameLauncher()
@@ -233,7 +233,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             {
                 var exception = Assert.ThrowsAsync<InvalidOperationException>(
                     () => launcher.LaunchAsync(TestConstants.DefaultBrowserOptions()));
-                Assert.AreEqual("Unable to create or connect to another process", exception!.Message);
+                Assert.That(exception!.Message, Is.EqualTo("Unable to create or connect to another process"));
             }
         }
 
@@ -244,7 +244,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             options.IgnoreDefaultArgs = true;
             await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
             await using var page = await browser.NewPageAsync();
-            Assert.AreEqual(121, await page.EvaluateExpressionAsync<int>("11 * 11"));
+            Assert.That(await page.EvaluateExpressionAsync<int>("11 * 11"), Is.EqualTo(121));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should filter out ignored default arguments in Chrome")]
@@ -255,9 +255,9 @@ namespace PuppeteerSharp.Tests.LauncherTests
             options.IgnoredDefaultArgs = [defaultArgs[0], defaultArgs[2]];
             await using var browser = await Puppeteer.LaunchAsync(options);
             var spawnArgs = browser.Process.StartInfo.Arguments;
-            StringAssert.DoesNotContain(defaultArgs[0], spawnArgs);
-            StringAssert.Contains(defaultArgs[1], spawnArgs);
-            StringAssert.DoesNotContain(defaultArgs[2], spawnArgs);
+            Assert.That(spawnArgs, Does.Not.Contain(defaultArgs[0]));
+            Assert.That(spawnArgs, Does.Contain(defaultArgs[1]));
+            Assert.That(spawnArgs, Does.Not.Contain(defaultArgs[2]));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should have default URL when launching browser")]
@@ -265,7 +265,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
         {
             await using var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions(), TestConstants.LoggerFactory);
             var pages = (await browser.PagesAsync()).Select(page => page.Url);
-            Assert.AreEqual(new[] { TestConstants.AboutBlank }, pages);
+            Assert.That(pages, Is.EqualTo(new[] { TestConstants.AboutBlank }));
         }
 
 
@@ -295,7 +295,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             {
                 await pages[0].WaitForNavigationAsync();
             }
-            Assert.AreEqual(TestConstants.EmptyPage, pages[0].Url);
+            Assert.That(pages[0].Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should set the default viewport")]
@@ -310,8 +310,8 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             await using var browser = await Puppeteer.LaunchAsync(options);
             await using var page = await browser.NewPageAsync();
-            Assert.AreEqual(456, await page.EvaluateExpressionAsync<int>("window.innerWidth"));
-            Assert.AreEqual(789, await page.EvaluateExpressionAsync<int>("window.innerHeight"));
+            Assert.That(await page.EvaluateExpressionAsync<int>("window.innerWidth"), Is.EqualTo(456));
+            Assert.That(await page.EvaluateExpressionAsync<int>("window.innerHeight"), Is.EqualTo(789));
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should disable the default viewport")]
@@ -322,7 +322,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             await using var browser = await Puppeteer.LaunchAsync(options);
             await using var page = await browser.NewPageAsync();
-            Assert.Null(page.Viewport);
+            Assert.That(page.Viewport, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "should take fullPage screenshots when defaultViewport is null")]
@@ -334,7 +334,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var browser = await Puppeteer.LaunchAsync(options);
             await using var page = await browser.NewPageAsync();
             await page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
-            Assert.IsNotEmpty(await page.ScreenshotDataAsync(new ScreenshotOptions { FullPage = true }));
+            Assert.That(await page.ScreenshotDataAsync(new ScreenshotOptions { FullPage = true }), Is.Not.Empty);
         }
 
         [Test, Retry(2)]
@@ -350,7 +350,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             await using (await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
             {
-                Assert.True(customSocketCreated);
+                Assert.That(customSocketCreated, Is.True);
             }
         }
 
@@ -367,7 +367,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
 
             await using (await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
             {
-                Assert.True(customTransportCreated);
+                Assert.That(customTransportCreated, Is.True);
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
@@ -210,7 +210,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             Assert.That(launcher.Process.HasExited, Is.True);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ChromeShouldBeClosedOnDispose()
         {
             var options = TestConstants.DefaultBrowserOptions();
@@ -227,7 +227,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
             Assert.That(launcher.Process.HasExited, Is.True);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldNotOpenTwoChromesUsingTheSameLauncher()
         {
             var launcher = new Launcher(TestConstants.LoggerFactory);

--- a/lib/PuppeteerSharp.Tests/MouseTests/MouseTests.cs
+++ b/lib/PuppeteerSharp.Tests/MouseTests/MouseTests.cs
@@ -45,12 +45,12 @@ namespace PuppeteerSharp.Tests.MouseTests
             await Page.Mouse.ClickAsync(50, 60);
             var e = await Page.EvaluateFunctionAsync<MouseEvent>("() => globalThis.clickPromise");
 
-            Assert.AreEqual("click", e.Type);
-            Assert.AreEqual(1, e.Detail);
-            Assert.AreEqual(50, e.ClientX);
-            Assert.AreEqual(60, e.ClientY);
-            Assert.True(e.IsTrusted);
-            Assert.AreEqual(0, e.Button);
+            Assert.That(e.Type, Is.EqualTo("click"));
+            Assert.That(e.Detail, Is.EqualTo(1));
+            Assert.That(e.ClientX, Is.EqualTo(50));
+            Assert.That(e.ClientY, Is.EqualTo(60));
+            Assert.That(e.IsTrusted, Is.True);
+            Assert.That(e.Button, Is.EqualTo(0));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should resize the textarea")]
@@ -64,8 +64,8 @@ namespace PuppeteerSharp.Tests.MouseTests
             await mouse.MoveAsync(dimensions.X + dimensions.Width + 100, dimensions.Y + dimensions.Height + 100);
             await mouse.UpAsync();
             var newDimensions = await Page.EvaluateFunctionAsync<Dimensions>(Dimensions);
-            Assert.AreEqual(Math.Round(dimensions.Width + 104, MidpointRounding.AwayFromZero), newDimensions.Width);
-            Assert.AreEqual(Math.Round(dimensions.Height + 104, MidpointRounding.AwayFromZero), newDimensions.Height);
+            Assert.That(newDimensions.Width, Is.EqualTo(Math.Round(dimensions.Width + 104, MidpointRounding.AwayFromZero)));
+            Assert.That(newDimensions.Height, Is.EqualTo(Math.Round(dimensions.Height + 104, MidpointRounding.AwayFromZero)));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should select the text with mouse")]
@@ -83,10 +83,10 @@ namespace PuppeteerSharp.Tests.MouseTests
             await Page.Mouse.DownAsync();
             await Page.Mouse.MoveAsync(100, 100);
             await Page.Mouse.UpAsync();
-            Assert.AreEqual(text, await Page.EvaluateFunctionAsync<string>(@"() => {
+            Assert.That(await Page.EvaluateFunctionAsync<string>(@"() => {
                 const textarea = document.querySelector('textarea');
                 return textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
-            }"));
+            }"), Is.EqualTo(text));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should trigger hover state")]
@@ -94,11 +94,11 @@ namespace PuppeteerSharp.Tests.MouseTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.HoverAsync("#button-6");
-            Assert.AreEqual("button-6", await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"), Is.EqualTo("button-6"));
             await Page.HoverAsync("#button-2");
-            Assert.AreEqual("button-2", await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"), Is.EqualTo("button-2"));
             await Page.HoverAsync("#button-91");
-            Assert.AreEqual("button-91", await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"), Is.EqualTo("button-91"));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should trigger hover state with removed window.Node")]
@@ -107,7 +107,7 @@ namespace PuppeteerSharp.Tests.MouseTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/scrollable.html");
             await Page.EvaluateExpressionAsync("delete window.Node");
             await Page.HoverAsync("#button-6");
-            Assert.AreEqual("button-6", await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('button:hover').id"), Is.EqualTo("button-6"));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should set modifier keys on click")]
@@ -120,20 +120,13 @@ namespace PuppeteerSharp.Tests.MouseTests
             {
                 await Page.Keyboard.DownAsync(modifier.Key);
                 await Page.ClickAsync("#button-3");
-                if (!(await Page.EvaluateFunctionAsync<bool>("mod => window.lastEvent[mod]", modifier.Value)))
-                {
-                    Assert.True(false, $"{modifier.Value} should be true");
-                }
-
+                Assert.That(await Page.EvaluateFunctionAsync<bool>("mod => window.lastEvent[mod]", modifier.Value), Is.True, $"{modifier.Value} should be true");
                 await Page.Keyboard.UpAsync(modifier.Key);
             }
             await Page.ClickAsync("#button-3");
             foreach (var modifier in modifiers)
             {
-                if (await Page.EvaluateFunctionAsync<bool>("mod => window.lastEvent[mod]", modifier.Value))
-                {
-                    Assert.False(true, $"{modifiers.Values} should be false");
-                }
+                Assert.That(await Page.EvaluateFunctionAsync<bool>("mod => window.lastEvent[mod]", modifier.Value), Is.False, $"{modifiers.Values} should be false");
             }
         }
 
@@ -143,8 +136,8 @@ namespace PuppeteerSharp.Tests.MouseTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/wheel.html");
             var elem = await Page.QuerySelectorAsync("div");
             var boundingBoxBefore = await elem.BoundingBoxAsync();
-            Assert.AreEqual(115, boundingBoxBefore.Width);
-            Assert.AreEqual(115, boundingBoxBefore.Height);
+            Assert.That(boundingBoxBefore.Width, Is.EqualTo(115));
+            Assert.That(boundingBoxBefore.Height, Is.EqualTo(115));
 
             await Page.Mouse.MoveAsync(
                 boundingBoxBefore.X + (boundingBoxBefore.Width / 2),
@@ -157,13 +150,13 @@ namespace PuppeteerSharp.Tests.MouseTests
             // We don't have this OS check upstream
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Assert.AreEqual(345, boundingBoxAfter.Width);
-                Assert.AreEqual(345, boundingBoxAfter.Height);
+                Assert.That(boundingBoxAfter.Width, Is.EqualTo(345));
+                Assert.That(boundingBoxAfter.Height, Is.EqualTo(345));
             }
             else
             {
-                Assert.AreEqual(230, boundingBoxAfter.Width);
-                Assert.AreEqual(230, boundingBoxAfter.Height);
+                Assert.That(boundingBoxAfter.Width, Is.EqualTo(230));
+                Assert.That(boundingBoxAfter.Height, Is.EqualTo(230));
             }
         }
 
@@ -178,13 +171,14 @@ namespace PuppeteerSharp.Tests.MouseTests
                 });
             }");
             await Page.Mouse.MoveAsync(200, 300, new MoveOptions { Steps = 5 });
-            Assert.AreEqual(new[] {
-                new[]{ 120, 140 },
-                new[]{ 140, 180 },
-                new[]{ 160, 220 },
-                new[]{ 180, 260 },
-                new[]{ 200, 300 }
-            }, await Page.EvaluateExpressionAsync<int[][]>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<int[][]>("result"),
+                Is.EqualTo(new[] {
+                    new[]{ 120, 140 },
+                    new[]{ 140, 180 },
+                    new[]{ 160, 220 },
+                    new[]{ 180, 260 },
+                    new[]{ 200, 300 }
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should work with mobile viewports and cross process navigations")]
@@ -206,11 +200,12 @@ namespace PuppeteerSharp.Tests.MouseTests
 
             await Page.Mouse.ClickAsync(30, 40);
 
-            Assert.AreEqual(new DomPointInternal()
-            {
-                X = 30,
-                Y = 40
-            }, await Page.EvaluateExpressionAsync<DomPointInternal>("result"));
+            Assert.That(await Page.EvaluateExpressionAsync<DomPointInternal>("result"),
+                Is.EqualTo(new DomPointInternal()
+                {
+                    X = 30,
+                    Y = 40
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should throw if buttons are pressed incorrectly")]
@@ -234,8 +229,8 @@ namespace PuppeteerSharp.Tests.MouseTests
 
             var data = await Page.EvaluateExpressionAsync<ClickData[]>("window.clicks");
 
-            Assert.AreEqual(
-                new ClickData[]
+            Assert.That(
+                data.Take(3), Is.EqualTo(new ClickData[]
                 {
                     new()
                     {
@@ -267,11 +262,10 @@ namespace PuppeteerSharp.Tests.MouseTests
                         IsTrusted = true,
                         Button = 0,
                     },
-                },
-                data.Take(3));
+                }));
 
-            Assert.AreEqual(
-                new ClickData[]
+            Assert.That(
+                data.Skip(3).Take(3), Is.EqualTo(new ClickData[]
                 {
                     new()
                     {
@@ -303,8 +297,7 @@ namespace PuppeteerSharp.Tests.MouseTests
                         IsTrusted = true,
                         Button = 0,
                     },
-                },
-                data.Skip(3).Take(3));
+                }));
         }
 
         [Test, Retry(2), PuppeteerTest("mouse.spec", "Mouse", "should reset properly")]
@@ -323,8 +316,8 @@ namespace PuppeteerSharp.Tests.MouseTests
 
             var data = await Page.EvaluateExpressionAsync<ClickData[]>("window.clicks");
 
-            Assert.AreEqual(
-                new ClickData[]
+            Assert.That(
+                data, Is.EqualTo(new ClickData[]
                 {
                     new()
                     {
@@ -376,8 +369,7 @@ namespace PuppeteerSharp.Tests.MouseTests
                         IsTrusted = true,
                         Button = 0,
                     },
-                },
-                data);
+                }));
         }
 
         private Task AddMouseDataListenersAsync(IPage page, bool includeMove = false)

--- a/lib/PuppeteerSharp.Tests/NavigationTests/FrameGoToTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/FrameGoToTests.cs
@@ -21,8 +21,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
             Assert.That(Page.Frames.Where(f => f.Url.Contains("/frames/frame.html")), Has.Exactly(1).Items);
             var childFrame = Page.FirstChildFrame();
             var response = await childFrame.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreSame(response.Frame, childFrame);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(childFrame, Is.SameAs(response.Frame));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Frame.goto", "should reject when frame detaches")]
@@ -35,13 +35,13 @@ namespace PuppeteerSharp.Tests.NavigationTests
             await waitForRequestTask;
             await Page.QuerySelectorAsync("iframe").EvaluateFunctionAsync("frame => frame.remove()");
             var exception = Assert.ThrowsAsync<NavigationException>(async () => await navigationTask);
-            Assert.True(
+            Assert.That(
                 new[]
                 {
                     "Navigating frame was detached",
                     "Error: NS_BINDING_ABORTED",
                     "net::ERR_ABORTED"
-                }.Any(error => exception.Message.Contains(error)));
+                }.Any(error => exception.Message.Contains(error)), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Frame.goto", "should return matching responses")]
@@ -85,8 +85,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
             {
                 matchingData[i].ServerResponseTcs.TrySetResult(serverResponseTexts[i]);
                 var response = await matchingData[i].NavigationTask;
-                Assert.AreSame(matchingData[i].FrameTask.Result, response.Frame);
-                Assert.AreEqual(serverResponseTexts[i], await response.TextAsync());
+                Assert.That(response.Frame, Is.SameAs(matchingData[i].FrameTask.Result));
+                Assert.That(await response.TextAsync(), Is.EqualTo(serverResponseTexts[i]));
             }
         }
 

--- a/lib/PuppeteerSharp.Tests/NavigationTests/FrameWaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/FrameWaitForNavigationTests.cs
@@ -24,10 +24,10 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 frame.EvaluateFunctionAsync("url => window.location.href = url", TestConstants.ServerUrl + "/grid.html")
             );
             var response = await waitForNavigationResult;
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            StringAssert.Contains("grid.html", response.Url);
-            Assert.AreSame(frame, response.Frame);
-            StringAssert.Contains("/frames/one-frame.html", Page.Url);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Does.Contain("grid.html"));
+            Assert.That(response.Frame, Is.SameAs(frame));
+            Assert.That(Page.Url, Does.Contain("/frames/one-frame.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Frame.waitForNavigation", "should fail when frame detaches")]
@@ -43,7 +43,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             await Page.QuerySelectorAsync("iframe").EvaluateFunctionAsync("frame => frame.remove()");
             var exception = Assert.ThrowsAsync<PuppeteerException>(() => waitForNavigationResult);
-            Assert.AreEqual("Navigating frame was detached", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Navigating frame was detached"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageGoBackTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageGoBackTests.cs
@@ -18,15 +18,15 @@ namespace PuppeteerSharp.Tests.NavigationTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
 
             var response = await Page.GoBackAsync();
-            Assert.True(response.Ok);
-            Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+            Assert.That(response.Ok, Is.True);
+            Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
 
             response = await Page.GoForwardAsync();
-            Assert.True(response.Ok);
-            StringAssert.Contains("grid", response.Url);
+            Assert.That(response.Ok, Is.True);
+            Assert.That(response.Url, Does.Contain("grid"));
 
             response = await Page.GoForwardAsync();
-            Assert.Null(response);
+            Assert.That(response, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goBack", "should work with HistoryAPI")]
@@ -37,14 +37,14 @@ namespace PuppeteerSharp.Tests.NavigationTests
               history.pushState({ }, '', '/first.html');
               history.pushState({ }, '', '/second.html');
             ");
-            Assert.AreEqual(TestConstants.ServerUrl + "/second.html", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/second.html"));
 
             await Page.GoBackAsync();
-            Assert.AreEqual(TestConstants.ServerUrl + "/first.html", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/first.html"));
             await Page.GoBackAsync();
-            Assert.AreEqual(TestConstants.EmptyPage, Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
             await Page.GoForwardAsync();
-            Assert.AreEqual(TestConstants.ServerUrl + "/first.html", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/first.html"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageGotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageGotoTests.cs
@@ -16,18 +16,18 @@ namespace PuppeteerSharp.Tests.NavigationTests
         public async Task ShouldWork()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(TestConstants.EmptyPage, Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work with anchor navigation")]
         public async Task ShouldWorkWithAnchorNavigation()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(TestConstants.EmptyPage, Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
             await Page.GoToAsync($"{TestConstants.EmptyPage}#foo");
-            Assert.AreEqual($"{TestConstants.EmptyPage}#foo", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo($"{TestConstants.EmptyPage}#foo"));
             await Page.GoToAsync($"{TestConstants.EmptyPage}#bar");
-            Assert.AreEqual($"{TestConstants.EmptyPage}#bar", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo($"{TestConstants.EmptyPage}#bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work with redirects")]
@@ -44,14 +44,14 @@ namespace PuppeteerSharp.Tests.NavigationTests
         public async Task ShouldNavigateToAboutBlank()
         {
             var response = await Page.GoToAsync(TestConstants.AboutBlank);
-            Assert.Null(response);
+            Assert.That(response, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should return response when page changes its URL after load")]
         public async Task ShouldReturnResponseWhenPageChangesItsURLAfterLoad()
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/historyapi.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work with subframes return 204")]
@@ -78,11 +78,11 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("net::ERR_ABORTED", exception.Message);
+                Assert.That(exception.Message, Does.Contain("net::ERR_ABORTED"));
             }
             else
             {
-                StringAssert.Contains("NS_BINDING_ABORTED", exception.Message);
+                Assert.That(exception.Message, Does.Contain("NS_BINDING_ABORTED"));
             }
         }
 
@@ -93,8 +93,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
             {
                 WaitUntilNavigation.DOMContentLoaded
             });
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.Null(response.SecurityDetails);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.SecurityDetails, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work when page calls history API in beforeunload")]
@@ -106,7 +106,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 window.addEventListener('beforeunload', () => history.replaceState(null, 'initial', window.location.href), false);
             }");
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work when reload causes history API in beforeunload")]
@@ -118,7 +118,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 window.addEventListener('beforeunload', () => history.replaceState(null, 'initial', window.location.href), false);
             }");
             var response = await Page.ReloadAsync();
-            Assert.AreEqual(1, await Page.EvaluateFunctionAsync<int>("() => 1"));
+            Assert.That(await Page.EvaluateFunctionAsync<int>("() => 1"), Is.EqualTo(1));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should navigate to empty page with networkidle0")]
@@ -129,7 +129,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 WaitUntil =
                 [WaitUntilNavigation.Networkidle0]
             });
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
 
@@ -142,14 +142,14 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 WaitUntil =
                 [WaitUntilNavigation.Networkidle0]
             });
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should navigate to empty page with networkidle2")]
         public async Task ShouldNavigateToEmptyPageWithNetworkidle2()
         {
             var response = await Page.GoToAsync(TestConstants.EmptyPage, new NavigationOptions { WaitUntil = new[] { WaitUntilNavigation.Networkidle2 } });
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should fail when navigating to bad url")]
@@ -159,30 +159,30 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("Cannot navigate to invalid URL", exception.Message);
+                Assert.That(exception.Message, Does.Contain("Cannot navigate to invalid URL"));
             }
             else
             {
-                StringAssert.Contains("invalid URL", exception.Message);
+                Assert.That(exception.Message, Does.Contain("invalid URL"));
             }
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should fail when navigating to bad SSL")]
         public void ShouldFailWhenNavigatingToBadSSL()
         {
-            Page.Request += (_, e) => Assert.NotNull(e.Request);
-            Page.RequestFinished += (_, e) => Assert.NotNull(e.Request);
-            Page.RequestFailed += (_, e) => Assert.NotNull(e.Request);
+            Page.Request += (_, e) => Assert.That(e.Request, Is.Not.Null);
+            Page.RequestFinished += (_, e) => Assert.That(e.Request, Is.Not.Null);
+            Page.RequestFailed += (_, e) => Assert.That(e.Request, Is.Not.Null);
 
             var exception = Assert.ThrowsAsync<NavigationException>(async () => await Page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html"));
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("net::ERR_CERT_AUTHORITY_INVALID", exception.Message);
+                Assert.That(exception.Message, Does.Contain("net::ERR_CERT_AUTHORITY_INVALID"));
             }
             else
             {
-                StringAssert.Contains("SSL_ERROR_UNKNOWN", exception.Message);
+                Assert.That(exception.Message, Does.Contain("SSL_ERROR_UNKNOWN"));
             }
         }
 
@@ -193,11 +193,11 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("net::ERR_CERT_AUTHORITY_INVALID", exception.Message);
+                Assert.That(exception.Message, Does.Contain("net::ERR_CERT_AUTHORITY_INVALID"));
             }
             else
             {
-                StringAssert.Contains("SSL_ERROR_UNKNOWN", exception.Message);
+                Assert.That(exception.Message, Does.Contain("SSL_ERROR_UNKNOWN"));
             }
         }
 
@@ -208,11 +208,11 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("net::ERR_CONNECTION_REFUSED", exception.Message);
+                Assert.That(exception.Message, Does.Contain("net::ERR_CONNECTION_REFUSED"));
             }
             else
             {
-                StringAssert.Contains("NS_ERROR_CONNECTION_REFUSED", exception.Message);
+                Assert.That(exception.Message, Does.Contain("NS_ERROR_CONNECTION_REFUSED"));
             }
         }
 
@@ -223,7 +223,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             var exception = Assert.ThrowsAsync<NavigationException>(async ()
                 => await Page.GoToAsync(TestConstants.EmptyPage, new NavigationOptions { Timeout = 1 }));
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should fail when exceeding default maximum navigation timeout")]
@@ -233,7 +233,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             Page.DefaultNavigationTimeout = 1;
             var exception = Assert.ThrowsAsync<NavigationException>(async () => await Page.GoToAsync(TestConstants.EmptyPage));
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should fail when exceeding default maximum timeout")]
@@ -243,7 +243,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
             Server.SetRoute("/empty.html", _ => Task.Delay(-1));
             Page.DefaultTimeout = 1;
             var exception = Assert.ThrowsAsync<NavigationException>(async () => await Page.GoToAsync(TestConstants.EmptyPage));
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should prioritize default navigation timeout over default timeout")]
@@ -254,7 +254,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
             Page.DefaultTimeout = 0;
             Page.DefaultNavigationTimeout = 1;
             var exception = Assert.ThrowsAsync<NavigationException>(async () => await Page.GoToAsync(TestConstants.EmptyPage));
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should disable timeout when its set to 0")]
@@ -269,28 +269,28 @@ namespace PuppeteerSharp.Tests.NavigationTests
             Page.Load += OnLoad;
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html", new NavigationOptions { Timeout = 0, WaitUntil = new[] { WaitUntilNavigation.Load } });
-            Assert.True(loaded);
+            Assert.That(loaded, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work when navigating to valid url")]
         public async Task ShouldWorkWhenNavigatingToValidUrl()
         {
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work when navigating to data url")]
         public async Task ShouldWorkWhenNavigatingToDataUrl()
         {
             var response = await Page.GoToAsync("data:text/html,hello");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work when navigating to 404")]
         public async Task ShouldWorkWhenNavigatingTo404()
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/not-found");
-            Assert.AreEqual(HttpStatusCode.NotFound, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should not throw an error for a 404 response with an empty body")]
@@ -303,8 +303,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
             });
 
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/404-error");
-            Assert.False(response.Ok);
-            Assert.AreEqual(HttpStatusCode.NotFound, response.Status);
+            Assert.That(response.Ok, Is.False);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should not throw an error for a 500 response with an empty body")]
@@ -317,8 +317,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
             });
 
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/500-error");
-            Assert.False(response.Ok);
-            Assert.AreEqual(HttpStatusCode.InternalServerError, response.Status);
+            Assert.That(response.Ok, Is.False);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.InternalServerError));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should return last response in redirect chain")]
@@ -329,8 +329,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
             Server.SetRedirect("/redirect/3.html", TestConstants.EmptyPage);
 
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/redirect/1.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should wait for network idle to succeed navigation")]
@@ -381,11 +381,11 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             await pageLoaded.Task.WithTimeout();
 
-            Assert.False(navigationFinished);
+            Assert.That(navigationFinished, Is.False);
 
             await initialFetchResourcesRequested.WithTimeout();
 
-            Assert.False(navigationFinished);
+            Assert.That(navigationFinished, Is.False);
 
             await Task.WhenAll(
                 fetches["/fetch-request-a.js"].Task,
@@ -406,7 +406,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
 
             await secondFetchResourceRequested.WithTimeout();
 
-            Assert.False(navigationFinished);
+            Assert.That(navigationFinished, Is.False);
 
             await fetches["/fetch-request-d.js"].Task.WithTimeout();
 
@@ -420,7 +420,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
             }
 
             var navigationResponse = await navigationTask;
-            Assert.AreEqual(HttpStatusCode.OK, navigationResponse.Status);
+            Assert.That(navigationResponse.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should navigate to dataURL and fire dataURL requests")]
@@ -436,9 +436,9 @@ namespace PuppeteerSharp.Tests.NavigationTests
             };
             var dataUrl = "data:text/html,<div>yo</div>";
             var response = await Page.GoToAsync(dataUrl);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(dataUrl, requests[0].Url);
+            Assert.That(requests[0].Url, Is.EqualTo(dataUrl));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should navigate to URL with hash and fire requests without hash")]
@@ -453,18 +453,18 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 }
             };
             var response = await Page.GoToAsync(TestConstants.EmptyPage + "#hash");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.EmptyPage, requests[0].Url);
+            Assert.That(requests[0].Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should work with self requesting page")]
         public async Task ShouldWorkWithSelfRequestingPage()
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/self-request.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            StringAssert.Contains("self-request.html", response.Url);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Does.Contain("self-request.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should fail when navigating and show the url at the error message")]
@@ -472,8 +472,8 @@ namespace PuppeteerSharp.Tests.NavigationTests
         {
             var url = TestConstants.HttpsPrefix + "/redirect/1.html";
             var exception = Assert.ThrowsAsync<NavigationException>(async () => await Page.GoToAsync(url));
-            StringAssert.Contains(url, exception.Message);
-            StringAssert.Contains(url, exception.Url);
+            Assert.That(exception.Message, Does.Contain(url));
+            Assert.That(exception.Url, Does.Contain(url));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should send referer")]
@@ -491,9 +491,9 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 })
             );
 
-            Assert.AreEqual("http://google.com/", referer1);
+            Assert.That(referer1, Is.EqualTo("http://google.com/"));
             // Make sure subresources do not inherit referer.
-            Assert.AreEqual(TestConstants.ServerUrl + "/grid.html", referer2);
+            Assert.That(referer2, Is.EqualTo(TestConstants.ServerUrl + "/grid.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.goto", "should send referer policy")]
@@ -511,9 +511,9 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 })
             );
 
-            Assert.IsNull(referer1);
+            Assert.That(referer1, Is.Null);
             // Make sure subresources do not inherit referer.
-            Assert.AreEqual(TestConstants.ServerUrl + "/grid.html", referer2);
+            Assert.That(referer2, Is.EqualTo(TestConstants.ServerUrl + "/grid.html"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageReloadTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageReloadTests.cs
@@ -16,7 +16,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.EvaluateFunctionAsync("() => (globalThis._foo = 10)");
             await Page.ReloadAsync();
-            Assert.Null(await Page.EvaluateFunctionAsync("() => globalThis._foo"));
+            Assert.That(await Page.EvaluateFunctionAsync("() => globalThis._foo"), Is.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageWaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageWaitForNavigationTests.cs
@@ -22,8 +22,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 Page.EvaluateFunctionAsync("url => window.location.href = url", TestConstants.ServerUrl + "/grid.html")
             );
             var response = await waitForNavigationResult;
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            StringAssert.Contains("grid.html", response.Url);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Does.Contain("grid.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "Page.waitForNavigation", "should work with both domcontentloaded and load")]
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
             await waitForRequestTask.WithTimeout();
             await domContentLoadedTask.WithTimeout();
-            Assert.False(bothFired);
+            Assert.That(bothFired, Is.False);
             responseCompleted.SetResult(true);
             await bothFiredTask.WithTimeout();
             await navigationTask.WithTimeout();
@@ -70,8 +70,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 navigationTask,
                 Page.ClickAsync("a")
             );
-            Assert.Null(await navigationTask);
-            Assert.AreEqual(TestConstants.EmptyPage + "#foobar", Page.Url);
+            Assert.That(await navigationTask, Is.Null);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage + "#foobar"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.waitForNavigation", "should work with history.pushState()")]
@@ -89,8 +89,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 navigationTask,
                 Page.ClickAsync("a")
             );
-            Assert.Null(await navigationTask);
-            Assert.AreEqual(TestConstants.ServerUrl + "/wow.html", Page.Url);
+            Assert.That(await navigationTask, Is.Null);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/wow.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.waitForNavigation", "should work with history.replaceState()")]
@@ -108,8 +108,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 navigationTask,
                 Page.ClickAsync("a")
             );
-            Assert.Null(await navigationTask);
-            Assert.AreEqual(TestConstants.ServerUrl + "/replaced.html", Page.Url);
+            Assert.That(await navigationTask, Is.Null);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/replaced.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.waitForNavigation", "should work with DOM history.back()/history.forward()")]
@@ -126,21 +126,21 @@ namespace PuppeteerSharp.Tests.PageTests
                 history.pushState({}, '', '/second.html');
               </script>
             ");
-            Assert.AreEqual(TestConstants.ServerUrl + "/second.html", Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/second.html"));
             var navigationTask = Page.WaitForNavigationAsync();
             await Task.WhenAll(
                 navigationTask,
                 Page.ClickAsync("a#back")
             );
-            Assert.Null(await navigationTask);
-            Assert.AreEqual(TestConstants.ServerUrl + "/first.html", Page.Url);
+            Assert.That(await navigationTask, Is.Null);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/first.html"));
             navigationTask = Page.WaitForNavigationAsync();
             await Task.WhenAll(
                 navigationTask,
                 Page.ClickAsync("a#forward")
             );
-            Assert.Null(await navigationTask);
-            Assert.AreEqual(TestConstants.ServerUrl + "/second.html", Page.Url);
+            Assert.That(await navigationTask, Is.Null);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/second.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("navigation.spec", "navigation Page.waitForNavigation", "should work when subframe issues window.stop()")]

--- a/lib/PuppeteerSharp.Tests/NetworkManagerTests/NetworkManagerTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkManagerTests/NetworkManagerTests.cs
@@ -179,7 +179,7 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 })
             });
 
-        Assert.AreEqual(2, requests.Count);
+        Assert.That(requests, Has.Count.EqualTo(2));
     }
 
     [Test, Retry(2), PuppeteerTest("NetworkManager.test.ts", "NetworkManager",
@@ -274,7 +274,7 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 MessageData = JToken.FromObject(new LoadingFinishedEventResponse { RequestId = "1360.2", })
             });
 
-        Assert.AreEqual(1, requests.Count);
+        Assert.That(requests, Has.Count.EqualTo(1));
     }
 
     [Test, Retry(2), PuppeteerTest("NetworkManager.test.ts", "NetworkManager",
@@ -361,9 +361,9 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 MessageData = JToken.FromObject(new LoadingFinishedEventResponse() { RequestId = "LOADERID", })
             });
 
-        Assert.AreEqual(1, pendingRequests.Count);
-        Assert.AreEqual(0, finishedRequests.Count);
-        Assert.Null(pendingRequests[0].Response);
+        Assert.That(pendingRequests, Has.Count.EqualTo(1));
+        Assert.That(finishedRequests, Is.Empty);
+        Assert.That(pendingRequests[0].Response, Is.Null);
 
         client.MessageReceived += Raise.EventWith(
             client,
@@ -382,9 +382,9 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 })
             });
 
-        Assert.AreEqual(1, pendingRequests.Count);
-        Assert.AreEqual(1, finishedRequests.Count);
-        Assert.NotNull(pendingRequests[0].Response);
+        Assert.That(pendingRequests, Has.Count.EqualTo(1));
+        Assert.That(finishedRequests, Has.Count.EqualTo(1));
+        Assert.That(pendingRequests[0].Response, Is.Not.Null);
     }
 
     [Test, Retry(2), PuppeteerTest("NetworkManager.test.ts", "NetworkManager",
@@ -469,9 +469,9 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 })
             });
 
-        Assert.AreEqual(1, responses.Count);
-        Assert.AreEqual(1, requests.Count);
-        Assert.NotNull(requests[0].Response);
+        Assert.That(responses, Has.Count.EqualTo(1));
+        Assert.That(requests, Has.Count.EqualTo(1));
+        Assert.That(requests[0].Response, Is.Not.Null);
     }
 
     [Test, Retry(2), PuppeteerTest("NetworkManager.test.ts", "NetworkManager",
@@ -568,9 +568,9 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 })
             });
 
-        Assert.AreEqual(1, requests.Count);
-        Assert.AreEqual(1, responses.Count);
-        Assert.NotNull(requests[0].Response);
+        Assert.That(requests, Has.Count.EqualTo(1));
+        Assert.That(responses, Has.Count.EqualTo(1));
+        Assert.That(requests[0].Response, Is.Not.Null);
     }
 
     [Test, Retry(2), PuppeteerTest("NetworkManager.test.ts", "NetworkManager", "should handle cached redirects")]
@@ -813,6 +813,6 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                     })
             });
 
-        Assert.AreEqual(new[] { HttpStatusCode.OK, HttpStatusCode.Found, HttpStatusCode.OK }, responses.Select(response => response.Status));
+        Assert.That(responses.Select(response => response.Status), Is.EqualTo(new[] { HttpStatusCode.OK, HttpStatusCode.Found, HttpStatusCode.OK }));
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/NetworkEventTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/NetworkEventTests.cs
@@ -21,12 +21,12 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Page.Request += (_, e) => requests.Add(e.Request);
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.EmptyPage, requests[0].Url);
-            Assert.AreEqual(ResourceType.Document, requests[0].ResourceType);
-            Assert.AreEqual(HttpMethod.Get, requests[0].Method);
-            Assert.NotNull(requests[0].Response);
-            Assert.AreEqual(Page.MainFrame, requests[0].Frame);
-            Assert.AreEqual(TestConstants.EmptyPage, requests[0].Frame.Url);
+            Assert.That(requests[0].Url, Is.EqualTo(TestConstants.EmptyPage));
+            Assert.That(requests[0].ResourceType, Is.EqualTo(ResourceType.Document));
+            Assert.That(requests[0].Method, Is.EqualTo(HttpMethod.Get));
+            Assert.That(requests[0].Response, Is.Not.Null);
+            Assert.That(requests[0].Frame, Is.EqualTo(Page.MainFrame));
+            Assert.That(requests[0].Frame.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Network Events", "Page.Events.RequestServedFromCache")]
@@ -35,9 +35,9 @@ namespace PuppeteerSharp.Tests.NetworkTests
             var cached = new List<string>();
             Page.RequestServedFromCache += (_, e) => cached.Add(e.Request.Url.Split('/').Last());
             await Page.GoToAsync(TestConstants.ServerUrl + "/cached/one-style.html");
-            Assert.IsEmpty(cached);
+            Assert.That(cached, Is.Empty);
             await Page.ReloadAsync();
-            Assert.AreEqual(new[] { "one-style.css" }, cached);
+            Assert.That(cached, Is.EqualTo(new[] { "one-style.css" }));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Network Events", "Page.Events.Response")]
@@ -47,16 +47,16 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Page.Response += (_, e) => responses.Add(e.Response);
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.That(responses, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.EmptyPage, responses[0].Url);
-            Assert.AreEqual(HttpStatusCode.OK, responses[0].Status);
-            Assert.False(responses[0].FromCache);
-            Assert.False(responses[0].FromServiceWorker);
-            Assert.NotNull(responses[0].Request);
+            Assert.That(responses[0].Url, Is.EqualTo(TestConstants.EmptyPage));
+            Assert.That(responses[0].Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(responses[0].FromCache, Is.False);
+            Assert.That(responses[0].FromServiceWorker, Is.False);
+            Assert.That(responses[0].Request, Is.Not.Null);
 
             var remoteAddress = responses[0].RemoteAddress;
             // Either IPv6 or IPv4, depending on environment.
-            Assert.True(remoteAddress.IP == "[::1]" || remoteAddress.IP == "127.0.0.1");
-            Assert.AreEqual(TestConstants.Port, remoteAddress.Port);
+            Assert.That(remoteAddress.IP == "[::1]" || remoteAddress.IP == "127.0.0.1", Is.True);
+            Assert.That(remoteAddress.Port, Is.EqualTo(TestConstants.Port));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Network Events", "Page.Events.RequestFailed")]
@@ -79,20 +79,20 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
 
             Assert.That(failedRequests, Has.Exactly(1).Items);
-            StringAssert.Contains("one-style.css", failedRequests[0].Url);
-            Assert.Null(failedRequests[0].Response);
-            Assert.AreEqual(ResourceType.StyleSheet, failedRequests[0].ResourceType);
+            Assert.That(failedRequests[0].Url, Does.Contain("one-style.css"));
+            Assert.That(failedRequests[0].Response, Is.Null);
+            Assert.That(failedRequests[0].ResourceType, Is.EqualTo(ResourceType.StyleSheet));
 
             if (TestConstants.IsChrome)
             {
-                Assert.AreEqual("net::ERR_FAILED", failedRequests[0].FailureText);
+                Assert.That(failedRequests[0].FailureText, Is.EqualTo("net::ERR_FAILED"));
             }
             else
             {
-                Assert.AreEqual("NS_ERROR_FAILURE", failedRequests[0].FailureText);
+                Assert.That(failedRequests[0].FailureText, Is.EqualTo("NS_ERROR_FAILURE"));
             }
 
-            Assert.NotNull(failedRequests[0].Frame);
+            Assert.That(failedRequests[0].Frame, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Network Events", "Page.Events.RequestFinished")]
@@ -102,11 +102,11 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Page.RequestFinished += (_, e) => requests.Add(e.Request);
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.EmptyPage, requests[0].Url);
-            Assert.NotNull(requests[0].Response);
-            Assert.AreEqual(HttpMethod.Get, requests[0].Method);
-            Assert.AreEqual(Page.MainFrame, requests[0].Frame);
-            Assert.AreEqual(TestConstants.EmptyPage, requests[0].Frame.Url);
+            Assert.That(requests[0].Url, Is.EqualTo(TestConstants.EmptyPage));
+            Assert.That(requests[0].Response, Is.Not.Null);
+            Assert.That(requests[0].Method, Is.EqualTo(HttpMethod.Get));
+            Assert.That(requests[0].Frame, Is.EqualTo(Page.MainFrame));
+            Assert.That(requests[0].Frame.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Network Events", "should fire events in proper order")]
@@ -117,7 +117,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Page.Response += (_, _) => events.Add("response");
             Page.RequestFinished += (_, _) => events.Add("requestfinished");
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(new[] { "request", "response", "requestfinished" }, events.ToArray());
+            Assert.That(events.ToArray(), Is.EqualTo(new[] { "request", "response", "requestfinished" }));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Network Events", "should support redirects")]
@@ -132,20 +132,20 @@ namespace PuppeteerSharp.Tests.NetworkTests
             const string FOO_URL = TestConstants.ServerUrl + "/foo.html";
             var response = await Page.GoToAsync(FOO_URL);
             System.Console.WriteLine(string.Concat(events, ','));
-            Assert.AreEqual(new[] {
+            Assert.That(events.ToArray(), Is.EqualTo(new[] {
                 $"GET {FOO_URL}",
                 $"302 {FOO_URL}",
                 $"DONE {FOO_URL}",
                 $"GET {TestConstants.EmptyPage}",
                 $"200 {TestConstants.EmptyPage}",
                 $"DONE {TestConstants.EmptyPage}"
-            }, events.ToArray());
+            }));
 
             // Check redirect chain
             var redirectChain = response.Request.RedirectChain;
             Assert.That(redirectChain, Has.Exactly(1).Items);
-            StringAssert.Contains("/foo.html", redirectChain[0].Url);
-            Assert.AreEqual(TestConstants.Port, redirectChain[0].Response.RemoteAddress.Port);
+            Assert.That(redirectChain[0].Url, Does.Contain("/foo.html"));
+            Assert.That(redirectChain[0].Response.RemoteAddress.Port, Is.EqualTo(TestConstants.Port));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/PageAuthenticateTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/PageAuthenticateTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             try
             {
                 var response = await Page.GoToAsync(TestConstants.EmptyPage);
-                Assert.AreEqual(HttpStatusCode.Unauthorized, response.Status);
+                Assert.That(response.Status, Is.EqualTo(HttpStatusCode.Unauthorized));
             }
             catch (Exception e)
             {
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             });
 
             var newResponse = await Page.ReloadAsync();
-            Assert.AreEqual(HttpStatusCode.OK, newResponse.Status);
+            Assert.That(newResponse.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Page.authenticate", "should fail if wrong credentials")]
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             });
 
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.Unauthorized, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.Unauthorized));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Page.authenticate", "should allow disable authentication")]
@@ -65,7 +65,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             });
 
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
 
             await Page.AuthenticateAsync(new Credentials()
             {
@@ -76,7 +76,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             try
             {
                 response = await Page.GoToAsync(TestConstants.CrossProcessUrl + "/empty.html");
-                Assert.AreEqual(HttpStatusCode.Unauthorized, response.Status);
+                Assert.That(response.Status, Is.EqualTo(HttpStatusCode.Unauthorized));
             }
             catch (Exception e)
             {
@@ -105,10 +105,10 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/cached/one-style.html");
             await Page.ReloadAsync();
 
-            Assert.AreEqual(HttpStatusCode.NotModified, responses["one-style.html"].Status);
-            Assert.False(responses["one-style.html"].FromCache);
-            Assert.AreEqual(HttpStatusCode.OK, responses["one-style.css"].Status);
-            Assert.True(responses["one-style.css"].FromCache);
+            Assert.That(responses["one-style.html"].Status, Is.EqualTo(HttpStatusCode.NotModified));
+            Assert.That(responses["one-style.html"].FromCache, Is.False);
+            Assert.That(responses["one-style.css"].Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(responses["one-style.css"].FromCache, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/PageEventRequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/PageEventRequestTests.cs
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.EmptyPage);
 
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            Assert.AreEqual(2, requests.Count);
+            Assert.That(requests, Has.Count.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Page.Events.Request", "should fire for fetches")]
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.EvaluateExpressionAsync("fetch('/empty.html')");
-            Assert.AreEqual(2, requests.Count);
+            Assert.That(requests, Has.Count.EqualTo(2));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/PageSetBypassServiceWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/PageSetBypassServiceWorkerTests.cs
@@ -56,12 +56,12 @@ public class PageSetBypassServiceWorkerTests : PuppeteerPageBaseTest
             WaitUntil = [WaitUntilNavigation.Networkidle2],
         });
 
-        Assert.False(Page.IsServiceWorkerBypassed);
-        Assert.AreEqual(2, responses.Count);
-        Assert.AreEqual(HttpStatusCode.OK, responses["sw.html"].Status);
-        Assert.True(responses["sw.html"].FromServiceWorker);
-        Assert.AreEqual(HttpStatusCode.OK, responses["style.css"].Status);
-        Assert.True(responses["style.css"].FromServiceWorker);
+        Assert.That(Page.IsServiceWorkerBypassed, Is.False);
+        Assert.That(responses, Has.Count.EqualTo(2));
+        Assert.That(responses["sw.html"].Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(responses["sw.html"].FromServiceWorker, Is.True);
+        Assert.That(responses["style.css"].Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(responses["style.css"].FromServiceWorker, Is.True);
 
         await Page.SetBypassServiceWorkerAsync(true);
         await Page.ReloadAsync(new NavigationOptions()
@@ -69,10 +69,10 @@ public class PageSetBypassServiceWorkerTests : PuppeteerPageBaseTest
             WaitUntil = [WaitUntilNavigation.Networkidle2],
         });
 
-        Assert.True(Page.IsServiceWorkerBypassed);
-        Assert.AreEqual(HttpStatusCode.OK, responses["sw.html"].Status);
-        Assert.False(responses["sw.html"].FromServiceWorker);
-        Assert.AreEqual(HttpStatusCode.OK, responses["style.css"].Status);
-        Assert.False(responses["style.css"].FromServiceWorker);
+        Assert.That(Page.IsServiceWorkerBypassed, Is.True);
+        Assert.That(responses["sw.html"].Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(responses["sw.html"].FromServiceWorker, Is.False);
+        Assert.That(responses["style.css"].Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(responses["style.css"].FromServiceWorker, Is.False);
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/PageSetExtraHttpHeadersTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/PageSetExtraHttpHeadersTests.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             var headerTask = Server.WaitForRequest("/empty.html", request => request.Headers["Foo"]);
             await Task.WhenAll(Page.GoToAsync(TestConstants.EmptyPage), headerTask);
 
-            Assert.AreEqual("Bar", headerTask.Result);
+            Assert.That(headerTask.Result, Is.EqualTo("Bar"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestFrameTests.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(Page.MainFrame, requests[0].Frame);
+            Assert.That(requests[0].Frame, Is.EqualTo(Page.MainFrame));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.Frame", "should work for subframe navigation request")]
@@ -45,8 +45,8 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.EmptyPage);
 
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            Assert.AreEqual(2, requests.Count);
-            Assert.AreEqual(Page.FirstChildFrame(), requests[1].Frame);
+            Assert.That(requests, Has.Count.EqualTo(2));
+            Assert.That(requests[1].Frame, Is.EqualTo(Page.FirstChildFrame()));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.Frame", "should work for fetch requests")]
@@ -63,8 +63,8 @@ namespace PuppeteerSharp.Tests.NetworkTests
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.EvaluateExpressionAsync("fetch('/empty.html')");
-            Assert.AreEqual(2, requests.Count);
-            Assert.AreEqual(Page.MainFrame, requests[0].Frame);
+            Assert.That(requests, Has.Count.EqualTo(2));
+            Assert.That(requests[0].Frame, Is.EqualTo(Page.MainFrame));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestHeadersTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestHeadersTests.cs
@@ -13,11 +13,11 @@ namespace PuppeteerSharp.Tests.NetworkTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("Chrome", response.Request.Headers["User-Agent"]);
+                Assert.That(response.Request.Headers["User-Agent"], Does.Contain("Chrome"));
             }
             else
             {
-                StringAssert.Contains("Firefox", response.Request.Headers["User-Agent"]);
+                Assert.That(response.Request.Headers["User-Agent"], Does.Contain("Firefox"));
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestIsNavigationRequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestIsNavigationRequestTests.cs
@@ -23,11 +23,11 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Page.Request += (_, e) => requests[e.Request.Url.Split('/').Last()] = e.Request;
             Server.SetRedirect("/rrredirect", "/frames/one-frame.html");
             await Page.GoToAsync(TestConstants.ServerUrl + "/rrredirect");
-            Assert.True(requests["rrredirect"].IsNavigationRequest);
-            Assert.True(requests["one-frame.html"].IsNavigationRequest);
-            Assert.True(requests["frame.html"].IsNavigationRequest);
-            Assert.False(requests["script.js"].IsNavigationRequest);
-            Assert.False(requests["style.css"].IsNavigationRequest);
+            Assert.That(requests["rrredirect"].IsNavigationRequest, Is.True);
+            Assert.That(requests["one-frame.html"].IsNavigationRequest, Is.True);
+            Assert.That(requests["frame.html"].IsNavigationRequest, Is.True);
+            Assert.That(requests["script.js"].IsNavigationRequest, Is.False);
+            Assert.That(requests["style.css"].IsNavigationRequest, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.isNavigationRequest", "should work with request interception")]
@@ -43,11 +43,11 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.SetRequestInterceptionAsync(true);
             Server.SetRedirect("/rrredirect", "/frames/one-frame.html");
             await Page.GoToAsync(TestConstants.ServerUrl + "/rrredirect");
-            Assert.True(requests["rrredirect"].IsNavigationRequest);
-            Assert.True(requests["one-frame.html"].IsNavigationRequest);
-            Assert.True(requests["frame.html"].IsNavigationRequest);
-            Assert.False(requests["script.js"].IsNavigationRequest);
-            Assert.False(requests["style.css"].IsNavigationRequest);
+            Assert.That(requests["rrredirect"].IsNavigationRequest, Is.True);
+            Assert.That(requests["one-frame.html"].IsNavigationRequest, Is.True);
+            Assert.That(requests["frame.html"].IsNavigationRequest, Is.True);
+            Assert.That(requests["script.js"].IsNavigationRequest, Is.False);
+            Assert.That(requests["style.css"].IsNavigationRequest, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.isNavigationRequest", "should work when navigating to image")]
@@ -56,7 +56,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             var requests = new List<IRequest>();
             Page.Request += (_, e) => requests.Add(e.Request);
             await Page.GoToAsync(TestConstants.ServerUrl + "/pptr.png");
-            Assert.True(requests[0].IsNavigationRequest);
+            Assert.That(requests[0].IsNavigationRequest, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
@@ -15,15 +15,15 @@ namespace PuppeteerSharp.Tests.NetworkTests
             var requestTask = Page.WaitForRequestAsync((request) => !TestUtils.IsFavicon(request));
             await Page.EvaluateExpressionHandleAsync("fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar'})})");
             var request = await requestTask.WithTimeout();
-            Assert.NotNull(request);
-            Assert.AreEqual("{\"foo\":\"bar\"}", request.PostData);
+            Assert.That(request, Is.Not.Null);
+            Assert.That(request.PostData, Is.EqualTo("{\"foo\":\"bar\"}"));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.postData", "should be |undefined| when there is no post data")]
         public async Task ShouldBeUndefinedWhenThereIsNoPostData()
         {
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.Null(response.Request.PostData);
+            Assert.That(response.Request.PostData, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.postData", "should work with blobs")]
@@ -39,10 +39,10 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 }),
             })");
             var request = await requestTask.WithTimeout();
-            Assert.NotNull(request);
-            Assert.Null(request.PostData);
-            Assert.True(request.HasPostData);
-            Assert.AreEqual("{\"foo\":\"bar\"}", await request.FetchPostDataAsync());
+            Assert.That(request, Is.Not.Null);
+            Assert.That(request.PostData, Is.Null);
+            Assert.That(request.HasPostData, Is.True);
+            Assert.That(await request.FetchPostDataAsync(), Is.EqualTo("{\"foo\":\"bar\"}"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseBufferTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseBufferTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/pptr.png");
             var imageBuffer = File.ReadAllBytes("./Assets/pptr.png");
-            Assert.AreEqual(imageBuffer, await response.BufferAsync());
+            Assert.That(await response.BufferAsync(), Is.EqualTo(imageBuffer));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Response.buffer", "should work with compression")]
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Server.EnableGzip("/pptr.png");
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/pptr.png");
             var imageBuffer = File.ReadAllBytes("./Assets/pptr.png");
-            Assert.AreEqual(imageBuffer, await response.BufferAsync());
+            Assert.That(await response.BufferAsync(), Is.EqualTo(imageBuffer));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromCacheTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromCacheTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldReturnFalseForNonCachedContent()
         {
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.False(response.FromCache);
+            Assert.That(response.FromCache, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Response.fromCache", "should work")]
@@ -35,11 +35,11 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/cached/one-style.html");
             await Page.ReloadAsync();
 
-            Assert.AreEqual(2, responses.Count);
-            Assert.AreEqual(HttpStatusCode.NotModified, responses["one-style.html"].Status);
-            Assert.False(responses["one-style.html"].FromCache);
-            Assert.AreEqual(HttpStatusCode.OK, responses["one-style.css"].Status);
-            Assert.True(responses["one-style.css"].FromCache);
+            Assert.That(responses, Has.Count.EqualTo(2));
+            Assert.That(responses["one-style.html"].Status, Is.EqualTo(HttpStatusCode.NotModified));
+            Assert.That(responses["one-style.html"].FromCache, Is.False);
+            Assert.That(responses["one-style.css"].Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(responses["one-style.css"].FromCache, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromServiceWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseFromServiceWorkerTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldReturnFalseForNonServiceWorkerContent()
         {
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.False(response.FromServiceWorker);
+            Assert.That(response.FromServiceWorker, Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Response.fromServiceWorker", "Response.fromServiceWorker")]
@@ -36,11 +36,11 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.EvaluateFunctionAsync("async () => await window.activationPromise");
             await Page.ReloadAsync();
 
-            Assert.AreEqual(2, responses.Count);
-            Assert.AreEqual(HttpStatusCode.OK, responses["sw.html"].Status);
-            Assert.True(responses["sw.html"].FromServiceWorker);
-            Assert.AreEqual(HttpStatusCode.OK, responses["style.css"].Status);
-            Assert.True(responses["style.css"].FromServiceWorker);
+            Assert.That(responses, Has.Count.EqualTo(2));
+            Assert.That(responses["sw.html"].Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(responses["sw.html"].FromServiceWorker, Is.True);
+            Assert.That(responses["style.css"].Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(responses["style.css"].FromServiceWorker, Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseHeadersTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseHeadersTests.cs
@@ -20,7 +20,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             });
 
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            StringAssert.Contains("bar", response.Headers["foo"]);
+            Assert.That(response.Headers["foo"], Does.Contain("bar"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseJsonTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseJsonTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/simple.json");
-            Assert.AreEqual(JObject.Parse("{foo: 'bar'}"), await response.JsonAsync());
+            Assert.That(await response.JsonAsync(), Is.EqualTo(JObject.Parse("{foo: 'bar'}")));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseStatusTextTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseStatusTextTests.cs
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 return Task.CompletedTask;
             });
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/cool");
-            Assert.AreEqual("cool!", response.StatusText);
+            Assert.That(response.StatusText, Is.EqualTo("cool!"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/simple.json");
-            Assert.AreEqual("{\"foo\": \"bar\"}", (await response.TextAsync()).Trim());
+            Assert.That((await response.TextAsync()).Trim(), Is.EqualTo("{\"foo\": \"bar\"}"));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Response.text", "should return uncompressed text")]
@@ -26,8 +26,8 @@ namespace PuppeteerSharp.Tests.NetworkTests
         {
             Server.EnableGzip("/simple.json");
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/simple.json");
-            Assert.AreEqual("gzip", response.Headers["Content-Encoding"]);
-            Assert.AreEqual("{\"foo\": \"bar\"}", (await response.TextAsync()).Trim());
+            Assert.That(response.Headers["Content-Encoding"], Is.EqualTo("gzip"));
+            Assert.That((await response.TextAsync()).Trim(), Is.EqualTo("{\"foo\": \"bar\"}"));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Response.text", "should throw when requesting body of redirected response")]
@@ -38,10 +38,10 @@ namespace PuppeteerSharp.Tests.NetworkTests
             var redirectChain = response.Request.RedirectChain;
             Assert.That(redirectChain, Has.Exactly(1).Items);
             var redirected = redirectChain[0].Response;
-            Assert.AreEqual(HttpStatusCode.Redirect, redirected.Status);
+            Assert.That(redirected.Status, Is.EqualTo(HttpStatusCode.Redirect));
 
             var exception = Assert.ThrowsAsync<PuppeteerException>(async () => await redirected.TextAsync());
-            StringAssert.Contains("Response body is unavailable for redirect responses", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Response body is unavailable for redirect responses"));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Response.text", "should wait until response completes")]
@@ -82,10 +82,10 @@ namespace PuppeteerSharp.Tests.NetworkTests
                 WaitForPageResponseEvent()
             );
 
-            Assert.NotNull(serverResponse);
-            Assert.NotNull(pageResponse);
-            Assert.AreEqual(HttpStatusCode.OK, pageResponse.Status);
-            Assert.False(requestFinished);
+            Assert.That(serverResponse, Is.Not.Null);
+            Assert.That(pageResponse, Is.Not.Null);
+            Assert.That(pageResponse.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(requestFinished, Is.False);
 
             var responseText = pageResponse.TextAsync();
             // Write part of the response and wait for it to be flushed.
@@ -93,7 +93,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             // Finish response.
             await serverResponse.WriteAsync("ld!");
             serverResponseCompletion.SetResult(true);
-            Assert.AreEqual("hello world!", await responseText);
+            Assert.That(await responseText, Is.EqualTo("hello world!"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
+++ b/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             );
             await frameTask.WithTimeout();
-            Assert.AreEqual(2, Page.MainFrame.ChildFrames.Count);
+            Assert.That(Page.MainFrame.ChildFrames, Has.Count.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should track navigations within OOP iframes")]
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             );
             var frame = await frameTask.WithTimeout();
-            StringAssert.Contains("/empty.html", frame.Url);
+            Assert.That(frame.Url, Does.Contain("/empty.html"));
             var nav = frame.WaitForNavigationAsync();
             await FrameUtils.NavigateFrameAsync(
               Page,
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/assets/frame.html"
             );
             await nav.WithTimeout();
-            StringAssert.Contains("/assets/frame.html", frame.Url);
+            Assert.That(frame.Url, Does.Contain("/assets/frame.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should support OOP iframes becoming normal iframes again")]
@@ -68,20 +68,20 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frameTask = Page.WaitForFrameAsync((frame) => frame != Page.MainFrame);
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage).WithTimeout();
             var frame = await frameTask.WithTimeout();
-            Assert.False(frame.IsOopFrame);
+            Assert.That(frame.IsOopFrame, Is.False);
             var nav = frame.WaitForNavigationAsync();
             await FrameUtils.NavigateFrameAsync(
               Page,
               "frame1",
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             ).WithTimeout();
-            Assert.True(frame.IsOopFrame);
+            Assert.That(frame.IsOopFrame, Is.True);
             await nav.WithTimeout();
             nav = frame.WaitForNavigationAsync();
             await FrameUtils.NavigateFrameAsync(Page, "frame1", TestConstants.EmptyPage).WithTimeout();
             await nav.WithTimeout();
-            Assert.False(frame.IsOopFrame);
-            Assert.AreEqual(2, Page.Frames.Length);
+            Assert.That(frame.IsOopFrame, Is.False);
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should support frames within OOP frames")]
@@ -100,8 +100,8 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frame1 = await frame1Task;
             var frame2 = await frame2Task;
 
-            StringAssert.Contains("one-frame", await frame1.EvaluateExpressionAsync<string>("document.location.href"));
-            StringAssert.Contains("frame.html", await frame2.EvaluateExpressionAsync<string>("document.location.href"));
+            Assert.That(await frame1.EvaluateExpressionAsync<string>("document.location.href"), Does.Contain("one-frame"));
+            Assert.That(await frame2.EvaluateExpressionAsync<string>("document.location.href"), Does.Contain("frame.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should recover cross-origin frames on reconnect")]
@@ -127,9 +127,9 @@ namespace PuppeteerSharp.Tests.OOPIFTests
 
             var pages = await browserTwo.PagesAsync();
             var emptyPages = pages.Where(page => page.Url == TestConstants.EmptyPage).ToArray();
-            Assert.AreEqual(1, emptyPages.Length);
+            Assert.That(emptyPages, Has.Length.EqualTo(1));
             var dump2 = await FrameUtils.DumpFramesAsync(emptyPages[0].MainFrame);
-            Assert.AreEqual(dump1, dump2);
+            Assert.That(dump2, Is.EqualTo(dump1));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should support OOP iframes getting detached")]
@@ -139,13 +139,13 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frameTask = Page.WaitForFrameAsync((frame) => frame != Page.MainFrame);
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage).WithTimeout();
             var frame = await frameTask.WithTimeout();
-            Assert.False(frame.IsOopFrame);
+            Assert.That(frame.IsOopFrame, Is.False);
             await FrameUtils.NavigateFrameAsync(
               Page,
               "frame1",
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             ).WithTimeout();
-            Assert.True(frame.IsOopFrame);
+            Assert.That(frame.IsOopFrame, Is.True);
             var detachedTcs = new TaskCompletionSource<bool>();
             Page.FrameDetached += (sender, e) => detachedTcs.TrySetResult(true);
             await FrameUtils.DetachFrameAsync(Page, "frame1").WithTimeout();
@@ -160,7 +160,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frameTask = Page.WaitForFrameAsync((frame) => frame != Page.MainFrame);
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage).WithTimeout();
             var frame = await frameTask.WithTimeout();
-            Assert.False(frame.IsOopFrame);
+            Assert.That(frame.IsOopFrame, Is.False);
             var nav = frame.WaitForNavigationAsync();
             await FrameUtils.NavigateFrameAsync(
               Page,
@@ -168,7 +168,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             ).WithTimeout();
             await nav.WithTimeout();
-            Assert.True(frame.IsOopFrame);
+            Assert.That(frame.IsOopFrame, Is.True);
             var detachedTcs = new TaskCompletionSource<bool>();
             Page.FrameDetached += (sender, e) => detachedTcs.TrySetResult(true);
             await FrameUtils.DetachFrameAsync(Page, "frame1").WithTimeout();
@@ -187,9 +187,9 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             );
             var frame = await frameTask.WithTimeout();
-            StringAssert.Contains("/empty.html", frame.Url);
+            Assert.That(frame.Url, Does.Contain("/empty.html"));
             await FrameUtils.NavigateFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            Assert.AreEqual(TestConstants.EmptyPage, frame.Url);
+            Assert.That(frame.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should support evaluating in oop iframes")]
@@ -205,7 +205,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frame = await frameTask.WithTimeout();
             await frame.EvaluateFunctionAsync("() => _test = 'Test 123!'");
             var result = await frame.EvaluateFunctionAsync<string>("() => window._test");
-            Assert.AreEqual("Test 123!", result);
+            Assert.That(result, Is.EqualTo("Test 123!"));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should provide access to elements")]
@@ -260,8 +260,8 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frameTask = Page.WaitForFrameAsync((frame) => frame.Url.EndsWith("oopif.html"));
             await Page.GoToAsync($"http://mainframe:{TestConstants.Port}/dynamic-oopif.html");
             var frame = await frameTask.WithTimeout();
-            Assert.AreEqual(1, (await GetIframesAsync()).Length);
-            Assert.AreEqual(2, Page.Frames.Length);
+            Assert.That((await GetIframesAsync()), Has.Length.EqualTo(1));
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should wait for inner OOPIFs")]
@@ -270,9 +270,9 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             var frameTask = Page.WaitForFrameAsync((frame) => frame.Url.EndsWith("inner-frame2.html"));
             await Page.GoToAsync($"http://mainframe:{TestConstants.Port}/main-frame.html");
             var frame = await frameTask.WithTimeout();
-            Assert.AreEqual(2, (await GetIframesAsync()).Length);
-            Assert.AreEqual(2, Page.Frames.Count(frameElement => frameElement.IsOopFrame));
-            Assert.AreEqual(1, await frame.EvaluateFunctionAsync<int>("() => document.querySelectorAll('button').length"));
+            Assert.That((await GetIframesAsync()), Has.Length.EqualTo(2));
+            Assert.That(Page.Frames.Count(frameElement => frameElement.IsOopFrame), Is.EqualTo(2));
+            Assert.That(await frame.EvaluateFunctionAsync<int>("() => document.querySelectorAll('button').length"), Is.EqualTo(1));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should load oopif iframes with subresources and request interception")]
@@ -286,7 +286,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             await frameTask.WithTimeout();
             await requestTask.WithTimeout();
             Assert.That(GetIframesAsync, Has.Exactly(1).Items);
-            Assert.AreEqual(requestTask.Result.Frame, frameTask.Result);
+            Assert.That(frameTask.Result, Is.EqualTo(requestTask.Result.Frame));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should support frames within OOP iframes")]
@@ -301,22 +301,22 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             ).WithTimeout(2_000);
             var frame1 = oopIframe.ChildFrames.First();
-            StringAssert.Contains("empty.html", frame1.Url);
+            Assert.That(frame1.Url, Does.Contain("empty.html"));
             await FrameUtils.NavigateFrameAsync(
               oopIframe,
               "frame1",
               TestConstants.CrossProcessHttpPrefix + "/oopif.html"
             ).WithTimeout();
-            StringAssert.Contains("oopif.html", frame1.Url);
+            Assert.That(frame1.Url, Does.Contain("oopif.html"));
             await frame1.GoToAsync(
                 TestConstants.CrossProcessHttpPrefix + "/oopif.html#navigate-within-document",
                 new NavigationOptions { WaitUntil = new[] { WaitUntilNavigation.Load } }).WithTimeout();
-            StringAssert.Contains("/oopif.html#navigate-within-document", frame1.Url);
+            Assert.That(frame1.Url, Does.Contain("/oopif.html#navigate-within-document"));
             var detachedTcs = new TaskCompletionSource<bool>();
             Page.FrameDetached += (sender, e) => detachedTcs.TrySetResult(true);
             await FrameUtils.DetachFrameAsync(oopIframe, "frame1").WithTimeout();
             await detachedTcs.Task.WithTimeout();
-            Assert.IsEmpty(oopIframe.ChildFrames);
+            Assert.That(oopIframe.ChildFrames, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "clickablePoint, boundingBox, boxModel should work for elements inside OOPIFs")]
@@ -344,8 +344,8 @@ namespace PuppeteerSharp.Tests.OOPIFTests
 
             var button = await frame.WaitForSelectorAsync("#test-button", new WaitForSelectorOptions { Visible = true });
             var result = await button.ClickablePointAsync();
-            Assert.True(result.X > 150); // padding + margin + border left
-            Assert.True(result.Y > 150); // padding + margin + border top
+            Assert.That(result.X, Is.GreaterThan(150)); // padding + margin + border left
+            Assert.That(result.Y, Is.GreaterThan(150)); // padding + margin + border top
             var resultBoxModel = await button.BoxModelAsync();
             foreach (var quad in new[] {
               resultBoxModel.Content,
@@ -355,13 +355,13 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             {
                 foreach (var part in quad)
                 {
-                    Assert.True(part.X > 150); // padding + margin + border left
-                    Assert.True(part.Y > 150); // padding + margin + border top
+                    Assert.That(part.X, Is.GreaterThan(150)); // padding + margin + border left
+                    Assert.That(part.Y, Is.GreaterThan(150)); // padding + margin + border top
                 }
             }
             var resultBoundingBox = await button.BoundingBoxAsync();
-            Assert.True(resultBoundingBox.X > 150); // padding + margin + border left
-            Assert.True(resultBoundingBox.Y > 150); // padding + margin + border top
+            Assert.That(resultBoundingBox.X, Is.GreaterThan(150)); // padding + margin + border left
+            Assert.That(resultBoundingBox.Y, Is.GreaterThan(150)); // padding + margin + border top
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF", "should detect existing OOPIFs when Puppeteer connects to an existing page")]
@@ -371,7 +371,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/dynamic-oopif.html");
             await frameTask.WithTimeout();
             Assert.That(GetIframesAsync, Has.Exactly(1).Items);
-            Assert.AreEqual(2, Page.Frames.Length);
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
 
             var browserURL = $"http://127.0.0.1:{_port}";
             var browser1 = await Puppeteer.ConnectAsync(new() { BrowserURL = browserURL }, TestConstants.LoggerFactory);
@@ -454,7 +454,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
                 AwaitPromise = true,
             });
 
-            Assert.Contains($"http://oopifdomain:{TestConstants.Port}/fetch", networkEvents);
+            Assert.That(networkEvents, Does.Contain($"http://oopifdomain:{TestConstants.Port}/fetch"));
         }
 
         [Test, Retry(2), PuppeteerTest("oopif.spec", "OOPIF waitForFrame", "should report google.com frame")]
@@ -478,7 +478,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             await page.WaitForSelectorAsync("iframe[src=\"https://google.com/\"]");
             var urls = Array.ConvertAll(page.Frames, frame => frame.Url);
             Array.Sort((Array)urls);
-            Assert.AreEqual(new[] { TestConstants.EmptyPage, "https://google.com/" }, urls);
+            Assert.That(urls, Is.EqualTo(new[] { TestConstants.EmptyPage, "https://google.com/" }));
         }
 
         private async Task<ElementHandle[]> GetIframesAsync()

--- a/lib/PuppeteerSharp.Tests/PageTests/AddScriptTagTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/AddScriptTagTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var exception = Assert.ThrowsAsync<ArgumentException>(()
                 => Page.AddScriptTagAsync(new AddTagOptions()));
-            Assert.AreEqual("Provide options with a `Url`, `Path` or `Content` property", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Provide options with a `Url`, `Path` or `Content` property"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should work with a url")]
@@ -25,8 +25,8 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var scriptHandle = await Page.AddScriptTagAsync(new AddTagOptions { Url = "/injectedfile.js" });
-            Assert.NotNull(scriptHandle);
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("__injected"));
+            Assert.That(scriptHandle, Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync<int>("__injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should work with a url and type=module")]
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.AddScriptTagAsync(new AddTagOptions { Url = "/es6/es6import.js", Type = "module" });
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("__es6injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("__es6injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should work with a path and type=module")]
@@ -47,7 +47,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 Type = "module"
             });
             await Page.WaitForFunctionAsync("() => window.__es6injected");
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("__es6injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("__es6injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should work with a content and type=module")]
@@ -60,7 +60,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 Type = "module"
             });
             await Page.WaitForFunctionAsync("() => window.__es6injected");
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("__es6injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("__es6injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should throw an error if loading from url fail")]
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(()
                 => Page.AddScriptTagAsync(new AddTagOptions { Url = "/nonexistfile.js" }));
-            StringAssert.Contains("Could not load script", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Could not load script"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should work with a path")]
@@ -80,8 +80,8 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Path = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("Assets", "injectedfile.js"))
             });
-            Assert.NotNull(scriptHandle);
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("__injected"));
+            Assert.That(scriptHandle, Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync<int>("__injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should include sourcemap when path is provided")]
@@ -93,7 +93,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 Path = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("Assets", "injectedfile.js"))
             });
             var result = await Page.EvaluateExpressionAsync<string>("__injectedError.stack");
-            StringAssert.Contains(Path.Combine("Assets", "injectedfile.js"), result);
+            Assert.That(result, Does.Contain(Path.Combine("Assets", "injectedfile.js")));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should work with content")]
@@ -101,8 +101,8 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var scriptHandle = await Page.AddScriptTagAsync(new AddTagOptions { Content = "window.__injected = 35;" });
-            Assert.NotNull(scriptHandle);
-            Assert.AreEqual(35, await Page.EvaluateExpressionAsync<int>("__injected"));
+            Assert.That(scriptHandle, Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync<int>("__injected"), Is.EqualTo(35));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should add id when provided")]
@@ -112,8 +112,8 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.AddScriptTagAsync(new AddTagOptions { Content = "window.__injected = 1;", Id = "one" });
             await Page.AddScriptTagAsync(new AddTagOptions { Url = "/injectedfile.js", Id = "two" });
 
-            Assert.NotNull(await Page.QuerySelectorAsync("#one"));
-            Assert.NotNull(await Page.QuerySelectorAsync("#two"));
+            Assert.That(await Page.QuerySelectorAsync("#one"), Is.Not.Null);
+            Assert.That(await Page.QuerySelectorAsync("#two"), Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should throw when added with content to the CSP page")]
@@ -126,7 +126,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 {
                     Content = "window.__injected = 35;"
                 }));
-            Assert.NotNull(exception);
+            Assert.That(exception, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addScriptTag", "should throw when added with URL to the CSP page")]
@@ -138,7 +138,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 {
                     Url = TestConstants.CrossProcessUrl + "/injectedfile.js"
                 }));
-            Assert.NotNull(exception);
+            Assert.That(exception, Is.Not.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/AddStyleTagTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/AddStyleTagTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var exception = Assert.ThrowsAsync<ArgumentException>(()
                 => Page.AddStyleTagAsync(new AddTagOptions()));
-            Assert.AreEqual("Provide options with a `Url`, `Path` or `Content` property", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Provide options with a `Url`, `Path` or `Content` property"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should work with a url")]
@@ -25,9 +25,10 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var styleHandle = await Page.AddStyleTagAsync(new AddTagOptions { Url = "/injectedstyle.css" });
-            Assert.NotNull(styleHandle);
-            Assert.AreEqual("rgb(255, 0, 0)", await Page.EvaluateExpressionAsync<string>(
-                "window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')"));
+            Assert.That(styleHandle, Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync<string>(
+                "window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')"),
+                Is.EqualTo("rgb(255, 0, 0)"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should throw an error if loading from url fail")]
@@ -36,7 +37,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(()
                 => Page.AddStyleTagAsync(new AddTagOptions { Url = "/nonexistfile.js" }));
-            StringAssert.Contains("Could not load style", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Could not load style"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should work with a path")]
@@ -44,9 +45,10 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var styleHandle = await Page.AddStyleTagAsync(new AddTagOptions { Path = "Assets/injectedstyle.css" });
-            Assert.NotNull(styleHandle);
-            Assert.AreEqual("rgb(255, 0, 0)", await Page.EvaluateExpressionAsync<string>(
-                "window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')"));
+            Assert.That(styleHandle, Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync<string>(
+                "window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')"),
+                Is.EqualTo("rgb(255, 0, 0)"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should include sourcemap when path is provided")]
@@ -59,7 +61,7 @@ namespace PuppeteerSharp.Tests.PageTests
             });
             var styleHandle = await Page.QuerySelectorAsync("style");
             var styleContent = await Page.EvaluateFunctionAsync<string>("style => style.innerHTML", styleHandle);
-            StringAssert.Contains(Path.Combine("Assets", "injectedstyle.css"), styleContent);
+            Assert.That(styleContent, Does.Contain(Path.Combine("Assets", "injectedstyle.css")));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should work with content")]
@@ -67,9 +69,10 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var styleHandle = await Page.AddStyleTagAsync(new AddTagOptions { Content = "body { background-color: green; }" });
-            Assert.NotNull(styleHandle);
-            Assert.AreEqual("rgb(0, 128, 0)", await Page.EvaluateExpressionAsync<string>(
-                "window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')"));
+            Assert.That(styleHandle, Is.Not.Null);
+            Assert.That(await Page.EvaluateExpressionAsync<string>(
+                "window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')"),
+                Is.EqualTo("rgb(0, 128, 0)"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should throw when added with content to the CSP page")]
@@ -81,7 +84,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 {
                     Content = "body { background-color: green; }"
                 }));
-            Assert.NotNull(exception);
+            Assert.That(exception, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.addStyleTag", "should throw when added with URL to the CSP page")]
@@ -93,7 +96,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 {
                     Url = TestConstants.CrossProcessUrl + "/injectedstyle.css"
                 }));
-            Assert.NotNull(exception);
+            Assert.That(exception, Is.Not.Null);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/BrowserContextTests.cs
@@ -10,6 +10,6 @@ namespace PuppeteerSharp.Tests.PageTests
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.browserContext", "should return the correct browser context instance")]
-        public void ShouldReturnTheCorrectBrowserInstance() => Assert.AreSame(Context, Page.BrowserContext);
+        public void ShouldReturnTheCorrectBrowserInstance() => Assert.That(Page.BrowserContext, Is.SameAs(Context));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/BrowserTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/BrowserTests.cs
@@ -11,6 +11,6 @@ namespace PuppeteerSharp.Tests.PageTests
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.browser", "should return the correct browser instance")]
-        public void ShouldReturnTheCorrectBrowserInstance() => Assert.AreSame(Browser, Page.Browser);
+        public void ShouldReturnTheCorrectBrowserInstance() => Assert.That(Page.Browser, Is.SameAs(Browser));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
@@ -8,22 +8,31 @@ namespace PuppeteerSharp.Tests.PageTests
     {
         public CloseTests() : base() { }
 
-        // [Test,  Retry(2),  PuppeteerTest("page.spec", "Page Page.close", "should reject all promises when page is closed")]
-        // [Ignore("TODO: See how to refactor this on nunit")]
-        public void ShouldRejectAllPromisesWhenPageIsClosed()
+        [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.close", "should reject all promises when page is closed")]
+        public async Task ShouldRejectAllPromisesWhenPageIsClosed()
         {
-            /*
-            var exceptionTask = Assert.ThrowsAsync<TargetClosedException>(() => Page.EvaluateFunctionAsync("() => new Promise(r => {})"));
+            TargetClosedException exception = null;
+
+            var exceptionTask = Assert.ThatAsync(async () =>
+            {
+                try
+                {
+                    await Page.EvaluateFunctionAsync("() => new Promise(r => {})");
+                }
+                catch (TargetClosedException e)
+                {
+                    exception = e;
+                    throw;
+                }
+            }, Throws.InstanceOf<TargetClosedException>());
 
             await Task.WhenAll(
                 exceptionTask,
                 Page.CloseAsync()
             );
 
-            var exception = await exceptionTask;
-            StringAssert.Contains("Protocol error", exception.Message);
-            Assert.AreEqual("Target.detachedFromTarget", exception.CloseReason);
-            */
+            Assert.That(exception.Message, Does.Contain("Protocol error"));
+            Assert.That(exception.CloseReason, Is.EqualTo("Target.detachedFromTarget"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.close", "should not be visible in browser.pages")]
@@ -36,6 +45,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(await browser.PagesAsync(), Does.Not.Contains(page));
         }
 
+        [Test]
         public async Task ShouldNotBeVisibleInBrowserPagesWithDisposeAsync()
         {
             await using var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions());

--- a/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
@@ -45,7 +45,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(await browser.PagesAsync(), Does.Not.Contains(page));
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldNotBeVisibleInBrowserPagesWithDisposeAsync()
         {
             await using var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions());

--- a/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await using var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions());
             var page = await browser.NewPageAsync();
-            Assert.Contains(page, await browser.PagesAsync());
+            Assert.That(await browser.PagesAsync(), Does.Contain(page));
             await page.CloseAsync();
             Assert.That(await browser.PagesAsync(), Does.Not.Contains(page));
         }
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await using var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions());
             var page = await browser.NewPageAsync();
-            Assert.Contains(page, await browser.PagesAsync());
+            Assert.That(await browser.PagesAsync(), Does.Contain(page));
             await page.DisposeAsync();
             Assert.That(await browser.PagesAsync(), Does.Not.Contains(page));
         }
@@ -53,16 +53,16 @@ namespace PuppeteerSharp.Tests.PageTests
             var dialogTask = new TaskCompletionSource<bool>();
             Page.Dialog += async (_, e) =>
             {
-                Assert.AreEqual(DialogType.BeforeUnload, e.Dialog.DialogType);
-                Assert.AreEqual(string.Empty, e.Dialog.DefaultValue);
+                Assert.That(e.Dialog.DialogType, Is.EqualTo(DialogType.BeforeUnload));
+                Assert.That(e.Dialog.DefaultValue, Is.EqualTo(string.Empty));
 
                 if (TestConstants.IsChrome)
                 {
-                    Assert.AreEqual(string.Empty, e.Dialog.Message);
+                    Assert.That(e.Dialog.Message, Is.EqualTo(string.Empty));
                 }
                 else
                 {
-                    Assert.AreEqual("This page is asking you to confirm that you want to leave - data you have entered may not be saved.", e.Dialog.Message);
+                    Assert.That(e.Dialog.Message, Is.EqualTo("This page is asking you to confirm that you want to leave - data you have entered may not be saved."));
                 }
 
                 await e.Dialog.Accept();
@@ -95,9 +95,9 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldSetThePageCloseState()
         {
             var page = await Context.NewPageAsync();
-            Assert.False(page.IsClosed);
+            Assert.That(page.IsClosed, Is.False);
             await page.CloseAsync();
-            Assert.True(page.IsClosed);
+            Assert.That(page.IsClosed, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.close", "should terminate network waiters")]
@@ -110,12 +110,12 @@ namespace PuppeteerSharp.Tests.PageTests
             await newPage.CloseAsync();
 
             var exception = Assert.ThrowsAsync<TargetClosedException>(() => requestTask);
-            StringAssert.Contains("Target closed", exception.Message);
-            StringAssert.DoesNotContain("Timeout", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Target closed"));
+            Assert.That(exception.Message, Does.Not.Contain("Timeout"));
 
             exception = Assert.ThrowsAsync<TargetClosedException>(() => responseTask);
-            StringAssert.Contains("Target closed", exception.Message);
-            StringAssert.DoesNotContain("Timeout", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Target closed"));
+            Assert.That(exception.Message, Does.Not.Contain("Timeout"));
         }
 
         [Test, Retry(2)]

--- a/lib/PuppeteerSharp.Tests/PageTests/ExposeFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/ExposeFunctionTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.ExposeFunctionAsync("compute", (int a, int b) => a * b);
             var result = await Page.EvaluateFunctionAsync<int>("async () => compute(9, 4)");
-            Assert.AreEqual(36, result);
+            Assert.That(result, Is.EqualTo(36));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should throw exception in page context")]
@@ -31,8 +31,8 @@ namespace PuppeteerSharp.Tests.PageTests
                     return { message: e.message, stack: e.stack};
                 }
             }");
-            Assert.AreEqual("WOOF WOOF", result.SelectToken("message").ToObject<string>());
-            StringAssert.Contains("ExposeFunctionTests", result.SelectToken("stack").ToObject<string>());
+            Assert.That(result.SelectToken("message").ToObject<string>(), Is.EqualTo("WOOF WOOF"));
+            Assert.That(result.SelectToken("stack").ToObject<string>(), Does.Contain("ExposeFunctionTests"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should be callable from-inside evaluateOnNewDocument")]
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.ExposeFunctionAsync("woof", () => called = true);
             await Page.EvaluateFunctionOnNewDocumentAsync("async () => woof()");
             await Page.ReloadAsync();
-            Assert.True(called);
+            Assert.That(called, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should work")]
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.ExposeFunctionAsync("compute", (int a, int b) => a * b);
             await Page.GoToAsync(TestConstants.EmptyPage);
             var result = await Page.EvaluateFunctionAsync<int>("async () => compute(9, 4)");
-            Assert.AreEqual(36, result);
+            Assert.That(result, Is.EqualTo(36));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should await returned promise")]
@@ -59,7 +59,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.ExposeFunctionAsync("compute", (int a, int b) => Task.FromResult(a * b));
             var result = await Page.EvaluateFunctionAsync<int>("async () => compute(3, 5)");
-            Assert.AreEqual(15, result);
+            Assert.That(result, Is.EqualTo(15));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should work on frames")]
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
             var frame = Page.FirstChildFrame();
             var result = await frame.EvaluateFunctionAsync<int>("async () => compute(3, 5)");
-            Assert.AreEqual(15, result);
+            Assert.That(result, Is.EqualTo(15));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should work with loading frames")]
@@ -101,7 +101,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await navTask;
             var frame = Page.FirstChildFrame();
             var result = await frame.EvaluateFunctionAsync<int>("() => globalThis.compute(3, 5)");
-            Assert.AreEqual(15, result);
+            Assert.That(result, Is.EqualTo(15));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should work on frames before navigation")]
@@ -112,7 +112,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
             var frame = Page.FirstChildFrame();
             var result = await frame.EvaluateFunctionAsync<int>("async () => compute(3, 5)");
-            Assert.AreEqual(15, result);
+            Assert.That(result, Is.EqualTo(15));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.exposeFunction", "should work with complex objects")]
@@ -122,7 +122,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.ExposeFunctionAsync("complexObject", (dynamic a, dynamic b) => Task.FromResult(new { X = a.x + b.x }));
 
             var result = await Page.EvaluateFunctionAsync<JToken>("async () => complexObject({x: 5}, {x: 2})");
-            Assert.AreEqual(7, result.SelectToken("x").ToObject<int>());
+            Assert.That(result.SelectToken("x").ToObject<int>(), Is.EqualTo(7));
         }
 
         [Test, Retry(2), PuppeteerTest("puppeteer-sharp", "ExposeFunctionTests", "should await returned task")]
@@ -135,7 +135,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 return Task.CompletedTask;
             });
             await Page.EvaluateFunctionAsync("async () => changeFlag()");
-            Assert.True(called);
+            Assert.That(called, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("puppeteer-sharp", "ExposeFunctionTests", "should work with action")]
@@ -147,7 +147,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 called = true;
             });
             await Page.EvaluateFunctionAsync("async () => changeFlag()");
-            Assert.True(called);
+            Assert.That(called, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("puppeteer-sharp", "ExposeFunctionTests", "should keel the callback clean")]
@@ -171,7 +171,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 }
             }
 
-            Assert.False(((CdpCDPSession)Page.Client).HasPendingCallbacks(), message);
+            Assert.That(((CdpCDPSession)Page.Client).HasPendingCallbacks(), Is.False, message);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/GeolocationTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GeolocationTests.cs
@@ -26,11 +26,11 @@ namespace PuppeteerSharp.Tests.PageTests
                 @"() => new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
                     resolve({latitude: position.coords.latitude, longitude: position.coords.longitude});
                 }))");
-            Assert.AreEqual(new GeolocationOption
+            Assert.That(geolocation, Is.EqualTo(new GeolocationOption
             {
                 Latitude = 10,
                 Longitude = 10
-            }, geolocation);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setGeolocation", "should throw when invalid longitude")]
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     Longitude = 200,
                     Latitude = 100
                 }));
-            StringAssert.Contains("Invalid longitude '200'", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Invalid longitude '200'"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/MetricsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/MetricsTests.cs
@@ -30,7 +30,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.EvaluateExpressionAsync("console.timeStamp('test42')");
             var result = await metricsTaskWrapper.Task;
 
-            Assert.AreEqual("test42", result.Title);
+            Assert.That(result.Title, Is.EqualTo("test42"));
             CheckMetrics(result.Metrics);
         }
 
@@ -40,11 +40,11 @@ namespace PuppeteerSharp.Tests.PageTests
 
             foreach (var name in metrics.Keys)
             {
-                Assert.Contains(name, metricsToCheck);
-                Assert.True(metrics[name] >= 0);
+                Assert.That(metricsToCheck, Does.Contain(name));
+                Assert.That(metrics[name], Is.GreaterThanOrEqualTo(0));
                 metricsToCheck.Remove(name);
             }
-            Assert.True(metricsToCheck.Count == 0);
+            Assert.That(metricsToCheck, Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/OfflineModeTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/OfflineModeTests.cs
@@ -19,19 +19,19 @@ namespace PuppeteerSharp.Tests.PageTests
 
             await Page.SetOfflineModeAsync(false);
             var response = await Page.ReloadAsync();
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setOfflineMode", "should emulate navigator.onLine")]
         public async Task ShouldEmulateNavigatorOnLine()
         {
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("window.navigator.onLine"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.navigator.onLine"), Is.True);
 
             await Page.SetOfflineModeAsync(true);
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("window.navigator.onLine"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.navigator.onLine"), Is.False);
 
             await Page.SetOfflineModeAsync(false);
-            Assert.True(await Page.EvaluateExpressionAsync<bool>("window.navigator.onLine"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("window.navigator.onLine"), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/PageBringToFrontTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageBringToFrontTests.cs
@@ -11,16 +11,16 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await using var page = await Context.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual("visible", await page.EvaluateExpressionAsync<string>("document.visibilityState"));
+            Assert.That(await page.EvaluateExpressionAsync<string>("document.visibilityState"), Is.EqualTo("visible"));
 
             await using var newPage = await Context.NewPageAsync();
             await newPage.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual("hidden", await page.EvaluateExpressionAsync<string>("document.visibilityState"));
-            Assert.AreEqual("visible", await newPage.EvaluateExpressionAsync<string>("document.visibilityState"));
+            Assert.That(await page.EvaluateExpressionAsync<string>("document.visibilityState"), Is.EqualTo("hidden"));
+            Assert.That(await newPage.EvaluateExpressionAsync<string>("document.visibilityState"), Is.EqualTo("visible"));
 
             await page.BringToFrontAsync();
-            Assert.AreEqual("visible", await page.EvaluateExpressionAsync<string>("document.visibilityState"));
-            Assert.AreEqual("hidden", await newPage.EvaluateExpressionAsync<string>("document.visibilityState"));
+            Assert.That(await page.EvaluateExpressionAsync<string>("document.visibilityState"), Is.EqualTo("visible"));
+            Assert.That(await newPage.EvaluateExpressionAsync<string>("document.visibilityState"), Is.EqualTo("hidden"));
 
             await newPage.CloseAsync();
         }

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsConsoleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsConsoleTests.cs
@@ -187,6 +187,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await popupTarget.PageAsync();
         }
 
+        [Test]
         public async Task ShouldNotFailForNullArgument()
         {
             var consoleTcs = new TaskCompletionSource<string>();

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsConsoleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsConsoleTests.cs
@@ -187,7 +187,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await popupTarget.PageAsync();
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldNotFailForNullArgument()
         {
             var consoleTcs = new TaskCompletionSource<string>();

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsConsoleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsConsoleTests.cs
@@ -25,13 +25,13 @@ namespace PuppeteerSharp.Tests.PageTests
 
             var obj = new Dictionary<string, object> { { "foo", "bar" } };
 
-            Assert.AreEqual("hello 5 JSHandle@object", message.Text);
-            Assert.AreEqual(ConsoleType.Log, message.Type);
+            Assert.That(message.Text, Is.EqualTo("hello 5 JSHandle@object"));
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Log));
 
-            Assert.AreEqual("hello", await message.Args[0].JsonValueAsync());
-            Assert.AreEqual(5, await message.Args[1].JsonValueAsync<float>());
-            Assert.AreEqual(obj, await message.Args[2].JsonValueAsync<Dictionary<string, object>>());
-            Assert.AreEqual("bar", (await message.Args[2].JsonValueAsync<dynamic>()).foo.ToString());
+            Assert.That(await message.Args[0].JsonValueAsync(), Is.EqualTo("hello"));
+            Assert.That(await message.Args[1].JsonValueAsync<float>(), Is.EqualTo(5));
+            Assert.That(await message.Args[2].JsonValueAsync<Dictionary<string, object>>(), Is.EqualTo(obj));
+            Assert.That((await message.Args[2].JsonValueAsync<dynamic>()).foo.ToString(), Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Console", "should work for different console API calls with logging functions")]
@@ -52,7 +52,9 @@ namespace PuppeteerSharp.Tests.PageTests
               console.log(Promise.resolve('should not wait until resolved!'));
             }");
 
-            Assert.AreEqual(new[]
+            Assert.That(messages
+                .Select(_ => _.Type)
+                .ToArray(), Is.EqualTo(new[]
             {
                 ConsoleType.TimeEnd,
                 ConsoleType.Trace,
@@ -60,23 +62,21 @@ namespace PuppeteerSharp.Tests.PageTests
                 ConsoleType.Warning,
                 ConsoleType.Error,
                 ConsoleType.Log
-            }, messages
-                .Select(_ => _.Type)
-                .ToArray());
+            }));
 
-            StringAssert.Contains("calling console.time", messages[0].Text);
+            Assert.That(messages[0].Text, Does.Contain("calling console.time"));
 
-            Assert.AreEqual(new[]
+            Assert.That(messages
+                .Skip(1)
+                .Select(msg => msg.Text)
+                .ToArray(), Is.EqualTo(new[]
             {
                 "calling console.trace",
                 "calling console.dir",
                 "calling console.warn",
                 "calling console.error",
                 "JSHandle@promise"
-            }, messages
-                .Skip(1)
-                .Select(msg => msg.Text)
-                .ToArray());
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Console", "should not fail for window object")]
@@ -97,7 +97,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 Page.EvaluateExpressionAsync("console.error(window)")
             );
 
-            Assert.AreEqual("JSHandle@object", await consoleTcs.Task);
+            Assert.That(await consoleTcs.Task, Is.EqualTo("JSHandle@object"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Console", "should trigger correct Log")]
@@ -110,15 +110,15 @@ namespace PuppeteerSharp.Tests.PageTests
 
             await Page.EvaluateFunctionAsync("async url => fetch(url).catch(e => {})", TestConstants.EmptyPage);
             var message = await messageTask.Task;
-            StringAssert.Contains("No 'Access-Control-Allow-Origin'", message.Text);
+            Assert.That(message.Text, Does.Contain("No 'Access-Control-Allow-Origin'"));
 
             if (TestConstants.IsChrome)
             {
-                Assert.AreEqual(ConsoleType.Error, message.Type);
+                Assert.That(message.Type, Is.EqualTo(ConsoleType.Error));
             }
             else
             {
-                Assert.AreEqual(ConsoleType.Warning, message.Type);
+                Assert.That(message.Type, Is.EqualTo(ConsoleType.Warning));
             }
         }
 
@@ -134,12 +134,12 @@ namespace PuppeteerSharp.Tests.PageTests
                 Page.SetContentAsync("<script>fetch('http://wat');</script>"));
 
             var args = await consoleTask.Task;
-            StringAssert.Contains("ERR_NAME", args.Message.Text);
-            Assert.AreEqual(ConsoleType.Error, args.Message.Type);
-            Assert.AreEqual(new ConsoleMessageLocation
+            Assert.That(args.Message.Text, Does.Contain("ERR_NAME"));
+            Assert.That(args.Message.Type, Is.EqualTo(ConsoleType.Error));
+            Assert.That(args.Message.Location, Is.EqualTo(new ConsoleMessageLocation
             {
                 URL = "http://wat/",
-            }, args.Message.Location);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Console", "should have location and stack trace for console API calls")]
@@ -154,14 +154,14 @@ namespace PuppeteerSharp.Tests.PageTests
                 Page.GoToAsync(TestConstants.ServerUrl + "/consolelog.html"));
 
             var args = await consoleTask.Task;
-            Assert.AreEqual("yellow", args.Message.Text);
-            Assert.AreEqual(ConsoleType.Log, args.Message.Type);
-            Assert.AreEqual(new ConsoleMessageLocation
+            Assert.That(args.Message.Text, Is.EqualTo("yellow"));
+            Assert.That(args.Message.Type, Is.EqualTo(ConsoleType.Log));
+            Assert.That(args.Message.Location, Is.EqualTo(new ConsoleMessageLocation
             {
                 URL = TestConstants.ServerUrl + "/consolelog.html",
                 LineNumber = 7,
                 ColumnNumber = 14
-            }, args.Message.Location);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Console", "should not throw when there are console messages in detached iframes")]
@@ -204,7 +204,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 Page.EvaluateExpressionAsync("console.debug(null);")
             );
 
-            Assert.AreEqual("JSHandle:null", await consoleTcs.Task);
+            Assert.That(await consoleTcs.Task, Is.EqualTo("JSHandle:null"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsErrorTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsErrorTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var gotoTask = Page.GoToAsync("chrome://crash");
 
             await WaitForError();
-            Assert.AreEqual("Page crashed!", error);
+            Assert.That(error, Is.EqualTo("Page crashed!"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsPageErrorTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsPageErrorTests.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 WaitEvent(Page.Client, "Runtime.exceptionThrown")
             );
 
-            StringAssert.Contains("Fancy", error);
+            Assert.That(error, Does.Contain("Fancy"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsPopupTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsPopupTests.cs
@@ -20,8 +20,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 popupTaskSource.Task,
                 Page.EvaluateExpressionAsync("window.open('about:blank')"));
 
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.True(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
+            Assert.That(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Popup", "should work with noopener")]
@@ -34,8 +34,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 popupTaskSource.Task,
                 Page.EvaluateExpressionAsync("window.open('about:blank', null, 'noopener')"));
 
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.False(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
+            Assert.That(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Popup", "should work with clicking target=_blank and without rel=opener")]
@@ -51,8 +51,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 popupTaskSource.Task,
                 Page.ClickAsync("a"));
 
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.False(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
+            Assert.That(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Popup", "should work with clicking target=_blank and with rel=opener")]
@@ -68,8 +68,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 popupTaskSource.Task,
                 Page.QuerySelectorAsync("a").EvaluateFunctionAsync("a => a.click()"));
 
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.True(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
+            Assert.That(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Popup", "should work with fake-clicking target=_blank and rel=noopener")]
@@ -85,8 +85,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 popupTaskSource.Task,
                 Page.QuerySelectorAsync("a").EvaluateFunctionAsync("a => a.click()"));
 
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.False(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
+            Assert.That(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.Events.Popup", "should work with clicking target=_blank and rel=noopener")]
@@ -102,8 +102,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 popupTaskSource.Task,
                 Page.ClickAsync("a"));
 
-            Assert.False(await Page.EvaluateExpressionAsync<bool>("!!window.opener"));
-            Assert.False(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"));
+            Assert.That(await Page.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
+            Assert.That(await popupTaskSource.Task.Result.EvaluateExpressionAsync<bool>("!!window.opener"), Is.False);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
@@ -32,7 +32,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
             #endregion
 
-            Assert.True(File.Exists(outputFile));
+            Assert.That(File.Exists(outputFile), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("pdf.spec", "Page.pdf", "can print to PDF and save to file")]
@@ -46,7 +46,7 @@ namespace PuppeteerSharp.Tests.PageTests
             }
             await Page.PdfAsync(outputFile);
             fileInfo = new FileInfo(outputFile);
-            Assert.True(new FileInfo(outputFile).Length > 0);
+            Assert.That(new FileInfo(outputFile).Length, Is.GreaterThan(0));
             if (fileInfo.Exists)
             {
                 fileInfo.Delete();
@@ -70,7 +70,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
             // Firefox in Linux might generate and of by one result here.
             // If the difference is less than 2 bytes is good
-            Assert.True(Math.Abs(new FileInfo(outputFile).Length - stream.Length) < 2);
+            Assert.That(Math.Abs(new FileInfo(outputFile).Length - stream.Length), Is.LessThan(2));
         }
 
         [Test, Retry(2), PuppeteerTest("pdf.spec", "Page.pdf", "can print to PDF with accessible")]
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.PdfAsync(outputFile, new PdfOptions { Tagged = false });
             await Page.PdfAsync(accessibleOutputFile, new PdfOptions { Tagged = true });
 
-            Assert.Greater(new FileInfo(accessibleOutputFile).Length, new FileInfo(outputFile).Length);
+            Assert.That(new FileInfo(accessibleOutputFile).Length, Is.GreaterThan(new FileInfo(outputFile).Length));
         }
 
         [Test, Retry(2), PuppeteerTest("pdf.spec", "Page.pdf", "can print to PDF with outline")]
@@ -119,7 +119,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.PdfAsync(outputFile, new PdfOptions { Tagged = false });
             await Page.PdfAsync(outputFileOutlined, new PdfOptions { Tagged = true });
 
-            Assert.Greater(new FileInfo(outputFileOutlined).Length, new FileInfo(outputFile).Length);
+            Assert.That(new FileInfo(outputFileOutlined).Length, Is.GreaterThan(new FileInfo(outputFile).Length));
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
             var serialized = JsonConvert.SerializeObject(pdfOptions);
             var newPdfOptions = JsonConvert.DeserializeObject<PdfOptions>(serialized);
-            Assert.AreEqual(pdfOptions, newPdfOptions);
+            Assert.That(newPdfOptions, Is.EqualTo(pdfOptions));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/RemoveExposedFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/RemoveExposedFunctionTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 await Page.ExposeFunctionAsync("compute", (int a, int b) => a * b);
                 var result = await Page.EvaluateFunctionAsync<int>("async () => compute(9, 4)");
-                Assert.AreEqual(36, result);
+                Assert.That(result, Is.EqualTo(36));
 
                 await Page.RemoveExposedFunctionAsync("compute");
             }

--- a/lib/PuppeteerSharp.Tests/PageTests/SelectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SelectTests.cs
@@ -16,8 +16,8 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             await Page.SelectAsync("select", "blue");
-            Assert.AreEqual(new string[] { "blue" }, await Page.EvaluateExpressionAsync<string[]>("result.onInput"));
-            Assert.AreEqual(new string[] { "blue" }, await Page.EvaluateExpressionAsync<string[]>("result.onChange"));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onInput"), Is.EqualTo(new string[] { "blue" }));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onChange"), Is.EqualTo(new string[] { "blue" }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should select only first option")]
@@ -25,8 +25,8 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             await Page.SelectAsync("select", "blue", "green", "red");
-            Assert.AreEqual(new string[] { "blue" }, await Page.EvaluateExpressionAsync<string[]>("result.onInput"));
-            Assert.AreEqual(new string[] { "blue" }, await Page.EvaluateExpressionAsync<string[]>("result.onChange"));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onInput"), Is.EqualTo(new string[] { "blue" }));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onChange"), Is.EqualTo(new string[] { "blue" }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should not throw when select causes navigation")]
@@ -38,7 +38,7 @@ namespace PuppeteerSharp.Tests.PageTests
               Page.SelectAsync("select", "blue"),
               Page.WaitForNavigationAsync()
             );
-            StringAssert.Contains("empty.html", Page.Url);
+            Assert.That(Page.Url, Does.Contain("empty.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should select multiple options")]
@@ -47,10 +47,8 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             await Page.EvaluateExpressionAsync("makeMultiple()");
             await Page.SelectAsync("select", "blue", "green", "red");
-            Assert.AreEqual(new string[] { "blue", "green", "red" },
-                         await Page.EvaluateExpressionAsync<string[]>("result.onInput"));
-            Assert.AreEqual(new string[] { "blue", "green", "red" },
-                         await Page.EvaluateExpressionAsync<string[]>("result.onChange"));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onInput"), Is.EqualTo(new string[] { "blue", "green", "red" }));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onChange"), Is.EqualTo(new string[] { "blue", "green", "red" }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should respect event bubbling")]
@@ -58,8 +56,8 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             await Page.SelectAsync("select", "blue");
-            Assert.AreEqual(new string[] { "blue" }, await Page.EvaluateExpressionAsync<string[]>("result.onBubblingInput"));
-            Assert.AreEqual(new string[] { "blue" }, await Page.EvaluateExpressionAsync<string[]>("result.onBubblingChange"));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onBubblingInput"), Is.EqualTo(new string[] { "blue" }));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onBubblingChange"), Is.EqualTo(new string[] { "blue" }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should throw when element is not a <select>")]
@@ -67,7 +65,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(async () => await Page.SelectAsync("body", ""));
-            StringAssert.Contains("Element is not a <select> element.", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Element is not a <select> element."));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should return [] on no matched values")]
@@ -75,7 +73,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             var result = await Page.SelectAsync("select", "42", "abc");
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should return an array of matched values")]
@@ -85,7 +83,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.EvaluateExpressionAsync("makeMultiple()");
             var result = await Page.SelectAsync("select", "blue", "black", "magenta");
             Array.Sort(result);
-            Assert.AreEqual(new string[] { "black", "blue", "magenta" }, result);
+            Assert.That(result, Is.EqualTo(new string[] { "black", "blue", "magenta" }));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should return an array of one element when multiple is not set")]
@@ -99,7 +97,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldReturnEmptyArrayOnNoValues()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
-            Assert.IsEmpty(await Page.SelectAsync("select"));
+            Assert.That(await Page.SelectAsync("select"), Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should deselect all options when passed no values for a multiple select")]
@@ -109,8 +107,8 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.EvaluateExpressionAsync("makeMultiple()");
             await Page.SelectAsync("select", "blue", "black", "magenta");
             await Page.SelectAsync("select");
-            Assert.True(await Page.QuerySelectorAsync("select").EvaluateFunctionAsync<bool>(
-                "select => Array.from(select.options).every(option => !option.selected)"));
+            Assert.That(await Page.QuerySelectorAsync("select").EvaluateFunctionAsync<bool>(
+                "select => Array.from(select.options).every(option => !option.selected)"), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.select", "should deselect all options when passed no values for a select without multiple")]
@@ -119,8 +117,8 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
             await Page.SelectAsync("select", "blue", "black", "magenta");
             await Page.SelectAsync("select");
-            Assert.True(await Page.QuerySelectorAsync("select").EvaluateFunctionAsync<bool>(
-                "select => Array.from(select.options).every(option => !option.selected)"));
+            Assert.That(await Page.QuerySelectorAsync("select").EvaluateFunctionAsync<bool>(
+                "select => Array.from(select.options).every(option => !option.selected)"), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/SetBypassCSPTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetBypassCSPTests.cs
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             }).ContinueWith(_ => Task.CompletedTask);
-            Assert.Null(await Page.EvaluateExpressionAsync("window.__injected"));
+            Assert.That(await Page.EvaluateExpressionAsync("window.__injected"), Is.Null);
 
             // By-pass CSP and try one more time.
             await Page.SetBypassCSPAsync(true);
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             });
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("window.__injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setBypassCSP", "should bypass CSP header")]
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             }).ContinueWith(_ => Task.CompletedTask);
-            Assert.Null(await Page.EvaluateExpressionAsync("window.__injected"));
+            Assert.That(await Page.EvaluateExpressionAsync("window.__injected"), Is.Null);
 
             // By-pass CSP and try one more time.
             await Page.SetBypassCSPAsync(true);
@@ -50,7 +50,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             });
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("window.__injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setBypassCSP", "should bypass after cross-process navigation")]
@@ -62,14 +62,14 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             });
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("window.__injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(42));
 
             await Page.GoToAsync(TestConstants.CrossProcessUrl + "/csp.html");
             await Page.AddScriptTagAsync(new AddTagOptions
             {
                 Content = "window.__injected = 42;"
             });
-            Assert.AreEqual(42, await Page.EvaluateExpressionAsync<int>("window.__injected"));
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(42));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setBypassCSP", "should bypass CSP in iframes as well")]
@@ -83,7 +83,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             }).ContinueWith(_ => Task.CompletedTask);
-            Assert.Null(await frame.EvaluateFunctionAsync<int?>("() => window.__injected"));
+            Assert.That(await frame.EvaluateFunctionAsync<int?>("() => window.__injected"), Is.Null);
 
             // By-pass CSP and try one more time.
             await Page.SetBypassCSPAsync(true);
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 Content = "window.__injected = 42;"
             }).ContinueWith(_ => Task.CompletedTask);
-            Assert.AreEqual(42, await frame.EvaluateFunctionAsync<int?>("() => window.__injected"));
+            Assert.That(await frame.EvaluateFunctionAsync<int?>("() => window.__injected"), Is.EqualTo(42));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/SetCacheEnabledTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetCacheEnabledTests.cs
@@ -22,7 +22,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 waitForRequestTask,
                 Page.ReloadAsync());
 
-            Assert.False(string.IsNullOrEmpty(waitForRequestTask.Result));
+            Assert.That(string.IsNullOrEmpty(waitForRequestTask.Result), Is.False);
 
             await Page.SetCacheEnabledAsync(false);
             waitForRequestTask = Server.WaitForRequest<string>("/cached/one-style.html", (request) => request.Headers["if-modified-since"]);
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 waitForRequestTask,
                 Page.ReloadAsync());
 
-            Assert.True(string.IsNullOrEmpty(waitForRequestTask.Result));
+            Assert.That(string.IsNullOrEmpty(waitForRequestTask.Result), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setCacheEnabled", "should stay disabled when toggling request interception on/off")]
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.PageTests
               waitForRequestTask,
               Page.ReloadAsync());
 
-            Assert.True(string.IsNullOrEmpty(waitForRequestTask.Result));
+            Assert.That(string.IsNullOrEmpty(waitForRequestTask.Result), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.SetContentAsync("<div>hello</div>");
             var result = await Page.GetContentAsync();
 
-            Assert.AreEqual(ExpectedOutput, result);
+            Assert.That(result, Is.EqualTo(ExpectedOutput));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should work with doctype")]
@@ -37,7 +37,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.SetContentAsync($"{doctype}<div>hello</div>");
             var result = await Page.GetContentAsync();
 
-            Assert.AreEqual($"{doctype}{ExpectedOutput}", result);
+            Assert.That(result, Is.EqualTo($"{doctype}{ExpectedOutput}"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should work with HTML 4 doctype")]
@@ -49,7 +49,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.SetContentAsync($"{doctype}<div>hello</div>");
             var result = await Page.GetContentAsync();
 
-            Assert.AreEqual($"{doctype}{ExpectedOutput}", result);
+            Assert.That(result, Is.EqualTo($"{doctype}{ExpectedOutput}"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should respect timeout")]
@@ -65,7 +65,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     Timeout = 1
                 }));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should respect default navigation timeout")]
@@ -79,7 +79,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
                 await Page.SetContentAsync($"<img src='{TestConstants.ServerUrl + imgPath}'></img>"));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should await resources to load")]
@@ -93,7 +93,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var contentTask = Page.SetContentAsync($"<img src=\"{TestConstants.ServerUrl + imgPath}\"></img>")
                 .ContinueWith(_ => loaded = true);
             await waitTask;
-            Assert.False(loaded);
+            Assert.That(loaded, Is.False);
             imgResponse.SetResult(true);
             await contentTask;
         }
@@ -111,28 +111,28 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldWorkWithTrickyContent()
         {
             await Page.SetContentAsync("<div>hello world</div>\x7F");
-            Assert.AreEqual("hello world", await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"));
+            Assert.That(await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"), Is.EqualTo("hello world"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should work with accents")]
         public async Task ShouldWorkWithAccents()
         {
             await Page.SetContentAsync("<div>aberración</div>");
-            Assert.AreEqual("aberración", await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"));
+            Assert.That(await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"), Is.EqualTo("aberración"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should work with emojis")]
         public async Task ShouldWorkWithEmojis()
         {
             await Page.SetContentAsync("<div>🐥</div>");
-            Assert.AreEqual("🐥", await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"));
+            Assert.That(await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"), Is.EqualTo("🐥"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setContent", "should work with newline")]
         public async Task ShouldWorkWithNewline()
         {
             await Page.SetContentAsync("<div>\n</div>");
-            Assert.AreEqual("\n", await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"));
+            Assert.That(await Page.QuerySelectorAsync("div").EvaluateFunctionAsync<string>("div => div.textContent"), Is.EqualTo("\n"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/SetJavaScriptEnabledTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetJavaScriptEnabledTests.cs
@@ -18,11 +18,11 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync("data:text/html, <script>var something = 'forbidden'</script>");
 
             var exception = Assert.ThrowsAsync<EvaluationFailedException>(async () => await Page.EvaluateExpressionAsync("something"));
-            StringAssert.Contains("something is not defined", exception.Message);
+            Assert.That(exception.Message, Does.Contain("something is not defined"));
 
             await Page.SetJavaScriptEnabledAsync(true);
             await Page.GoToAsync("data:text/html, <script>var something = 'forbidden'</script>");
-            Assert.AreEqual("forbidden", await Page.EvaluateExpressionAsync<string>("something"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("something"), Is.EqualTo("forbidden"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/SetUserAgentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetUserAgentTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setUserAgent", "should work")]
         public async Task ShouldWork()
         {
-            StringAssert.Contains("Mozilla", await Page.EvaluateFunctionAsync<string>("() => navigator.userAgent"));
+            Assert.That(await Page.EvaluateFunctionAsync<string>("() => navigator.userAgent"), Does.Contain("Mozilla"));
             await Page.SetUserAgentAsync("foobar");
 
             var userAgentTask = Server.WaitForRequest("/empty.html", request => request.Headers["User-Agent"].ToString());
@@ -22,13 +22,13 @@ namespace PuppeteerSharp.Tests.PageTests
                 userAgentTask,
                 Page.GoToAsync(TestConstants.EmptyPage)
             );
-            Assert.AreEqual("foobar", userAgentTask.Result);
+            Assert.That(userAgentTask.Result, Is.EqualTo("foobar"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setUserAgent", "should work for subframes")]
         public async Task ShouldWorkForSubframes()
         {
-            StringAssert.Contains("Mozilla", await Page.EvaluateExpressionAsync<string>("navigator.userAgent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("navigator.userAgent"), Does.Contain("Mozilla"));
             await Page.SetUserAgentAsync("foobar");
             var waitForRequestTask = Server.WaitForRequest<string>("/empty.html", (request) => request.Headers["user-agent"]);
 
@@ -41,9 +41,9 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldSimulateDeviceUserAgent()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/mobile.html");
-            StringAssert.DoesNotContain("iPhone", await Page.EvaluateExpressionAsync<string>("navigator.userAgent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("navigator.userAgent"), Does.Not.Contain("iPhone"));
             await Page.SetUserAgentAsync(TestConstants.IPhone.UserAgent);
-            StringAssert.Contains("iPhone", await Page.EvaluateExpressionAsync<string>("navigator.userAgent"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("navigator.userAgent"), Does.Contain("iPhone"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.setUserAgent", "should work with additional userAgentMetdata")]
@@ -65,11 +65,11 @@ namespace PuppeteerSharp.Tests.PageTests
               requestTask,
               Page.GoToAsync(TestConstants.EmptyPage));
 
-            Assert.False(
+            Assert.That(
               await Page.EvaluateFunctionAsync<bool>(@"() => {
                 return navigator.userAgentData.mobile;
               }")
-            );
+, Is.False);
 
             var uaData = await Page.EvaluateFunctionAsync<Dictionary<string, object>>(@"() => {
                 return navigator.userAgentData.getHighEntropyValues([
@@ -80,11 +80,11 @@ namespace PuppeteerSharp.Tests.PageTests
                 ]);
             }");
 
-            Assert.AreEqual("Mock1", uaData["architecture"]);
-            Assert.AreEqual("Mockbook", uaData["model"]);
-            Assert.AreEqual("MockOS", uaData["platform"]);
-            Assert.AreEqual("3.1", uaData["platformVersion"]);
-            Assert.AreEqual("MockBrowser", await requestTask);
+            Assert.That(uaData["architecture"], Is.EqualTo("Mock1"));
+            Assert.That(uaData["model"], Is.EqualTo("Mockbook"));
+            Assert.That(uaData["platform"], Is.EqualTo("MockOS"));
+            Assert.That(uaData["platformVersion"], Is.EqualTo("3.1"));
+            Assert.That(await requestTask, Is.EqualTo("MockBrowser"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/TitleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/TitleTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldReturnThePageTitle()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/title.html");
-            Assert.AreEqual("Woof-Woof", await Page.GetTitleAsync());
+            Assert.That(await Page.GetTitleAsync(), Is.EqualTo("Woof-Woof"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/UrlTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/UrlTests.cs
@@ -14,9 +14,9 @@ namespace PuppeteerSharp.Tests.PageTests
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.url", "should work")]
         public async Task ShouldWork()
         {
-            Assert.AreEqual(TestConstants.AboutBlank, Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.AboutBlank));
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(TestConstants.EmptyPage, Page.Url);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
@@ -43,8 +43,8 @@ namespace PuppeteerSharp.Tests.PageTests
                 })
             );
 
-            Assert.True(t1 > t2);
-            Assert.True((t1 - t2).TotalMilliseconds >= 400);
+            Assert.That(t1, Is.GreaterThan(t2));
+            Assert.That((t1 - t2).TotalMilliseconds, Is.GreaterThanOrEqualTo(400));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForNetworkIdle", "should respect timeout")]
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
                 await Page.WaitForNetworkIdleAsync(new WaitForNetworkIdleOptions { Timeout = 1 }));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         // This should work on Firefox, this ignore should be temporal
@@ -88,7 +88,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 })
             );
 
-            Assert.True(t2 > t1);
+            Assert.That(t2, Is.GreaterThan(t1));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForNetworkIdle", "should work with no timeout")]

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForRequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForRequestTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     fetch('/digits/3.png');
                 }")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForRequest", "should work with predicate")]
@@ -38,7 +38,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 fetch('/digits/3.png');
             }")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForRequest", "should respect timeout")]
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
                 await Page.WaitForRequestAsync(_ => false, new WaitForOptions(1)));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForRequest", "should respect default timeout")]
@@ -59,7 +59,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
                 await Page.WaitForRequestAsync(_ => false));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForRequest", "should work with no timeout")]
@@ -76,7 +76,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     fetch('/digits/3.png');
                 }, 50)")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForResponseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForResponseTests.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     fetch('/digits/3.png');
                 }")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForResponse", "should work with predicate")]
@@ -43,7 +43,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 fetch('/digits/3.png');
             }")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForResponse", "should work with async predicate")]
@@ -64,7 +64,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 fetch('/digits/3.png');
             }")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForResponse", "should respect timeout")]
@@ -74,7 +74,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
                 await Page.WaitForResponseAsync(_ => false, new WaitForOptions(1)));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForResponse", "should respect default timeout")]
@@ -85,7 +85,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
                 await Page.WaitForResponseAsync(_ => false));
 
-            StringAssert.Contains("Timeout of 1 ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Timeout of 1 ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("page.spec", "Page Page.waitForResponse", "should work with no timeout")]
@@ -102,7 +102,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     fetch('/digits/3.png');
                 }, 50)")
             );
-            Assert.AreEqual(TestConstants.ServerUrl + "/digits/2.png", task.Result.Url);
+            Assert.That(task.Result.Url, Is.EqualTo(TestConstants.ServerUrl + "/digits/2.png"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/PrerenderTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/PrerenderTests.cs
@@ -20,7 +20,7 @@ public class PrerenderTests : PuppeteerPageBaseTest
             link.ClickAsync()
         );
 
-        Assert.AreEqual("target", await Page.EvaluateExpressionAsync<string>("document.body.innerText"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
     }
 
     [Test, Retry(2), PuppeteerTest("prerender.spec", "Prerender", "can navigate to a prerendered page via Puppeteer")]
@@ -33,6 +33,6 @@ public class PrerenderTests : PuppeteerPageBaseTest
 
 
         await Page.GoToAsync(TestConstants.ServerUrl + "/prerender/target.html");
-        Assert.AreEqual("target", await Page.EvaluateExpressionAsync<string>("document.body.innerText"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/ViaFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/ViaFrameTests.cs
@@ -21,9 +21,9 @@ public class ViaFrameTests : PuppeteerPageBaseTest
             link.ClickAsync()
         );
 
-        Assert.AreSame(mainFrame, Page.MainFrame);
-        Assert.AreEqual("target", await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"));
-        Assert.AreSame(mainFrame, Page.MainFrame);
+        Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
+        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
     }
 
     [Test, Retry(2), PuppeteerTest("prerender.spec", "Prerender via frame", "can navigate to a prerendered page via Puppeteer")]
@@ -36,8 +36,8 @@ public class ViaFrameTests : PuppeteerPageBaseTest
 
         var mainFrame = Page.MainFrame;
         await mainFrame.GoToAsync(TestConstants.ServerUrl + "/prerender/target.html");
-        Assert.AreSame(mainFrame, Page.MainFrame);
-        Assert.AreEqual("target", await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"));
-        Assert.AreSame(mainFrame, Page.MainFrame);
+        Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
+        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/WithEmulationTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/WithEmulationTests.cs
@@ -36,7 +36,7 @@ public class WithEmulationTests : PuppeteerPageBaseTest
             ];
         }");
 
-        Assert.AreEqual(300 * result[2], result[0]);
-        Assert.AreEqual(400 * result[2], result[1]);
+        Assert.That(result[0], Is.EqualTo(300 * result[2]));
+        Assert.That(result[1], Is.EqualTo(400 * result[2]));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/WithNetworkRequestsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/WithNetworkRequestsTests.cs
@@ -25,12 +25,12 @@ public class WithNetworkRequestsTests : PuppeteerPageBaseTest
             link.ClickAsync()
         );
 
-        Assert.AreSame(mainFrame, Page.MainFrame);
-        Assert.AreEqual("target", await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"));
-        Assert.AreSame(mainFrame, Page.MainFrame);
+        Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
+        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
 
-        Assert.True(urls.Exists(url => url.Contains("prerender/target.html")));
-        Assert.True(urls.Exists(url => url.Contains("prerender/index.html")));
-        Assert.True(urls.Exists(url => url.Contains("prerender/target.html?fromPrerendered")));
+        Assert.That(urls.Exists(url => url.Contains("prerender/target.html")), Is.True);
+        Assert.That(urls.Exists(url => url.Contains("prerender/index.html")), Is.True);
+        Assert.That(urls.Exists(url => url.Contains("prerender/target.html?fromPrerendered")), Is.True);
     }
 }

--- a/lib/PuppeteerSharp.Tests/PublishSingleFileTests/PublishSingleFileTests.cs
+++ b/lib/PuppeteerSharp.Tests/PublishSingleFileTests/PublishSingleFileTests.cs
@@ -38,9 +38,9 @@ namespace PuppeteerSharp.Tests.SingleFileDeployment
                 process.Kill();
             }
 
-            Assert.True(isExited);
+            Assert.That(isExited, Is.True);
 
-            Assert.True(File.Exists(actualFilePath), $"StdOut: {outputResult}\nStdErr: {errorResult}\n");
+            Assert.That(File.Exists(actualFilePath), Is.True, $"StdOut: {outputResult}\nStdErr: {errorResult}\n");
         }
 
         private static string GetStreamOutput(StreamReader stream)
@@ -74,11 +74,11 @@ namespace PuppeteerSharp.Tests.SingleFileDeployment
 
             var outputResult = GetStreamOutput(process.StandardOutput);
             var errorResult = GetStreamOutput(process.StandardError);
-            Assert.True(process.WaitForExit(20000));
+            Assert.That(process.WaitForExit(20000), Is.True);
 
-            Assert.IsEmpty(errorResult);
+            Assert.That(errorResult, Is.Empty);
 
-            Assert.True(File.Exists(expectedBinaryPath), outputResult);
+            Assert.That(File.Exists(expectedBinaryPath), Is.True, outputResult);
 
             return expectedBinaryPath;
         }

--- a/lib/PuppeteerSharp.Tests/PuppeteerBrowserBaseTest.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerBrowserBaseTest.cs
@@ -1,42 +1,27 @@
-using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace PuppeteerSharp.Tests
 {
-    public class PuppeteerBrowserBaseTest : PuppeteerBaseTest, IDisposable, IAsyncDisposable
+    public class PuppeteerBrowserBaseTest : PuppeteerBaseTest
     {
         protected IBrowser Browser { get; set; }
 
         protected LaunchOptions DefaultOptions { get; set; }
 
         [SetUp]
-        public virtual async Task InitializeAsync()
+        public async Task InitializeAsync()
             => Browser = await Puppeteer.LaunchAsync(
                 DefaultOptions ?? TestConstants.DefaultBrowserOptions(),
                 TestConstants.LoggerFactory);
 
         [TearDown]
-        public virtual async Task DisposeAsync()
+        public async Task TearDownAsync()
         {
             if (Browser is not null)
             {
-                await Browser.CloseAsync();
+                await Browser.DisposeAsync();
             }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing) => _ = DisposeAsync();
-
-        ValueTask IAsyncDisposable.DisposeAsync()
-        {
-            GC.SuppressFinalize(this);
-            return Browser.DisposeAsync();
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -11,8 +11,12 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="NUnit" Version="4.1.0" />
+		<PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.2.0" />

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 		<PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="NUnit" Version="4.1.0" />

--- a/lib/PuppeteerSharp.Tests/QueryHandlerTests/PierceSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/QueryHandlerTests/PierceSelectorTests.cs
@@ -45,7 +45,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests
             var text = await div.EvaluateFunctionAsync<string>(@"(element) => {
                 return element.textContent;
             }");
-            Assert.AreEqual("Hello", text);
+            Assert.That(text, Is.EqualTo("Hello"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Pierce selectors", "should find all elements in shadow")]
@@ -59,7 +59,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests
                         return element.textContent;
                     }");
                 }));
-            Assert.AreEqual("Hello World", string.Join(" ", text));
+            Assert.That(string.Join(" ", text), Is.EqualTo("Hello World"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Pierce selectors", "should find first child element")]
@@ -70,7 +70,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests
             var text = await childElement.EvaluateFunctionAsync<string>(@"(element) => {
                 return element.textContent;
             }");
-            Assert.AreEqual("Hello", text);
+            Assert.That(text, Is.EqualTo("Hello"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Pierce selectors", "should find all child elements")]
@@ -85,7 +85,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests
                         return element.textContent;
                     }");
                 }));
-            Assert.AreEqual("Hello World", string.Join(" ", text));
+            Assert.That(string.Join(" ", text), Is.EqualTo("Hello World"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QueryHandlerTests/TextSelectorTests/TextSelectorInElementHandlesTests.cs
+++ b/lib/PuppeteerSharp.Tests/QueryHandlerTests/TextSelectorTests/TextSelectorInElementHandlesTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         {
             await Page.SetContentAsync("<div class=\"a\"><span>a</span></div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
-            Assert.NotNull(await elementHandle.QuerySelectorAsync("text/a"));
+            Assert.That(await elementHandle.QuerySelectorAsync("text/a"), Is.Not.Null);
             Assert.That(await elementHandle.QuerySelectorAllAsync("text/a"), Has.Exactly(1).Items);
         }
 
@@ -26,8 +26,8 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         {
             await Page.SetContentAsync("<div class=\"a\"></div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
-            Assert.Null(await elementHandle.QuerySelectorAsync("text/a"));
-            Assert.IsEmpty(await elementHandle.QuerySelectorAllAsync("text/a"));
+            Assert.That(await elementHandle.QuerySelectorAsync("text/a"), Is.Null);
+            Assert.That(await elementHandle.QuerySelectorAllAsync("text/a"), Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QueryHandlerTests/TextSelectorTests/TextSelectorInPageTests.cs
+++ b/lib/PuppeteerSharp.Tests/QueryHandlerTests/TextSelectorTests/TextSelectorInPageTests.cs
@@ -17,15 +17,15 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         public async Task ShouldQueryExistingElement()
         {
             await Page.SetContentAsync("<section>test</section>");
-            Assert.NotNull(await Page.QuerySelectorAsync("text/test"));
+            Assert.That(await Page.QuerySelectorAsync("text/test"), Is.Not.Null);
             Assert.That(await Page.QuerySelectorAllAsync("text/test"), Has.Exactly(1).Items);
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should return empty array for non-existing element")]
         public async Task ShouldReturnEmptyArrayForNonExistingElement()
         {
-            Assert.Null(await Page.QuerySelectorAsync("text/test"));
-            Assert.IsEmpty(await Page.QuerySelectorAllAsync("text/test"));
+            Assert.That(await Page.QuerySelectorAsync("text/test"), Is.Null);
+            Assert.That(await Page.QuerySelectorAllAsync("text/test"), Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should return first element")]
@@ -33,14 +33,14 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         {
             await Page.SetContentAsync("<div id=\"1\">a</div><div>a</div>");
             var element = await Page.QuerySelectorAsync("text/a");
-            Assert.AreEqual("1", await element.EvaluateFunctionAsync<string>("element => element.id"));
+            Assert.That(await element.EvaluateFunctionAsync<string>("element => element.id"), Is.EqualTo("1"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should return multiple elements")]
         public async Task ShouldReturnMultipleElements()
         {
             await Page.SetContentAsync("<div>a</div><div>a</div>");
-            Assert.AreEqual(2, (await Page.QuerySelectorAllAsync("text/a")).Length);
+            Assert.That((await Page.QuerySelectorAllAsync("text/a")), Has.Length.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should pierce shadow DOM")]
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
                 document.body.append(div);
             }");
             var element = await Page.QuerySelectorAsync("text/a");
-            Assert.AreEqual("a", await element.EvaluateFunctionAsync<string>("element => element.textContent"));
+            Assert.That(await element.EvaluateFunctionAsync<string>("element => element.textContent"), Is.EqualTo("a"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should query deeply nested text")]
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         {
             await Page.SetContentAsync("<div><div>a</div><div>b</div></div>");
             var element = await Page.QuerySelectorAsync("text/a");
-            Assert.AreEqual("a", await element.EvaluateFunctionAsync<string>("element => element.textContent"));
+            Assert.That(await element.EvaluateFunctionAsync<string>("element => element.textContent"), Is.EqualTo("a"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should query inputs")]
@@ -74,14 +74,14 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         {
             await Page.SetContentAsync("<input value=\"a\">");
             var element = await Page.QuerySelectorAsync("text/a");
-            Assert.AreEqual("a", await element.EvaluateFunctionAsync<string>("element => element.value"));
+            Assert.That(await element.EvaluateFunctionAsync<string>("element => element.value"), Is.EqualTo("a"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should not query radio")]
         public async Task ShouldNotQueryRadio()
         {
             await Page.SetContentAsync("<radio value=\"a\">");
-            Assert.Null(await Page.QuerySelectorAsync("text/a"));
+            Assert.That(await Page.QuerySelectorAsync("text/a"), Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("queryhandler.spec", "Query handler tests Text selectors in Page", "should query text spanning multiple elements")]
@@ -89,7 +89,7 @@ namespace PuppeteerSharp.Tests.QueryHandlerTests.TextSelectorTests
         {
             await Page.SetContentAsync("<div><span>a</span> <span>b</span><div>");
             var element = await Page.QuerySelectorAsync("text/a b");
-            Assert.AreEqual("a b", await element.EvaluateFunctionAsync<string>("element => element.textContent"));
+            Assert.That(await element.EvaluateFunctionAsync<string>("element => element.textContent"), Is.EqualTo("a b"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QueryObjectsTests/QueryObjectsTests.cs
+++ b/lib/PuppeteerSharp.Tests/QueryObjectsTests/QueryObjectsTests.cs
@@ -25,16 +25,15 @@ namespace PuppeteerSharp.Tests.QueryObjectsTests
             }", classHandle);
 
             var objectsHandle = await Page.QueryObjectsAsync(prototypeHandle);
-            Assert.AreEqual(
-                1,
+            Assert.That(
                 await Page.EvaluateFunctionAsync<int>(@"objects => {
                     return objects.length;
-                }", objectsHandle));
+                }", objectsHandle), Is.EqualTo(1));
 
             // Check that instances.
-            Assert.True(await Page.EvaluateFunctionAsync<bool>(@"objects => {
+            Assert.That(await Page.EvaluateFunctionAsync<bool>(@"objects => {
                 return objects[0] === self.customClass;
-            }", objectsHandle));
+            }", objectsHandle), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("queryObjects.spec", "page.queryObjects", "should work for non-trivial page")]
@@ -57,16 +56,15 @@ namespace PuppeteerSharp.Tests.QueryObjectsTests
             }", classHandle);
 
             var objectsHandle = await Page.QueryObjectsAsync(prototypeHandle);
-            Assert.AreEqual(
-                1,
+            Assert.That(
                 await Page.EvaluateFunctionAsync<int>(@"objects => {
                     return objects.length;
-                }", objectsHandle));
+                }", objectsHandle), Is.EqualTo(1));
 
             // Check that instances.
-            Assert.True(await Page.EvaluateFunctionAsync<bool>(@"objects => {
+            Assert.That(await Page.EvaluateFunctionAsync<bool>(@"objects => {
                 return objects[0] === self.customClass;
-            }", objectsHandle));
+            }", objectsHandle), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("queryObjects.spec", "page.queryObjects", "should fail for disposed handles")]
@@ -76,7 +74,7 @@ namespace PuppeteerSharp.Tests.QueryObjectsTests
             await prototypeHandle.DisposeAsync();
             var exception = Assert.ThrowsAsync<PuppeteerException>(()
                 => Page.QueryObjectsAsync(prototypeHandle));
-            Assert.AreEqual("Prototype JSHandle is disposed!", exception!.Message);
+            Assert.That(exception!.Message, Is.EqualTo("Prototype JSHandle is disposed!"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryObjects.spec", "page.queryObjects", "should fail primitive values as prototypes")]
@@ -85,7 +83,7 @@ namespace PuppeteerSharp.Tests.QueryObjectsTests
             var prototypeHandle = await Page.EvaluateExpressionHandleAsync("42");
             var exception = Assert.ThrowsAsync<PuppeteerException>(()
                 => Page.QueryObjectsAsync(prototypeHandle));
-            Assert.AreEqual("Prototype JSHandle must not be referencing primitive value", exception!.Message);
+            Assert.That(exception!.Message, Is.EqualTo("Prototype JSHandle must not be referencing primitive value"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorAllEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorAllEvalTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var tweet = await Page.QuerySelectorAsync(".tweet");
             var content = await tweet.QuerySelectorAllHandleAsync(".like")
                 .EvaluateFunctionAsync<string[]>("nodes => nodes.map(n => n.innerText)");
-            Assert.AreEqual(new[] { "100", "10" }, content);
+            Assert.That(content, Is.EqualTo(new[] { "100", "10" }));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$$eval", "should retrieve content from subtree")]
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var elementHandle = await Page.QuerySelectorAsync("#myId");
             var content = await elementHandle.QuerySelectorAllHandleAsync(".a")
                 .EvaluateFunctionAsync<string[]>("nodes => nodes.map(n => n.innerText)");
-            Assert.AreEqual(new[] { "a1-child-div", "a2-child-div" }, content);
+            Assert.That(content, Is.EqualTo(new[] { "a1-child-div", "a2-child-div" }));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$$eval", "should not throw in case of missing selector")]
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var elementHandle = await Page.QuerySelectorAsync("#myId");
             var nodesLength = await elementHandle.QuerySelectorAllHandleAsync(".a")
                 .EvaluateFunctionAsync<int>("nodes => nodes.length");
-            Assert.AreEqual(0, nodesLength);
+            Assert.That(nodesLength, Is.EqualTo(0));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorAllTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorAllTests.cs
@@ -17,9 +17,9 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.SetContentAsync("<html><body><div>A</div><br/><div>B</div></body></html>");
             var html = await Page.QuerySelectorAsync("html");
             var elements = await html.QuerySelectorAllAsync("div");
-            Assert.AreEqual(2, elements.Length);
+            Assert.That(elements, Has.Length.EqualTo(2));
             var tasks = elements.Select(element => Page.EvaluateFunctionAsync<string>("e => e.textContent", element));
-            Assert.AreEqual(new[] { "A", "B" }, await Task.WhenAll(tasks));
+            Assert.That(await Task.WhenAll(tasks), Is.EqualTo(new[] { "A", "B" }));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$$", "should return empty array for non-existing elements")]
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await Page.SetContentAsync("<html><body><span>A</span><br/><span>B</span></body></html>");
             var html = await Page.QuerySelectorAsync("html");
             var elements = await html.QuerySelectorAllAsync("div");
-            Assert.IsEmpty(elements);
+            Assert.That(elements, Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var tweet = await Page.QuerySelectorAsync(".tweet");
             var content = await tweet.QuerySelectorAsync(".like")
                 .EvaluateFunctionAsync<string>("node => node.innerText");
-            Assert.AreEqual("100", content);
+            Assert.That(content, Is.EqualTo("100"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$eval", "should retrieve content from subtree")]
@@ -39,7 +39,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var elementHandle = await Page.QuerySelectorAsync("#myId");
             var content = await elementHandle.QuerySelectorAsync(".a")
                 .EvaluateFunctionAsync<string>("node => node.innerText");
-            Assert.AreEqual("a-child-div", content);
+            Assert.That(content, Is.EqualTo("a-child-div"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$eval", "should throw in case of missing selector")]
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var exception = Assert.ThrowsAsync<SelectorException>(
                 () => elementHandle.QuerySelectorAsync(".a").EvaluateFunctionAsync<string>("node => node.innerText")
             );
-            Assert.AreEqual("Error: failed to find element matching selector", exception.Message);
+            Assert.That(exception.Message, Is.EqualTo("Error: failed to find element matching selector"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var second = await html.QuerySelectorAsync(".second");
             var inner = await second.QuerySelectorAsync(".inner");
             var content = await Page.EvaluateFunctionAsync<string>("e => e.textContent", inner);
-            Assert.AreEqual("A", content);
+            Assert.That(content, Is.EqualTo("A"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$", "should return null for non-existing element")]
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             await Page.SetContentAsync("<html><body><div class=\"second\"><div class=\"inner\">B</div></div></body></html>");
             var html = await Page.QuerySelectorAsync("html");
             var second = await html.QuerySelectorAsync(".third");
-            Assert.Null(second);
+            Assert.That(second, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$$ xpath", "should query existing element")]
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var second = await html.QuerySelectorAllAsync("xpath/./body/div[contains(@class, 'second')]");
             var inner = await second[0].QuerySelectorAllAsync("xpath/./div[contains(@class, 'inner')]");
             var content = await Page.EvaluateFunctionAsync<string>("e => e.textContent", inner[0]);
-            Assert.AreEqual("A", content);
+            Assert.That(content, Is.EqualTo("A"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "ElementHandle.$$ xpath", "should return null for non-existing element")]
@@ -45,7 +45,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             await Page.SetContentAsync("<html><body><div class=\"second\"><div class=\"inner\">B</div></div></body></html>");
             var html = await Page.QuerySelectorAsync("html");
             var second = await html.QuerySelectorAllAsync("xpath/div[contains(@class, 'third')]");
-            Assert.IsEmpty(second);
+            Assert.That(second, Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllEvalTests.cs
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(sum, Is.EqualTo(500500));
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkWithAwaitedElements()
         {
             await Page.SetContentAsync("<div>hello</div><div>beautiful</div><div>world!</div>");

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllEvalTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.SetContentAsync("<div>hello</div><div>beautiful</div><div>world!</div>");
             var divsCount = await Page.QuerySelectorAllHandleAsync("div").EvaluateFunctionAsync<int>("divs => divs.length");
-            Assert.AreEqual(3, divsCount);
+            Assert.That(divsCount, Is.EqualTo(3));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$$eval", "should accept extra arguments")]
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.PageTests
             var divsCount = await Page
                 .QuerySelectorAllHandleAsync("div")
                 .EvaluateFunctionAsync<int>("(divs, two, three) => divs.length + two + three", 2, 3);
-            Assert.AreEqual(8, divsCount);
+            Assert.That(divsCount, Is.EqualTo(8));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$$eval", "should accept ElementHandles as arguments")]
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Tests.PageTests
                     (acc, section) => acc + Number(section.textContent),
                     0
                 ) + Number(div.textContent)", divHandle);
-            Assert.AreEqual(8, divsCount);
+            Assert.That(divsCount, Is.EqualTo(8));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$$eval", "$$eval should handle many elements")]
@@ -58,7 +58,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 .QuerySelectorAllHandleAsync("section")
                 .EvaluateFunctionAsync<int>(@"(sections, div) =>
                 sections.reduce((acc, section) => acc + Number(section.textContent), 0)");
-            Assert.AreEqual(500500, sum);
+            Assert.That(sum, Is.EqualTo(500500));
         }
 
         public async Task ShouldWorkWithAwaitedElements()
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.SetContentAsync("<div>hello</div><div>beautiful</div><div>world!</div>");
             var divs = await Page.QuerySelectorAllHandleAsync("div");
             var divsCount = await divs.EvaluateFunctionAsync<int>("divs => divs.length");
-            Assert.AreEqual(3, divsCount);
+            Assert.That(divsCount, Is.EqualTo(3));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllEvalTests.cs
@@ -61,6 +61,7 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(sum, Is.EqualTo(500500));
         }
 
+        [Test]
         public async Task ShouldWorkWithAwaitedElements()
         {
             await Page.SetContentAsync("<div>hello</div><div>beautiful</div><div>world!</div>");

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorAllTests.cs
@@ -16,9 +16,9 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.SetContentAsync("<div>A</div><br/><div>B</div>");
             var elements = await Page.QuerySelectorAllAsync("div");
-            Assert.AreEqual(2, elements.Length);
+            Assert.That(elements, Has.Length.EqualTo(2));
             var tasks = elements.Select(element => Page.EvaluateFunctionAsync<string>("e => e.textContent", element));
-            Assert.AreEqual(new[] { "A", "B" }, await Task.WhenAll(tasks));
+            Assert.That(await Task.WhenAll(tasks), Is.EqualTo(new[] { "A", "B" }));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$$", "should return empty array if nothing is found")]
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var elements = await Page.QuerySelectorAllAsync("div");
-            Assert.IsEmpty(elements);
+            Assert.That(elements, Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorEvalTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.SetContentAsync("<section id='testAttribute'>43543</section>");
             var idAttribute = await Page.QuerySelectorAsync("section").EvaluateFunctionAsync<string>("e => e.id");
-            Assert.AreEqual("testAttribute", idAttribute);
+            Assert.That(idAttribute, Is.EqualTo("testAttribute"));
         }
 
         public async Task ShouldWorkWithAwaitedElements()
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             await Page.SetContentAsync("<section id='testAttribute'>43543</section>");
             var section = await Page.QuerySelectorAsync("section");
             var idAttribute = await section.EvaluateFunctionAsync<string>("e => e.id");
-            Assert.AreEqual("testAttribute", idAttribute);
+            Assert.That(idAttribute, Is.EqualTo("testAttribute"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$eval", "should accept arguments")]
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.SetContentAsync("<section>hello</section>");
             var text = await Page.QuerySelectorAsync("section").EvaluateFunctionAsync<string>("(e, suffix) => e.textContent + suffix", " world!");
-            Assert.AreEqual("hello world!", text);
+            Assert.That(text, Is.EqualTo("hello world!"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$eval", "should accept ElementHandles as arguments")]
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             await Page.SetContentAsync("<section>hello</section><div> world</div>");
             var divHandle = await Page.QuerySelectorAsync("div");
             var text = await Page.QuerySelectorAsync("section").EvaluateFunctionAsync<string>("(e, div) => e.textContent + div.textContent", divHandle);
-            Assert.AreEqual("hello world", text);
+            Assert.That(text, Is.EqualTo("hello world"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$eval", "should throw error if no element is found")]
@@ -48,7 +48,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             var exception = Assert.ThrowsAsync<SelectorException>(()
                 => Page.QuerySelectorAsync("section").EvaluateFunctionAsync<string>("e => e.id"));
-            StringAssert.Contains("failed to find element matching selector", exception.Message);
+            Assert.That(exception.Message, Does.Contain("failed to find element matching selector"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorEvalTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             Assert.That(idAttribute, Is.EqualTo("testAttribute"));
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkWithAwaitedElements()
         {
             await Page.SetContentAsync("<section id='testAttribute'>43543</section>");

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorEvalTests.cs
@@ -18,6 +18,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             Assert.That(idAttribute, Is.EqualTo("testAttribute"));
         }
 
+        [Test]
         public async Task ShouldWorkWithAwaitedElements()
         {
             await Page.SetContentAsync("<section id='testAttribute'>43543</section>");

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/PageQuerySelectorTests.cs
@@ -11,14 +11,14 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.SetContentAsync("<section>test</section>");
             var element = await Page.QuerySelectorAsync("section");
-            Assert.NotNull(element);
+            Assert.That(element, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "Page.$", "should return null for non-existing element")]
         public async Task ShouldReturnNullForNonExistingElement()
         {
             var element = await Page.QuerySelectorAsync("non-existing-element");
-            Assert.Null(element);
+            Assert.That(element, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "querySelector Page.$$ xpath", "should query existing element")]
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.SetContentAsync("<section>test</section>");
             var elements = await Page.QuerySelectorAllAsync("xpath/html/body/section");
-            Assert.NotNull(elements[0]);
+            Assert.That(elements[0], Is.Not.Null);
             Assert.That(elements, Has.Exactly(1).Items);
         }
 
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         public async Task ShouldReturnEmptyArrayForNonExistingElement()
         {
             var elements = await Page.QuerySelectorAllAsync("xpath/html/body/non-existing-element");
-            Assert.IsEmpty(elements);
+            Assert.That(elements, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "querySelector Page.$$ xpath", "should return multiple elements")]
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         {
             await Page.SetContentAsync("<div></div><div></div>");
             var elements = await Page.QuerySelectorAllAsync("xpath/html/body/div");
-            Assert.AreEqual(2, elements.Length);
+            Assert.That(elements, Has.Length.EqualTo(2));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/QueryAllTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/QueryAllTests.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "should have registered handler")]
         public void ShouldHaveRegisteredHandler()
         {
-            Assert.Contains("allArray", ((Browser)Browser).GetCustomQueryHandlerNames().ToArray());
+            Assert.That(((Browser)Browser).GetCustomQueryHandlerNames().ToArray(), Does.Contain("allArray"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "$$ should query existing elements")]
@@ -36,11 +36,11 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             await Page.SetContentAsync("<html><body><div>A</div><br/><div>B</div></body></html>");
             var html = await Page.QuerySelectorAsync("html");
             var elements = await html.QuerySelectorAllAsync("allArray/div");
-            Assert.AreEqual(2, elements.Length);
+            Assert.That(elements, Has.Length.EqualTo(2));
             var tasks = elements.Select((element) =>
               Page.EvaluateFunctionAsync<string>("(e) => e.textContent", element)
             );
-            Assert.AreEqual(new[] { "A", "B" }, await Task.WhenAll(tasks));
+            Assert.That(await Task.WhenAll(tasks), Is.EqualTo(new[] { "A", "B" }));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "$$ should return empty array for non-existing elements")]
@@ -49,7 +49,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             await Page.SetContentAsync("<html><body><span>A</span><br/><span>B</span></body></html>");
             var html = await Page.QuerySelectorAsync("html");
             var elements = await html.QuerySelectorAllAsync("allArray/div");
-            Assert.IsEmpty(elements);
+            Assert.That(elements, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "$$eval should work")]
@@ -59,7 +59,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var divsCount = await Page.QuerySelectorAllHandleAsync("allArray/div")
                 .EvaluateFunctionAsync<int>("(divs) => divs.length");
 
-            Assert.AreEqual(3, divsCount);
+            Assert.That(divsCount, Is.EqualTo(3));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "$$eval should accept extra arguments")]
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
             var divsCount = await Page.QuerySelectorAllHandleAsync("allArray/div")
                 .EvaluateFunctionAsync<int>("(divs, two, three) => divs.length + two + three", 2, 3);
 
-            Assert.AreEqual(8, divsCount);
+            Assert.That(divsCount, Is.EqualTo(8));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "$$eval should accept ElementHandles as arguments")]
@@ -83,7 +83,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
                         (acc, section) => acc + Number(section.textContent),
                         0
                     ) + Number(div.textContent)", divHandle);
-            Assert.AreEqual("8", text);
+            Assert.That(text, Is.EqualTo("8"));
         }
 
         [Test, Retry(2), PuppeteerTest("queryselector.spec", "QueryAll", "should handle many elements")]
@@ -101,7 +101,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
                 .QuerySelectorAllHandleAsync("allArray/section")
                 .EvaluateFunctionAsync<int>(@"(sections, div) =>
                 sections.reduce((acc, section) => acc + Number(section.textContent), 0)");
-            Assert.AreEqual(500500, sum);
+            Assert.That(sum, Is.EqualTo(500500));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/PageSetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/PageSetRequestInterceptionTests.cs
@@ -122,9 +122,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             response = await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
         }
 
-        Assert.AreEqual(1, actionResults.Count);
-        Assert.AreEqual(expectedAction, actionResults[0]);
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
+        Assert.That(actionResults, Has.Count.EqualTo(1));
+        Assert.That(actionResults[0], Is.EqualTo(expectedAction));
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception", "should intercept")]
@@ -139,22 +139,22 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
                 return;
             }
 
-            StringAssert.Contains("empty.html", request.Url);
-            Assert.NotNull(request.Headers);
-            Assert.NotNull(request.Headers["user-agent"]);
-            Assert.NotNull(request.Headers["accept"]);
-            Assert.AreEqual(HttpMethod.Get, request.Method);
-            Assert.Null(request.PostData);
-            Assert.True(request.IsNavigationRequest);
-            Assert.AreEqual(ResourceType.Document, request.ResourceType);
-            Assert.AreEqual(Page.MainFrame, request.Frame);
-            Assert.AreEqual(TestConstants.AboutBlank, request.Frame.Url);
+            Assert.That(request.Url, Does.Contain("empty.html"));
+            Assert.That(request.Headers, Is.Not.Null);
+            Assert.That(request.Headers["user-agent"], Is.Not.Null);
+            Assert.That(request.Headers["accept"], Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo(HttpMethod.Get));
+            Assert.That(request.PostData, Is.Null);
+            Assert.That(request.IsNavigationRequest, Is.True);
+            Assert.That(request.ResourceType, Is.EqualTo(ResourceType.Document));
+            Assert.That(request.Frame, Is.EqualTo(Page.MainFrame));
+            Assert.That(request.Frame.Url, Is.EqualTo(TestConstants.AboutBlank));
             await request.ContinueAsync(new Payload(), 0);
         });
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.True(response.Ok);
+        Assert.That(response.Ok, Is.True);
 
-        Assert.AreEqual(TestConstants.Port, response.RemoteAddress.Port);
+        Assert.That(response.RemoteAddress.Port, Is.EqualTo(TestConstants.Port));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -212,7 +212,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             requestTask,
             Page.GoToAsync(TestConstants.ServerUrl + "/empty.html")
         );
-        Assert.True(string.IsNullOrEmpty(requestTask.Result));
+        Assert.That(string.IsNullOrEmpty(requestTask.Result), Is.True);
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -240,8 +240,8 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
 
         await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
         await requestsReadyTcs.Task.WithTimeout();
-        StringAssert.Contains("/one-style.css", requests[1].Url);
-        StringAssert.Contains("/one-style.html", requests[1].Headers["Referer"]);
+        Assert.That(requests[1].Url, Does.Contain("/one-style.css"));
+        Assert.That(requests[1].Headers["Referer"], Does.Contain("/one-style.html"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -256,7 +256,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         await Page.SetRequestInterceptionAsync(true);
         Page.AddRequestInterceptor(request => request.ContinueAsync(new Payload(), 0));
         var response = await Page.ReloadAsync();
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -285,11 +285,11 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         await Page.SetRequestInterceptionAsync(true);
         Page.AddRequestInterceptor(request =>
         {
-            Assert.AreEqual("bar", request.Headers["foo"]);
+            Assert.That(request.Headers["foo"], Is.EqualTo("bar"));
             return request.ContinueAsync(new Payload(), 0);
         });
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.True(response.Ok);
+        Assert.That(response.Ok, Is.True);
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -308,7 +308,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
                 request.send(null);
                 return request.status;
             }");
-        Assert.AreEqual(200, status);
+        Assert.That(status, Is.EqualTo(200));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -319,11 +319,11 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         await Page.SetRequestInterceptionAsync(true);
         Page.AddRequestInterceptor(request =>
         {
-            Assert.AreEqual(TestConstants.EmptyPage, request.Headers["referer"]);
+            Assert.That(request.Headers["referer"], Is.EqualTo(TestConstants.EmptyPage));
             return request.ContinueAsync(new Payload(), 0);
         });
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.True(response.Ok);
+        Assert.That(response.Ok, Is.True);
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception", "should be abortable")]
@@ -344,9 +344,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         var failedRequests = 0;
         Page.RequestFailed += (_, _) => failedRequests++;
         var response = await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
-        Assert.True(response.Ok);
-        Assert.Null(response.Request.FailureText);
-        Assert.AreEqual(1, failedRequests);
+        Assert.That(response.Ok, Is.True);
+        Assert.That(response.Request.FailureText, Is.Null);
+        Assert.That(failedRequests, Is.EqualTo(1));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -361,9 +361,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         var exception = Assert.ThrowsAsync<NavigationException>(
             () => Page.GoToAsync(TestConstants.EmptyPage));
 
-        StringAssert.StartsWith("net::ERR_INTERNET_DISCONNECTED", exception.Message);
-        Assert.NotNull(failedRequest);
-        Assert.AreEqual("net::ERR_INTERNET_DISCONNECTED", failedRequest.FailureText);
+        Assert.That(exception.Message, Does.StartWith("net::ERR_INTERNET_DISCONNECTED"));
+        Assert.That(failedRequest, Is.Not.Null);
+        Assert.That(failedRequest.FailureText, Is.EqualTo("net::ERR_INTERNET_DISCONNECTED"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception", "should send referer")]
@@ -377,7 +377,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             requestTask,
             Page.GoToAsync(TestConstants.ServerUrl + "/grid.html")
         );
-        Assert.AreEqual("http://google.com/", requestTask.Result);
+        Assert.That(requestTask.Result, Is.EqualTo("http://google.com/"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -391,11 +391,11 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
 
         if (TestConstants.IsChrome)
         {
-            StringAssert.Contains("net::ERR_FAILED", exception.Message);
+            Assert.That(exception.Message, Does.Contain("net::ERR_FAILED"));
         }
         else
         {
-            StringAssert.Contains("NS_ERROR_FAILURE", exception.Message);
+            Assert.That(exception.Message, Does.Contain("NS_ERROR_FAILURE"));
         }
     }
 
@@ -416,22 +416,22 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         Server.SetRedirect("/non-existing-page-3.html", "/non-existing-page-4.html");
         Server.SetRedirect("/non-existing-page-4.html", "/empty.html");
         var response = await Page.GoToAsync(TestConstants.ServerUrl + "/non-existing-page.html");
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
-        StringAssert.Contains("empty.html", response.Url);
-        Assert.AreEqual(5, requests.Count);
-        Assert.AreEqual(ResourceType.Document, requests[2].ResourceType);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Url, Does.Contain("empty.html"));
+        Assert.That(requests, Has.Count.EqualTo(5));
+        Assert.That(requests[2].ResourceType, Is.EqualTo(ResourceType.Document));
 
         // Check redirect chain
         var redirectChain = response.Request.RedirectChain;
-        Assert.AreEqual(4, redirectChain.Length);
-        StringAssert.Contains("/non-existing-page.html", redirectChain[0].Url);
-        StringAssert.Contains("/non-existing-page-3.html", redirectChain[2].Url);
+        Assert.That(redirectChain, Has.Length.EqualTo(4));
+        Assert.That(redirectChain[0].Url, Does.Contain("/non-existing-page.html"));
+        Assert.That(redirectChain[2].Url, Does.Contain("/non-existing-page-3.html"));
 
         for (var i = 0; i < redirectChain.Length; ++i)
         {
             var request = redirectChain[i];
-            Assert.True(request.IsNavigationRequest);
-            Assert.AreEqual(request, request.RedirectChain.ElementAt(i));
+            Assert.That(request.IsNavigationRequest, Is.True);
+            Assert.That(request.RedirectChain.ElementAt(i), Is.EqualTo(request));
         }
     }
 
@@ -458,17 +458,17 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             async context => { await context.Response.WriteAsync("body {box-sizing: border-box; }"); });
 
         var response = await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
-        StringAssert.Contains("one-style.html", response.Url);
-        Assert.AreEqual(5, requests.Count);
-        Assert.AreEqual(ResourceType.Document, requests[0].ResourceType);
-        Assert.AreEqual(ResourceType.StyleSheet, requests[1].ResourceType);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Url, Does.Contain("one-style.html"));
+        Assert.That(requests, Has.Count.EqualTo(5));
+        Assert.That(requests[0].ResourceType, Is.EqualTo(ResourceType.Document));
+        Assert.That(requests[1].ResourceType, Is.EqualTo(ResourceType.StyleSheet));
 
         // Check redirect chain
         var redirectChain = requests[1].RedirectChain;
-        Assert.AreEqual(3, redirectChain.Length);
-        StringAssert.Contains("one-style.css", redirectChain[0].Url);
-        StringAssert.Contains("three-style.css", redirectChain[2].Url);
+        Assert.That(redirectChain, Has.Length.EqualTo(3));
+        Assert.That(redirectChain[0].Url, Does.Contain("one-style.css"));
+        Assert.That(redirectChain[2].Url, Does.Contain("three-style.css"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -502,11 +502,11 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
 
         if (TestConstants.IsChrome)
         {
-            StringAssert.Contains("Failed to fetch", result);
+            Assert.That(result, Does.Contain("Failed to fetch"));
         }
         else
         {
-            StringAssert.Contains("NetworkError", result);
+            Assert.That(result, Does.Contain("NetworkError"));
         }
     }
 
@@ -543,7 +543,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
               fetch('/zzz').then(response => response.text()).catch(e => 'FAILED'),
               fetch('/zzz').then(response => response.text()).catch(e => 'FAILED'),
             ])");
-        Assert.AreEqual(new[] { "11", "FAILED", "22" }, results);
+        Assert.That(results, Is.EqualTo(new[] { "11", "FAILED", "22" }));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -560,9 +560,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
 
         var dataURL = "data:text/html,<div>yo</div>";
         var response = await Page.GoToAsync(dataURL);
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         Assert.That(requests, Has.Exactly(1).Items);
-        Assert.AreEqual(dataURL, requests[0].Url);
+        Assert.That(requests[0].Url, Is.EqualTo(dataURL));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -583,9 +583,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         var dataURL = "data:text/html,<div>yo</div>";
         var text = await Page.EvaluateFunctionAsync<string>("url => fetch(url).then(r => r.text())", dataURL);
 
-        Assert.AreEqual("<div>yo</div>", text);
+        Assert.That(text, Is.EqualTo("<div>yo</div>"));
         Assert.That(requests, Has.Exactly(1).Items);
-        Assert.AreEqual(dataURL, requests[0].Url);
+        Assert.That(requests[0].Url, Is.EqualTo(dataURL));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -600,10 +600,10 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             return request.ContinueAsync(new Payload(), 0);
         });
         var response = await Page.GoToAsync(TestConstants.EmptyPage + "#hash");
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
-        Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
         Assert.That(requests, Has.Exactly(1).Items);
-        Assert.AreEqual(TestConstants.EmptyPage, requests[0].Url);
+        Assert.That(requests[0].Url, Is.EqualTo(TestConstants.EmptyPage));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -615,7 +615,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         await Page.SetRequestInterceptionAsync(true);
         Page.AddRequestInterceptor(request => request.ContinueAsync(new Payload(), 0));
         var response = await Page.GoToAsync(TestConstants.ServerUrl + "/some nonexisting page");
-        Assert.AreEqual(HttpStatusCode.NotFound, response.Status);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.NotFound));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -626,7 +626,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         Server.SetRoute("/malformed?rnd=%911", _ => Task.CompletedTask);
         Page.AddRequestInterceptor(request => request.ContinueAsync(new Payload(), 0));
         var response = await Page.GoToAsync(TestConstants.ServerUrl + "/malformed?rnd=%911");
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -645,9 +645,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         var response =
             await Page.GoToAsync(
                 $"data:text/html,<link rel=\"stylesheet\" href=\"{TestConstants.ServerUrl}/fonts?helvetica|arial\"/>");
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
-        Assert.AreEqual(2, requests.Count);
-        Assert.AreEqual(HttpStatusCode.NotFound, requests[1].Response.Status);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(requests, Has.Count.EqualTo(2));
+        Assert.That(requests[1].Response.Status, Is.EqualTo(HttpStatusCode.NotFound));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -690,7 +690,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             }
         });
         await Page.GoToAsync(TestConstants.EmptyPage);
-        StringAssert.Contains("Request Interception is not enabled", exception.Message);
+        Assert.That(exception.Message, Does.Contain("Request Interception is not enabled"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -707,9 +707,9 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
 
         var uri = new Uri(Path.Combine(Directory.GetCurrentDirectory(), "Assets", "one-style.html")).AbsoluteUri;
         await Page.GoToAsync(uri);
-        Assert.AreEqual(2, urls.Count);
-        Assert.Contains("one-style.html", urls);
-        Assert.Contains("one-style.css", urls);
+        Assert.That(urls, Has.Count.EqualTo(2));
+        Assert.That(urls, Does.Contain("one-style.html"));
+        Assert.That(urls, Does.Contain("one-style.css"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",
@@ -725,7 +725,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
         Page.RequestServedFromCache += (_, e) => cached.Add(e.Request);
 
         await Page.ReloadAsync();
-        Assert.IsEmpty(cached);
+        Assert.That(cached, Is.Empty);
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Page.setRequestInterception",

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestContinueTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestContinueTests.cs
@@ -33,7 +33,7 @@ public class RequestContinueTests : PuppeteerPageBaseTest
             requestTask,
             Page.EvaluateExpressionAsync("fetch('/sleep.zzz')")
         );
-        Assert.AreEqual("bar", requestTask.Result);
+        Assert.That(requestTask.Result, Is.EqualTo("bar"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.continue",
@@ -51,8 +51,8 @@ public class RequestContinueTests : PuppeteerPageBaseTest
         string consoleMessage = null;
         Page.Console += (_, e) => consoleMessage = e.Message.Text;
         await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.AreEqual(TestConstants.EmptyPage, Page.Url);
-        Assert.AreEqual("yellow", consoleMessage);
+        Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
+        Assert.That(consoleMessage, Is.EqualTo("yellow"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.continue", "should amend method")]
@@ -69,7 +69,7 @@ public class RequestContinueTests : PuppeteerPageBaseTest
             Page.EvaluateExpressionAsync("fetch('/sleep.zzz')")
         );
 
-        Assert.AreEqual("POST", requestTask.Result);
+        Assert.That(requestTask.Result, Is.EqualTo("POST"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.continue", "should amend post data")]
@@ -88,7 +88,7 @@ public class RequestContinueTests : PuppeteerPageBaseTest
             Page.GoToAsync(TestConstants.ServerUrl + "/sleep.zzz")
         );
 
-        Assert.AreEqual("doggo", await requestTask.Result);
+        Assert.That(await requestTask.Result, Is.EqualTo("doggo"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.continue",
@@ -115,7 +115,7 @@ public class RequestContinueTests : PuppeteerPageBaseTest
             Page.GoToAsync(TestConstants.EmptyPage)
         );
         var serverRequest = await serverRequestTask;
-        Assert.AreEqual(HttpMethod.Post.Method, serverRequest.Result.Method);
-        Assert.AreEqual("doggo", serverRequest.Result.Body);
+        Assert.That(serverRequest.Result.Method, Is.EqualTo(HttpMethod.Post.Method));
+        Assert.That(serverRequest.Result.Body, Is.EqualTo("doggo"));
     }
 }

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestRespondTests.cs
@@ -21,9 +21,9 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         }, 0));
 
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.AreEqual(HttpStatusCode.Created, response.Status);
-        Assert.AreEqual("bar", response.Headers["foo"]);
-        Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.Created));
+        Assert.That(response.Headers["foo"], Is.EqualTo("bar"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
     }
 
     /// <summary>
@@ -42,9 +42,9 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         }, 0));
 
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.AreEqual(HttpStatusCode.UpgradeRequired, response.Status);
-        Assert.AreEqual("Upgrade Required", response.StatusText);
-        Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.UpgradeRequired));
+        Assert.That(response.StatusText, Is.EqualTo("Upgrade Required"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.respond", "should redirect")]
@@ -69,8 +69,8 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         var response = await Page.GoToAsync(TestConstants.ServerUrl + "/rrredirect");
 
         Assert.That(response.Request.RedirectChain, Has.Exactly(1).Items);
-        Assert.AreEqual(TestConstants.ServerUrl + "/rrredirect", response.Request.RedirectChain[0].Url);
-        Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+        Assert.That(response.Request.RedirectChain[0].Url, Is.EqualTo(TestConstants.ServerUrl + "/rrredirect"));
+        Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.respond", "should allow mocking binary responses")]
@@ -91,7 +91,7 @@ public class RequestRespondTests : PuppeteerPageBaseTest
                 return new Promise(fulfill => img.onload = fulfill);
             }", TestConstants.ServerUrl);
         var img = await Page.QuerySelectorAsync("img");
-        Assert.True(ScreenshotHelper.PixelMatch("mock-binary-response.png", await img.ScreenshotDataAsync()));
+        Assert.That(ScreenshotHelper.PixelMatch("mock-binary-response.png", await img.ScreenshotDataAsync()), Is.True);
     }
 
     [Test, Retry(2), PuppeteerTest("requestinterception-experimental.spec", "Request.respond",
@@ -107,9 +107,9 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         }, 0));
 
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
-        Assert.AreEqual("True", response.Headers["foo"]);
-        Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Headers["foo"], Is.EqualTo("True"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
     }
 
     public async Task ShouldAllowMultipleInterceptedRequestResponseHeaders()
@@ -132,12 +132,12 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         var response = await Page.GoToAsync(TestConstants.EmptyPage);
         var cookies = await Page.GetCookiesAsync(TestConstants.EmptyPage);
 
-        Assert.AreEqual(HttpStatusCode.OK, response.Status);
-        Assert.AreEqual("True\nFalse", response.Headers["foo"]);
-        Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
-        Assert.AreEqual("specialId", cookies[0].Name);
-        Assert.AreEqual("123456", cookies[0].Value);
-        Assert.AreEqual("sessionId", cookies[1].Name);
-        Assert.AreEqual("abcdef", cookies[1].Value);
+        Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Headers["foo"], Is.EqualTo("True\nFalse"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
+        Assert.That(cookies[0].Name, Is.EqualTo("specialId"));
+        Assert.That(cookies[0].Value, Is.EqualTo("123456"));
+        Assert.That(cookies[1].Name, Is.EqualTo("sessionId"));
+        Assert.That(cookies[1].Value, Is.EqualTo("abcdef"));
     }
 }

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestRespondTests.cs
@@ -112,6 +112,7 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
     }
 
+    [Test]
     public async Task ShouldAllowMultipleInterceptedRequestResponseHeaders()
     {
         await Page.SetRequestInterceptionAsync(true);

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/RequestRespondTests.cs
@@ -112,7 +112,7 @@ public class RequestRespondTests : PuppeteerPageBaseTest
         Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
     }
 
-    [Test]
+    [Test, Ignore("previously not marked as a test")]
     public async Task ShouldAllowMultipleInterceptedRequestResponseHeaders()
     {
         await Page.SetRequestInterceptionAsync(true);

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestContinueTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestContinueTests.cs
@@ -45,7 +45,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 requestTask,
                 Page.EvaluateExpressionAsync("fetch('/sleep.zzz')")
             );
-            Assert.AreEqual("bar", requestTask.Result);
+            Assert.That(requestTask.Result, Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.continue", "should redirect in a way non-observable to page")]
@@ -62,8 +62,8 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             string consoleMessage = null;
             Page.Console += (_, e) => consoleMessage = e.Message.Text;
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(TestConstants.EmptyPage, Page.Url);
-            Assert.AreEqual("yellow", consoleMessage);
+            Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
+            Assert.That(consoleMessage, Is.EqualTo("yellow"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.continue", "should amend method")]
@@ -83,7 +83,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 Page.EvaluateExpressionAsync("fetch('/sleep.zzz')")
             );
 
-            Assert.AreEqual("POST", requestTask.Result);
+            Assert.That(requestTask.Result, Is.EqualTo("POST"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.continue", "should amend post data")]
@@ -111,7 +111,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 Page.GoToAsync(TestConstants.ServerUrl + "/sleep.zzz")
             );
 
-            Assert.AreEqual("doggo", await requestTask.Result);
+            Assert.That(await requestTask.Result, Is.EqualTo("doggo"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.continue", "should amend both post data and method on navigation")]
@@ -135,8 +135,8 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 Page.GoToAsync(TestConstants.EmptyPage)
             );
             var serverRequest = await serverRequestTask;
-            Assert.AreEqual(HttpMethod.Post.Method, serverRequest.Result.Method);
-            Assert.AreEqual("doggo", serverRequest.Result.Body);
+            Assert.That(serverRequest.Result.Method, Is.EqualTo(HttpMethod.Post.Method));
+            Assert.That(serverRequest.Result.Body, Is.EqualTo("doggo"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
@@ -31,9 +31,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             };
 
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.Created, response.Status);
-            Assert.AreEqual("bar", response.Headers["foo"]);
-            Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.Created));
+            Assert.That(response.Headers["foo"], Is.EqualTo("bar"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
         }
 
         /// <summary>
@@ -55,9 +55,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             };
 
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.UpgradeRequired, response.Status);
-            Assert.AreEqual("Upgrade Required", response.StatusText);
-            Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.UpgradeRequired));
+            Assert.That(response.StatusText, Is.EqualTo("Upgrade Required"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.respond", "should redirect")]
@@ -86,8 +86,8 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/rrredirect");
 
             Assert.That(response.Request.RedirectChain, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.ServerUrl + "/rrredirect", response.Request.RedirectChain[0].Url);
-            Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+            Assert.That(response.Request.RedirectChain[0].Url, Is.EqualTo(TestConstants.ServerUrl + "/rrredirect"));
+            Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.respond", "should allow mocking binary responses")]
@@ -112,7 +112,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 return new Promise(fulfill => img.onload = fulfill);
             }", TestConstants.ServerUrl);
             var img = await Page.QuerySelectorAsync("img");
-            Assert.True(ScreenshotHelper.PixelMatch("mock-binary-response.png", await img.ScreenshotDataAsync()));
+            Assert.That(ScreenshotHelper.PixelMatch("mock-binary-response.png", await img.ScreenshotDataAsync()), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Request.respond", "should stringify intercepted request response headers")]
@@ -133,9 +133,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             };
 
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreEqual("True", response.Headers["foo"]);
-            Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Headers["foo"], Is.EqualTo("True"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
         }
 
         public async Task ShouldAllowMultipleInterceptedRequestResponseHeaders()
@@ -158,13 +158,13 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
             var cookies = await Page.GetCookiesAsync(TestConstants.EmptyPage);
 
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreEqual("True\nFalse", response.Headers["foo"]);
-            Assert.AreEqual("Yo, page!", await Page.EvaluateExpressionAsync<string>("document.body.textContent"));
-            Assert.AreEqual("specialId", cookies[0].Name);
-            Assert.AreEqual("123456", cookies[0].Value);
-            Assert.AreEqual("sessionId", cookies[1].Name);
-            Assert.AreEqual("abcdef", cookies[1].Value);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Headers["foo"], Is.EqualTo("True\nFalse"));
+            Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
+            Assert.That(cookies[0].Name, Is.EqualTo("specialId"));
+            Assert.That(cookies[0].Value, Is.EqualTo("123456"));
+            Assert.That(cookies[1].Name, Is.EqualTo("sessionId"));
+            Assert.That(cookies[1].Value, Is.EqualTo("abcdef"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
@@ -138,6 +138,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
         }
 
+        [Test]
         public async Task ShouldAllowMultipleInterceptedRequestResponseHeaders()
         {
             await Page.SetRequestInterceptionAsync(true);

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
@@ -138,7 +138,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.textContent"), Is.EqualTo("Yo, page!"));
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldAllowMultipleInterceptedRequestResponseHeaders()
         {
             await Page.SetRequestInterceptionAsync(true);

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
@@ -25,22 +25,22 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                     await e.Request.ContinueAsync();
                     return;
                 }
-                StringAssert.Contains("empty.html", e.Request.Url);
-                Assert.NotNull(e.Request.Headers);
-                Assert.NotNull(e.Request.Headers["user-agent"]);
-                Assert.NotNull(e.Request.Headers["accept"]);
-                Assert.AreEqual(HttpMethod.Get, e.Request.Method);
-                Assert.Null(e.Request.PostData);
-                Assert.True(e.Request.IsNavigationRequest);
-                Assert.AreEqual(ResourceType.Document, e.Request.ResourceType);
-                Assert.AreEqual(Page.MainFrame, e.Request.Frame);
-                Assert.AreEqual(TestConstants.AboutBlank, e.Request.Frame.Url);
+                Assert.That(e.Request.Url, Does.Contain("empty.html"));
+                Assert.That(e.Request.Headers, Is.Not.Null);
+                Assert.That(e.Request.Headers["user-agent"], Is.Not.Null);
+                Assert.That(e.Request.Headers["accept"], Is.Not.Null);
+                Assert.That(e.Request.Method, Is.EqualTo(HttpMethod.Get));
+                Assert.That(e.Request.PostData, Is.Null);
+                Assert.That(e.Request.IsNavigationRequest, Is.True);
+                Assert.That(e.Request.ResourceType, Is.EqualTo(ResourceType.Document));
+                Assert.That(e.Request.Frame, Is.EqualTo(Page.MainFrame));
+                Assert.That(e.Request.Frame.Url, Is.EqualTo(TestConstants.AboutBlank));
                 await e.Request.ContinueAsync();
             };
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.True(response.Ok);
+            Assert.That(response.Ok, Is.True);
 
-            Assert.AreEqual(TestConstants.Port, response.RemoteAddress.Port);
+            Assert.That(response.RemoteAddress.Port, Is.EqualTo(TestConstants.Port));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work when POST is redirected with 302")]
@@ -95,7 +95,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 requestTask,
                 Page.GoToAsync(TestConstants.ServerUrl + "/empty.html")
             );
-            Assert.True(string.IsNullOrEmpty(requestTask.Result));
+            Assert.That(string.IsNullOrEmpty(requestTask.Result), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should contain referer header")]
@@ -121,8 +121,8 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
             await requestsReadyTcs.Task.WithTimeout();
-            StringAssert.Contains("/one-style.css", requests[1].Url);
-            StringAssert.Contains("/one-style.html", requests[1].Headers["Referer"]);
+            Assert.That(requests[1].Url, Does.Contain("/one-style.css"));
+            Assert.That(requests[1].Headers["Referer"], Does.Contain("/one-style.html"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should properly return navigation response when URL has cookies")]
@@ -140,7 +140,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             await Page.SetRequestInterceptionAsync(true);
             Page.Request += (sender, e) => _ = e.Request.ContinueAsync();
             var response = await Page.ReloadAsync();
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should stop intercepting")]
@@ -168,11 +168,11 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             await Page.SetRequestInterceptionAsync(true);
             Page.Request += async (_, e) =>
             {
-                Assert.AreEqual("bar", e.Request.Headers["foo"]);
+                Assert.That(e.Request.Headers["foo"], Is.EqualTo("bar"));
                 await e.Request.ContinueAsync();
             };
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.True(response.Ok);
+            Assert.That(response.Ok, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work with redirect inside sync XHR")]
@@ -190,7 +190,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 request.send(null);
                 return request.status;
             }");
-            Assert.AreEqual(200, status);
+            Assert.That(status, Is.EqualTo(200));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work with custom referer headers")]
@@ -203,11 +203,11 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             await Page.SetRequestInterceptionAsync(true);
             Page.Request += async (_, e) =>
             {
-                Assert.AreEqual(TestConstants.EmptyPage, e.Request.Headers["referer"]);
+                Assert.That(e.Request.Headers["referer"], Is.EqualTo(TestConstants.EmptyPage));
                 await e.Request.ContinueAsync();
             };
             var response = await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.True(response.Ok);
+            Assert.That(response.Ok, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should be abortable")]
@@ -228,9 +228,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             var failedRequests = 0;
             Page.RequestFailed += (_, _) => failedRequests++;
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
-            Assert.True(response.Ok);
-            Assert.Null(response.Request.FailureText);
-            Assert.AreEqual(1, failedRequests);
+            Assert.That(response.Ok, Is.True);
+            Assert.That(response.Request.FailureText, Is.Null);
+            Assert.That(failedRequests, Is.EqualTo(1));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should be abortable with custom error codes")]
@@ -247,9 +247,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             var exception = Assert.ThrowsAsync<NavigationException>(
                 () => Page.GoToAsync(TestConstants.EmptyPage));
 
-            StringAssert.StartsWith("net::ERR_INTERNET_DISCONNECTED", exception.Message);
-            Assert.NotNull(failedRequest);
-            Assert.AreEqual("net::ERR_INTERNET_DISCONNECTED", failedRequest.FailureText);
+            Assert.That(exception.Message, Does.StartWith("net::ERR_INTERNET_DISCONNECTED"));
+            Assert.That(failedRequest, Is.Not.Null);
+            Assert.That(failedRequest.FailureText, Is.EqualTo("net::ERR_INTERNET_DISCONNECTED"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should send referer")]
@@ -266,7 +266,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 requestTask,
                 Page.GoToAsync(TestConstants.ServerUrl + "/grid.html")
             );
-            Assert.AreEqual("http://google.com/", requestTask.Result);
+            Assert.That(requestTask.Result, Is.EqualTo("http://google.com/"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should fail navigation when aborting main resource")]
@@ -279,11 +279,11 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("net::ERR_FAILED", exception.Message);
+                Assert.That(exception.Message, Does.Contain("net::ERR_FAILED"));
             }
             else
             {
-                StringAssert.Contains("NS_ERROR_FAILURE", exception.Message);
+                Assert.That(exception.Message, Does.Contain("NS_ERROR_FAILURE"));
             }
         }
 
@@ -303,22 +303,22 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Server.SetRedirect("/non-existing-page-3.html", "/non-existing-page-4.html");
             Server.SetRedirect("/non-existing-page-4.html", "/empty.html");
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/non-existing-page.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            StringAssert.Contains("empty.html", response.Url);
-            Assert.AreEqual(5, requests.Count);
-            Assert.AreEqual(ResourceType.Document, requests[2].ResourceType);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Does.Contain("empty.html"));
+            Assert.That(requests, Has.Count.EqualTo(5));
+            Assert.That(requests[2].ResourceType, Is.EqualTo(ResourceType.Document));
 
             // Check redirect chain
             var redirectChain = response.Request.RedirectChain;
-            Assert.AreEqual(4, redirectChain.Length);
-            StringAssert.Contains("/non-existing-page.html", redirectChain[0].Url);
-            StringAssert.Contains("/non-existing-page-3.html", redirectChain[2].Url);
+            Assert.That(redirectChain, Has.Length.EqualTo(4));
+            Assert.That(redirectChain[0].Url, Does.Contain("/non-existing-page.html"));
+            Assert.That(redirectChain[2].Url, Does.Contain("/non-existing-page-3.html"));
 
             for (var i = 0; i < redirectChain.Length; ++i)
             {
                 var request = redirectChain[i];
-                Assert.True(request.IsNavigationRequest);
-                Assert.AreEqual(request, request.RedirectChain.ElementAt(i));
+                Assert.That(request.IsNavigationRequest, Is.True);
+                Assert.That(request.RedirectChain.ElementAt(i), Is.EqualTo(request));
             }
         }
 
@@ -346,17 +346,17 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             });
 
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            StringAssert.Contains("one-style.html", response.Url);
-            Assert.AreEqual(5, requests.Count);
-            Assert.AreEqual(ResourceType.Document, requests[0].ResourceType);
-            Assert.AreEqual(ResourceType.StyleSheet, requests[1].ResourceType);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Does.Contain("one-style.html"));
+            Assert.That(requests, Has.Count.EqualTo(5));
+            Assert.That(requests[0].ResourceType, Is.EqualTo(ResourceType.Document));
+            Assert.That(requests[1].ResourceType, Is.EqualTo(ResourceType.StyleSheet));
 
             // Check redirect chain
             var redirectChain = requests[1].RedirectChain;
-            Assert.AreEqual(3, redirectChain.Length);
-            StringAssert.Contains("one-style.css", redirectChain[0].Url);
-            StringAssert.Contains("three-style.css", redirectChain[2].Url);
+            Assert.That(redirectChain, Has.Length.EqualTo(3));
+            Assert.That(redirectChain[0].Url, Does.Contain("one-style.css"));
+            Assert.That(redirectChain[2].Url, Does.Contain("three-style.css"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should be able to abort redirects")]
@@ -390,11 +390,11 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
 
             if (TestConstants.IsChrome)
             {
-                StringAssert.Contains("Failed to fetch", result);
+                Assert.That(result, Does.Contain("Failed to fetch"));
             }
             else
             {
-                StringAssert.Contains("NetworkError", result);
+                Assert.That(result, Does.Contain("NetworkError"));
             }
         }
 
@@ -432,7 +432,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
               fetch('/zzz').then(response => response.text()).catch(e => 'FAILED'),
               fetch('/zzz').then(response => response.text()).catch(e => 'FAILED'),
             ])");
-            Assert.AreEqual(new[] { "11", "FAILED", "22" }, results);
+            Assert.That(results, Is.EqualTo(new[] { "11", "FAILED", "22" }));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should navigate to dataURL and fire dataURL requests")]
@@ -447,9 +447,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             };
             var dataURL = "data:text/html,<div>yo</div>";
             var response = await Page.GoToAsync(dataURL);
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(dataURL, requests[0].Url);
+            Assert.That(requests[0].Url, Is.EqualTo(dataURL));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should be able to fetch dataURL and fire dataURL requests")]
@@ -469,9 +469,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             var dataURL = "data:text/html,<div>yo</div>";
             var text = await Page.EvaluateFunctionAsync<string>("url => fetch(url).then(r => r.text())", dataURL);
 
-            Assert.AreEqual("<div>yo</div>", text);
+            Assert.That(text, Is.EqualTo("<div>yo</div>"));
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(dataURL, requests[0].Url);
+            Assert.That(requests[0].Url, Is.EqualTo(dataURL));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should navigate to URL with hash and fire requests without hash")]
@@ -485,10 +485,10 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 await e.Request.ContinueAsync();
             };
             var response = await Page.GoToAsync(TestConstants.EmptyPage + "#hash");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreEqual(TestConstants.EmptyPage, response.Url);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.Url, Is.EqualTo(TestConstants.EmptyPage));
             Assert.That(requests, Has.Exactly(1).Items);
-            Assert.AreEqual(TestConstants.EmptyPage, requests[0].Url);
+            Assert.That(requests[0].Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work with encoded server")]
@@ -499,7 +499,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             await Page.SetRequestInterceptionAsync(true);
             Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/some nonexisting page");
-            Assert.AreEqual(HttpStatusCode.NotFound, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work with badly encoded server")]
@@ -509,7 +509,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Server.SetRoute("/malformed?rnd=%911", _ => Task.CompletedTask);
             Page.Request += async (_, e) => await e.Request.ContinueAsync();
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/malformed?rnd=%911");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work with encoded server - 2")]
@@ -525,9 +525,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 await e.Request.ContinueAsync();
             };
             var response = await Page.GoToAsync($"data:text/html,<link rel=\"stylesheet\" href=\"{TestConstants.ServerUrl}/fonts?helvetica|arial\"/>");
-            Assert.AreEqual(HttpStatusCode.OK, response.Status);
-            Assert.AreEqual(2, requests.Count);
-            Assert.AreEqual(HttpStatusCode.NotFound, requests[1].Response.Status);
+            Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(requests, Has.Count.EqualTo(2));
+            Assert.That(requests[1].Response.Status, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should not throw \"Invalid Interception Id\" if the request was cancelled")]
@@ -567,7 +567,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 }
             };
             await Page.GoToAsync(TestConstants.EmptyPage);
-            StringAssert.Contains("Request Interception is not enabled", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Request Interception is not enabled"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should work with file URLs")]
@@ -583,9 +583,9 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
 
             var uri = new Uri(Path.Combine(Directory.GetCurrentDirectory(), "Assets", "one-style.html")).AbsoluteUri;
             await Page.GoToAsync(uri);
-            Assert.AreEqual(2, urls.Count);
-            Assert.Contains("one-style.html", urls);
-            Assert.Contains("one-style.css", urls);
+            Assert.That(urls, Has.Count.EqualTo(2));
+            Assert.That(urls, Does.Contain("one-style.html"));
+            Assert.That(urls, Does.Contain("one-style.css"));
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should not cache if cache disabled")]
@@ -601,7 +601,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Page.RequestServedFromCache += (_, e) => cached.Add(e.Request);
 
             await Page.ReloadAsync();
-            Assert.IsEmpty(cached);
+            Assert.That(cached, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("requestinterception.spec", "Page.setRequestInterception", "should cache if cache enabled")]

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await Page.EvaluateExpressionAsync("window.scrollBy(50, 100)");
             var elementHandle = await Page.QuerySelectorAsync(".box:nth-of-type(3)");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-bounding-box.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-bounding-box.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should take into account padding and border")]
@@ -45,7 +45,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             ");
             var elementHandle = await Page.QuerySelectorAsync("div");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-padding-border.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-padding-border.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should capture full element when larger than viewport")]
@@ -73,9 +73,9 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             );
             var elementHandle = await Page.QuerySelectorAsync("div.to-screenshot");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-larger-than-viewport.png", screenshot));
-            Assert.AreEqual(JToken.FromObject(new { w = 500, h = 500 }),
-                await Page.EvaluateExpressionAsync("({ w: window.innerWidth, h: window.innerHeight })"));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-larger-than-viewport.png", screenshot), Is.True);
+            Assert.That(await Page.EvaluateExpressionAsync("({ w: window.innerWidth, h: window.innerHeight })"),
+                Is.EqualTo(JToken.FromObject(new { w = 500, h = 500 })));
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should scroll element into view")]
@@ -105,7 +105,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             ");
             var elementHandle = await Page.QuerySelectorAsync("div.to-screenshot");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-scrolled-into-view.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-scrolled-into-view.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should work with a rotated element")]
@@ -127,7 +127,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             ");
             var elementHandle = await Page.QuerySelectorAsync("div");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-rotate.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-rotate.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should fail to screenshot a detached element")]
@@ -138,7 +138,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await Page.EvaluateFunctionAsync("element => element.remove()", elementHandle);
 
             var exception = Assert.ThrowsAsync<PuppeteerException>(elementHandle.ScreenshotStreamAsync);
-            Assert.AreEqual("Node is either not visible or not an HTMLElement", exception!.Message);
+            Assert.That(exception!.Message, Is.EqualTo("Node is either not visible or not an HTMLElement"));
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should not hang with zero width/height element")]
@@ -147,7 +147,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await Page.SetContentAsync(@"<div style='width: 50px; height: 0'></div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
             var exception = Assert.ThrowsAsync<PuppeteerException>(elementHandle.ScreenshotDataAsync);
-            Assert.AreEqual("Node has 0 height.", exception!.Message);
+            Assert.That(exception!.Message, Is.EqualTo("Node has 0 height."));
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should work for an element with fractional dimensions")]
@@ -156,7 +156,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await Page.SetContentAsync("<div style=\"width:48.51px;height:19.8px;border:1px solid black;\"></div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-fractional.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-fractional.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should work for an element with an offset")]
@@ -165,7 +165,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await Page.SetContentAsync("<div style=\"position:absolute; top: 10.3px; left: 20.4px;width:50.3px;height:20.2px;border:1px solid black;\"></div>");
             var elementHandle = await Page.QuerySelectorAsync("div");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-fractional-offset.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-element-fractional-offset.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should work with a null viewport")]
@@ -179,7 +179,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await page.EvaluateExpressionAsync("window.scrollBy(50, 100)");
             var elementHandle = await page.QuerySelectorAsync(".box:nth-of-type(3)");
             var screenshot = await elementHandle.ScreenshotDataAsync();
-            Assert.Greater(screenshot.Length, 0);
+            Assert.That(screenshot, Is.Not.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
 {
     public class PageScreenshotTests : PuppeteerBrowserContextBaseTest
     {
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkWithFile()
         {
             var outputFile = Path.Combine(BaseDirectory, "output.png");
@@ -124,7 +124,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             Assert.That(ScreenshotHelper.PixelMatch("screenshot-clip-rect-scale2.png", screenshot), Is.True);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldClipScale()
         {
             await using var page = await Context.NewPageAsync();
@@ -361,7 +361,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             Assert.That(screenshot, Is.Not.Empty);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public void ShouldInferScreenshotTypeFromName()
         {
             Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpg"), Is.EqualTo(ScreenshotType.Jpeg));
@@ -371,7 +371,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.exe"), Is.Null);
         }
 
-        [Test]
+        [Test, Ignore("previously not marked as a test")]
         public async Task ShouldWorkWithQuality()
         {
             await using var page = await Context.NewPageAsync();

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
@@ -32,8 +32,8 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await page.ScreenshotAsync(outputFile);
 
             fileInfo = new FileInfo(outputFile);
-            Assert.True(new FileInfo(outputFile).Length > 0);
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", outputFile));
+            Assert.That(new FileInfo(outputFile).Length, Is.GreaterThan(0));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-sanity.png", outputFile), Is.True);
 
             if (fileInfo.Exists)
             {
@@ -59,7 +59,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await page.GoToAsync("http://www.google.com");
             await page.ScreenshotAsync(outputFile);
             #endregion
-            Assert.True(File.Exists(outputFile));
+            Assert.That(File.Exists(outputFile), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should work")]
@@ -73,7 +73,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             });
             await page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var screenshot = await page.ScreenshotDataAsync();
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should clip rect")]
@@ -96,7 +96,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                     Height = 100
                 }
             });
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-rect.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-clip-rect.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should use scale for clip")]
@@ -120,7 +120,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                     Scale = 2,
                 }
             });
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-rect-scale2.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-clip-rect-scale2.png", screenshot), Is.True);
         }
 
         public async Task ShouldClipScale()
@@ -143,7 +143,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                     Scale = 2
                 }
             });
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-rect-scale.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-clip-rect-scale.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should get screenshot bigger than the viewport")]
@@ -162,7 +162,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                     Height = 100
                 }
             });
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-offscreen-clip.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-offscreen-clip.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should run in parallel")]
@@ -192,7 +192,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             }
 
             await Task.WhenAll(tasks);
-            Assert.True(ScreenshotHelper.PixelMatch("grid-cell-1.png", tasks[0].Result));
+            Assert.That(ScreenshotHelper.PixelMatch("grid-cell-1.png", tasks[0].Result), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should take fullPage screenshots")]
@@ -209,7 +209,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             {
                 FullPage = true
             });
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-grid-fullpage.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-grid-fullpage.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should run in parallel in multiple pages")]
@@ -251,7 +251,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
 
             for (var i = 0; i < n; i++)
             {
-                Assert.True(ScreenshotHelper.PixelMatch($"grid-cell-{i}.png", screenshotTasks[i].Result));
+                Assert.That(ScreenshotHelper.PixelMatch($"grid-cell-{i}.png", screenshotTasks[i].Result), Is.True);
             }
 
             var closeTasks = new List<Task>();
@@ -278,7 +278,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                 OmitBackground = true
             });
 
-            Assert.True(ScreenshotHelper.PixelMatch("transparent.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("transparent.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Cdp", "should render white background on jpeg file")]
@@ -292,7 +292,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                 OmitBackground = true,
                 Type = ScreenshotType.Jpeg
             });
-            Assert.True(ScreenshotHelper.PixelMatch("white.jpg", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("white.jpg", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Cdp", "should work with webp")]
@@ -305,7 +305,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             {
                 Type = ScreenshotType.Webp
             });
-            Assert.Greater(screenshot.Length, 0);
+            Assert.That(screenshot, Is.Not.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should work with odd clip size on Retina displays")]
@@ -323,7 +323,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                 }
             });
 
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-odd-size.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-clip-odd-size.png", screenshot), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should return base64")]
@@ -338,7 +338,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var screenshot = await page.ScreenshotBase64Async();
 
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", Convert.FromBase64String(screenshot)));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-sanity.png", Convert.FromBase64String(screenshot)), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots Cdp", "should work in \"fromSurface: false\" mode")]
@@ -356,16 +356,16 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                 FromSurface = false,
             });
 
-            Assert.Greater(screenshot.Length, 0);
+            Assert.That(screenshot, Is.Not.Empty);
         }
 
         public void ShouldInferScreenshotTypeFromName()
         {
-            Assert.AreEqual(ScreenshotType.Jpeg, ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpg"));
-            Assert.AreEqual(ScreenshotType.Jpeg, ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpe"));
-            Assert.AreEqual(ScreenshotType.Jpeg, ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpeg"));
-            Assert.AreEqual(ScreenshotType.Png, ScreenshotOptions.GetScreenshotTypeFromFile("Test.png"));
-            Assert.Null(ScreenshotOptions.GetScreenshotTypeFromFile("Test.exe"));
+            Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpg"), Is.EqualTo(ScreenshotType.Jpeg));
+            Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpe"), Is.EqualTo(ScreenshotType.Jpeg));
+            Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpeg"), Is.EqualTo(ScreenshotType.Jpeg));
+            Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.png"), Is.EqualTo(ScreenshotType.Png));
+            Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.exe"), Is.Null);
         }
 
         public async Task ShouldWorkWithQuality()
@@ -383,7 +383,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
                 FullPage = true,
                 Quality = 100
             });
-            Assert.True(ScreenshotHelper.PixelMatch("screenshot-grid-fullpage.png", screenshot));
+            Assert.That(ScreenshotHelper.PixelMatch("screenshot-grid-fullpage.png", screenshot), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
@@ -10,6 +10,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
 {
     public class PageScreenshotTests : PuppeteerBrowserContextBaseTest
     {
+        [Test]
         public async Task ShouldWorkWithFile()
         {
             var outputFile = Path.Combine(BaseDirectory, "output.png");
@@ -123,6 +124,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             Assert.That(ScreenshotHelper.PixelMatch("screenshot-clip-rect-scale2.png", screenshot), Is.True);
         }
 
+        [Test]
         public async Task ShouldClipScale()
         {
             await using var page = await Context.NewPageAsync();
@@ -359,6 +361,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             Assert.That(screenshot, Is.Not.Empty);
         }
 
+        [Test]
         public void ShouldInferScreenshotTypeFromName()
         {
             Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.jpg"), Is.EqualTo(ScreenshotType.Jpeg));
@@ -368,6 +371,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             Assert.That(ScreenshotOptions.GetScreenshotTypeFromFile("Test.exe"), Is.Null);
         }
 
+        [Test]
         public async Task ShouldWorkWithQuality()
         {
             await using var page = await Context.NewPageAsync();

--- a/lib/PuppeteerSharp.Tests/TargetManagerTests/TargetManagerTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetManagerTests/TargetManagerTests.cs
@@ -27,39 +27,39 @@ namespace PuppeteerSharp.Tests.TargetManagerTests
         public async Task ShouldHandleTargets()
         {
             var targetManager = (Browser as CdpBrowser)!.TargetManager;
-            Assert.AreEqual(2, targetManager.GetAvailableTargets().Values.Count);
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(2));
 
-            Assert.IsEmpty(await Context.PagesAsync());
-            Assert.AreEqual(2, targetManager.GetAvailableTargets().Values.Count);
+            Assert.That(await Context.PagesAsync(), Is.Empty);
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(2));
 
             var page = await Context.NewPageAsync();
-            Assert.AreEqual(1, (await Context.PagesAsync()).Length);
-            Assert.AreEqual(3, targetManager.GetAvailableTargets().Values.Count);
+            Assert.That((await Context.PagesAsync()), Has.Length.EqualTo(1));
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(3));
 
             await page.GoToAsync(TestConstants.EmptyPage);
-            Assert.AreEqual(1, (await Context.PagesAsync()).Length);
-            Assert.AreEqual(3, targetManager.GetAvailableTargets().Values.Count);
+            Assert.That((await Context.PagesAsync()), Has.Length.EqualTo(1));
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(3));
 
             var frameTask = page.WaitForFrameAsync(target => target.Url == TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(page, "frame1", TestConstants.EmptyPage);
             await frameTask.WithTimeout();
-            Assert.AreEqual(1, (await Context.PagesAsync()).Length);
-            Assert.AreEqual(3, targetManager.GetAvailableTargets().Values.Count);
-            Assert.AreEqual(2, page.Frames.Length);
+            Assert.That((await Context.PagesAsync()), Has.Length.EqualTo(1));
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(3));
+            Assert.That(page.Frames, Has.Length.EqualTo(2));
 
             frameTask = page.WaitForFrameAsync(target => target.Url == TestConstants.CrossProcessUrl + "/empty.html");
             await FrameUtils.AttachFrameAsync(page, "frame2", TestConstants.CrossProcessUrl + "/empty.html");
             await frameTask.WithTimeout();
-            Assert.AreEqual(1, (await Context.PagesAsync()).Length);
-            Assert.AreEqual(4, targetManager.GetAvailableTargets().Values.Count);
-            Assert.AreEqual(3, page.Frames.Length);
+            Assert.That((await Context.PagesAsync()), Has.Length.EqualTo(1));
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(4));
+            Assert.That(page.Frames, Has.Length.EqualTo(3));
 
             frameTask = page.WaitForFrameAsync(target => target.Url == TestConstants.CrossProcessUrl + "/empty.html");
             await FrameUtils.AttachFrameAsync(page, "frame3", TestConstants.CrossProcessUrl + "/empty.html");
             await frameTask.WithTimeout();
-            Assert.AreEqual(1, (await Context.PagesAsync()).Length);
-            Assert.AreEqual(5, targetManager.GetAvailableTargets().Values.Count);
-            Assert.AreEqual(4, page.Frames.Length);
+            Assert.That((await Context.PagesAsync()), Has.Length.EqualTo(1));
+            Assert.That(targetManager.GetAvailableTargets().Values, Has.Count.EqualTo(5));
+            Assert.That(page.Frames, Has.Length.EqualTo(4));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/TargetTests/BrowserWaitForTargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetTests/BrowserWaitForTargetTests.cs
@@ -18,10 +18,10 @@ namespace PuppeteerSharp.Tests.TargetTests
         {
             var targetTask = Browser.WaitForTargetAsync((target) => target.Url == TestConstants.EmptyPage);
             var page = await Browser.NewPageAsync();
-            Assert.False(targetTask.IsCompleted);
+            Assert.That(targetTask.IsCompleted, Is.False);
             await page.GoToAsync(TestConstants.EmptyPage);
-            Assert.True(targetTask.IsCompleted);
-            Assert.AreSame(await targetTask.Result.PageAsync(), page);
+            Assert.That(targetTask.IsCompleted, Is.True);
+            Assert.That(page, Is.SameAs(await targetTask.Result.PageAsync()));
 
             await page.CloseAsync();
         }

--- a/lib/PuppeteerSharp.Tests/TargetTests/TargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetTests/TargetTests.cs
@@ -20,9 +20,9 @@ namespace PuppeteerSharp.Tests.TargetTests
         {
             // The pages will be the testing page and the original newtab page
             var targets = Browser.Targets();
-            Assert.True(targets.Any(target => target.Type == TargetType.Page
-                && target.Url == TestConstants.AboutBlank));
-            Assert.True(targets.Any(target => target.Type == TargetType.Browser));
+            Assert.That(targets.Any(target => target.Type == TargetType.Page
+                && target.Url == TestConstants.AboutBlank), Is.True);
+            Assert.That(targets.Any(target => target.Type == TargetType.Browser), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "Browser.pages should return all of the pages")]
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             // The pages will be the testing page and the original newtab page
             var allPages = (await Context.PagesAsync()).ToArray();
             Assert.That(allPages, Has.Exactly(1).Items);
-            Assert.Contains(Page, allPages);
+            Assert.That(allPages, Does.Contain(Page));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should contain browser target")]
@@ -39,7 +39,7 @@ namespace PuppeteerSharp.Tests.TargetTests
         {
             var targets = Browser.Targets();
             var browserTarget = targets.FirstOrDefault(target => target.Type == TargetType.Browser);
-            Assert.NotNull(browserTarget);
+            Assert.That(browserTarget, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should be able to use the default page in the browser")]
@@ -49,8 +49,8 @@ namespace PuppeteerSharp.Tests.TargetTests
             await using var browser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions());
             var allPages = await browser.PagesAsync();
             var originalPage = allPages.First(p => p != Page);
-            Assert.AreEqual("Hello world", await originalPage.EvaluateExpressionAsync<string>("['Hello', 'world'].join(' ')"));
-            Assert.NotNull(await originalPage.QuerySelectorAsync("body"));
+            Assert.That(await originalPage.EvaluateExpressionAsync<string>("['Hello', 'world'].join(' ')"), Is.EqualTo("Hello world"));
+            Assert.That(await originalPage.QuerySelectorAsync("body"), Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should report when a new page is created and closed")]
@@ -65,14 +65,14 @@ namespace PuppeteerSharp.Tests.TargetTests
                 );
 
             var otherPage = await otherPageTask.Result;
-            StringAssert.Contains(TestConstants.CrossProcessUrl, otherPage.Url);
+            Assert.That(otherPage.Url, Does.Contain(TestConstants.CrossProcessUrl));
 
-            Assert.AreEqual("Hello world", await otherPage.EvaluateExpressionAsync<string>("['Hello', 'world'].join(' ')"));
-            Assert.NotNull(await otherPage.QuerySelectorAsync("body"));
+            Assert.That(await otherPage.EvaluateExpressionAsync<string>("['Hello', 'world'].join(' ')"), Is.EqualTo("Hello world"));
+            Assert.That(await otherPage.QuerySelectorAsync("body"), Is.Not.Null);
 
             var allPages = await Context.PagesAsync();
-            Assert.Contains(Page, allPages);
-            Assert.Contains(otherPage, allPages);
+            Assert.That(allPages, Does.Contain(Page));
+            Assert.That(allPages, Does.Contain(otherPage));
 
             var closePageTaskCompletion = new TaskCompletionSource<IPage>();
             async void TargetDestroyedEventHandler(object sender, TargetChangedArgs e)
@@ -82,10 +82,10 @@ namespace PuppeteerSharp.Tests.TargetTests
             }
             Context.TargetDestroyed += TargetDestroyedEventHandler;
             await otherPage.CloseAsync();
-            Assert.AreEqual(otherPage, await closePageTaskCompletion.Task);
+            Assert.That(await closePageTaskCompletion.Task, Is.EqualTo(otherPage));
 
             allPages = await Task.WhenAll(Context.Targets().Select(target => target.PageAsync()));
-            Assert.Contains(Page, allPages);
+            Assert.That(allPages, Does.Contain(Page));
             Assert.That(allPages, Does.Not.Contain(otherPage));
         }
 
@@ -103,8 +103,8 @@ namespace PuppeteerSharp.Tests.TargetTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/serviceworkers/empty/sw.html");
 
             var createdTarget = await createdTargetTaskCompletion.Task;
-            Assert.AreEqual(TargetType.ServiceWorker, createdTarget.Type);
-            Assert.AreEqual(TestConstants.ServerUrl + "/serviceworkers/empty/sw.js", createdTarget.Url);
+            Assert.That(createdTarget.Type, Is.EqualTo(TargetType.ServiceWorker));
+            Assert.That(createdTarget.Url, Is.EqualTo(TestConstants.ServerUrl + "/serviceworkers/empty/sw.js"));
 
             var targetDestroyedTaskCompletion = new TaskCompletionSource<ITarget>();
             void TargetDestroyedEventHandler(object sender, TargetChangedArgs e)
@@ -114,7 +114,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             }
             Context.TargetDestroyed += TargetDestroyedEventHandler;
             await Page.EvaluateExpressionAsync("window.registrationPromise.then(registration => registration.unregister())");
-            Assert.AreEqual(createdTarget, await targetDestroyedTaskCompletion.Task);
+            Assert.That(await targetDestroyedTaskCompletion.Task, Is.EqualTo(createdTarget));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should create a worker from a service worker")]
@@ -124,7 +124,7 @@ namespace PuppeteerSharp.Tests.TargetTests
 
             var target = await Context.WaitForTargetAsync(t => t.Type == TargetType.ServiceWorker);
             var worker = await target.WorkerAsync();
-            Assert.AreEqual("[object ServiceWorkerGlobalScope]", await worker.EvaluateFunctionAsync<string>("() => self.toString()"));
+            Assert.That(await worker.EvaluateFunctionAsync<string>("() => self.toString()"), Is.EqualTo("[object ServiceWorkerGlobalScope]"));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should close a service worker")]
@@ -138,7 +138,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             var workerDestroyed = new TaskCompletionSource<TargetChangedArgs>();
             Context.TargetDestroyed += (sender, e) => workerDestroyed.TrySetResult(e);
             await worker.CloseAsync();
-            Assert.AreSame(target, (await workerDestroyed.Task).Target);
+            Assert.That((await workerDestroyed.Task).Target, Is.SameAs(target));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should create a worker from a shared worker")]
@@ -151,7 +151,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             }");
             var target = await Context.WaitForTargetAsync(t => t.Type == TargetType.SharedWorker);
             var worker = await target.WorkerAsync();
-            Assert.AreEqual("[object SharedWorkerGlobalScope]", await worker.EvaluateFunctionAsync<string>("() => self.toString()"));
+            Assert.That(await worker.EvaluateFunctionAsync<string>("() => self.toString()"), Is.EqualTo("[object SharedWorkerGlobalScope]"));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should close a shared worker")]
@@ -169,7 +169,7 @@ namespace PuppeteerSharp.Tests.TargetTests
             var workerDestroyed = new TaskCompletionSource<TargetChangedArgs>();
             Context.TargetDestroyed += (sender, e) => workerDestroyed.TrySetResult(e);
             await worker.CloseAsync();
-            Assert.AreSame(target, (await workerDestroyed.Task).Target);
+            Assert.That((await workerDestroyed.Task).Target, Is.SameAs(target));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should report when a target url changes")]
@@ -187,13 +187,13 @@ namespace PuppeteerSharp.Tests.TargetTests
 
             await Page.GoToAsync(TestConstants.CrossProcessUrl + "/");
             var changedTarget = await changedTargetTaskCompletion.Task;
-            Assert.AreEqual(TestConstants.CrossProcessUrl + "/", changedTarget.Url);
+            Assert.That(changedTarget.Url, Is.EqualTo(TestConstants.CrossProcessUrl + "/"));
 
             changedTargetTaskCompletion = new TaskCompletionSource<ITarget>();
             Context.TargetChanged += ChangedTargetEventHandler;
             await Page.GoToAsync(TestConstants.EmptyPage);
             changedTarget = await changedTargetTaskCompletion.Task;
-            Assert.AreEqual(TestConstants.EmptyPage, changedTarget.Url);
+            Assert.That(changedTarget.Url, Is.EqualTo(TestConstants.EmptyPage));
         }
 
         [Test, Retry(2), PuppeteerTest("target.spec", "Target", "should not report uninitialized pages")]
@@ -211,17 +211,17 @@ namespace PuppeteerSharp.Tests.TargetTests
             Context.TargetCreated += TargetCreatedEventHandler;
             var newPageTask = Context.NewPageAsync();
             var target = await targetCompletionTask.Task;
-            Assert.AreEqual(TestConstants.AboutBlank, target.Url);
+            Assert.That(target.Url, Is.EqualTo(TestConstants.AboutBlank));
 
             var newPage = await newPageTask;
             targetCompletionTask = new TaskCompletionSource<ITarget>();
             Context.TargetCreated += TargetCreatedEventHandler;
             var evaluateTask = newPage.EvaluateExpressionHandleAsync("window.open('about:blank')");
             var target2 = await targetCompletionTask.Task;
-            Assert.AreEqual(TestConstants.AboutBlank, target2.Url);
+            Assert.That(target2.Url, Is.EqualTo(TestConstants.AboutBlank));
             await evaluateTask;
             await newPage.CloseAsync();
-            Assert.False(targetChanged, "target should not be reported as changed");
+            Assert.That(targetChanged, Is.False, "target should not be reported as changed");
             Context.TargetChanged -= listener;
         }
 
@@ -257,10 +257,10 @@ namespace PuppeteerSharp.Tests.TargetTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/popup/window-open.html");
             var createdTarget = await targetCreatedCompletion.Task;
 
-            Assert.AreEqual(TestConstants.ServerUrl + "/popup/popup.html", (await createdTarget.PageAsync()).Url);
+            Assert.That((await createdTarget.PageAsync()).Url, Is.EqualTo(TestConstants.ServerUrl + "/popup/popup.html"));
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.AreSame(Page.Target, createdTarget.Opener);
-            Assert.Null(Page.Target.Opener);
+            Assert.That(createdTarget.Opener, Is.SameAs(Page.Target));
+            Assert.That(Page.Target.Opener, Is.Null);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
     }

--- a/lib/PuppeteerSharp.Tests/TouchScreenTests/TouchscreenPrototypeTapTests.cs
+++ b/lib/PuppeteerSharp.Tests/TouchScreenTests/TouchscreenPrototypeTapTests.cs
@@ -37,8 +37,9 @@ public class TouchscreenPrototypeTapTests : PuppeteerPageBaseTest
         await Page.TapAsync("button");
 
         var result = await Page.EvaluateExpressionAsync<TouchEvent[]>("allEvents");
-        Assert.AreEqual(
-            JsonConvert.SerializeObject(new[]
+        Assert.That(
+            JsonConvert.SerializeObject(result),
+            Is.EqualTo(JsonConvert.SerializeObject(new[]
             {
                 new TouchEvent()
                 {
@@ -126,6 +127,6 @@ public class TouchscreenPrototypeTapTests : PuppeteerPageBaseTest
                     TiltY = 0,
                     Twist = 0,
                 },
-            }), JsonConvert.SerializeObject(result));
+            })));
     }
 }

--- a/lib/PuppeteerSharp.Tests/TouchScreenTests/TouchscreenPrototypeTouchMoveTests.cs
+++ b/lib/PuppeteerSharp.Tests/TouchScreenTests/TouchscreenPrototypeTouchMoveTests.cs
@@ -43,8 +43,9 @@ public class TouchscreenPrototypeTouchMoveTests : PuppeteerPageBaseTest
         await Page.Touchscreen.TouchEndAsync();
 
         var result = await Page.EvaluateExpressionAsync<TouchEvent[]>("allEvents");
-        Assert.AreEqual(
-            JsonConvert.SerializeObject(new[]
+        Assert.That(
+            JsonConvert.SerializeObject(result),
+            Is.EqualTo(JsonConvert.SerializeObject(new[]
             {
                 new TouchEvent()
                 {
@@ -281,6 +282,6 @@ public class TouchscreenPrototypeTouchMoveTests : PuppeteerPageBaseTest
                         },
                     },
                 },
-            }), JsonConvert.SerializeObject(result));
+            })));
     }
 }

--- a/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
+++ b/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
@@ -9,7 +9,7 @@ using PuppeteerSharp.Nunit;
 
 namespace PuppeteerSharp.Tests.TracingTests
 {
-    public class TracingTests : PuppeteerPageBaseTest
+    public sealed class TracingTests : PuppeteerPageBaseTest, IAsyncDisposable
     {
         private readonly string _file;
 
@@ -18,10 +18,8 @@ namespace PuppeteerSharp.Tests.TracingTests
             _file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         }
 
-        public override async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            await base.DisposeAsync();
-
             var attempts = 0;
             const int maxAttempts = 5;
 

--- a/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
+++ b/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
@@ -59,7 +59,7 @@ namespace PuppeteerSharp.Tests.TracingTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             await Page.Tracing.StopAsync();
 
-            Assert.True(File.Exists(_file));
+            Assert.That(File.Exists(_file), Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("tracing.spec", "Tracing", "should run with custom categories if provided")]
@@ -81,7 +81,7 @@ namespace PuppeteerSharp.Tests.TracingTests
             using (var reader = new JsonTextReader(file))
             {
                 var traceJson = JToken.ReadFrom(reader);
-                StringAssert.Contains("disabled-by-default-v8.cpu_profiler.hires", traceJson["metadata"]["trace-config"].ToString());
+                Assert.That(traceJson["metadata"]["trace-config"].ToString(), Does.Contain("disabled-by-default-v8.cpu_profiler.hires"));
             }
         }
 
@@ -99,7 +99,7 @@ namespace PuppeteerSharp.Tests.TracingTests
             using (var reader = new JsonTextReader(file))
             {
                 var traceJson = JToken.ReadFrom(reader);
-                StringAssert.Contains("toplevel", traceJson["traceEvents"].ToString());
+                Assert.That(traceJson["traceEvents"].ToString(), Does.Contain("toplevel"));
             }
         }
 
@@ -134,7 +134,7 @@ namespace PuppeteerSharp.Tests.TracingTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var trace = await Page.Tracing.StopAsync();
             var buf = File.ReadAllText(_file);
-            Assert.AreEqual(trace, buf);
+            Assert.That(buf, Is.EqualTo(trace));
         }
 
         [Test, Retry(2), PuppeteerTest("tracing.spec", "Tracing", "should work without options")]
@@ -143,7 +143,7 @@ namespace PuppeteerSharp.Tests.TracingTests
             await Page.Tracing.StartAsync();
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var trace = await Page.Tracing.StopAsync();
-            Assert.NotNull(trace);
+            Assert.That(trace, Is.Not.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("tracing.spec", "Tracing", "should support a buffer without a path")]
@@ -155,7 +155,7 @@ namespace PuppeteerSharp.Tests.TracingTests
             });
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var trace = await Page.Tracing.StopAsync();
-            StringAssert.Contains("screenshot", trace);
+            Assert.That(trace, Does.Contain("screenshot"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
@@ -6,7 +6,7 @@ using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp.Tests.WaitTaskTests
 {
-    public sealed class FrameWaitForFunctionTests : PuppeteerPageBaseTest
+    public sealed class FrameWaitForFunctionTests : PuppeteerPageBaseTest, IDisposable
     {
         private PollerInterceptor _pollerInterceptor;
 
@@ -27,9 +27,8 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             };
         }
 
-        protected override void Dispose(bool disposing)
+        public void Dispose()
         {
-            base.Dispose(disposing);
             _pollerInterceptor.Dispose();
         }
 

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForFunctionTests.cs
@@ -56,7 +56,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             await Page.EvaluateFunctionAsync("() => setTimeout(window.__FOO = 'hit', 50)");
             await watchdog;
 
-            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > polling / 2);
+            Assert.That((DateTime.UtcNow - startTime).TotalMilliseconds, Is.GreaterThan(polling / 2));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should poll on interval async")]
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             await startedPolling;
             await Page.EvaluateFunctionAsync("async () => setTimeout(window.__FOO = 'hit', 50)");
             await watchdog;
-            Assert.True((DateTime.UtcNow - startTime).TotalMilliseconds > polling / 2);
+            Assert.That((DateTime.UtcNow - startTime).TotalMilliseconds, Is.GreaterThan(polling / 2));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should poll on mutation")]
@@ -82,7 +82,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
                 .ContinueWith(_ => success = true);
             await startedPolling;
             await Page.EvaluateExpressionAsync("window.__FOO = 'hit'");
-            Assert.False(success);
+            Assert.That(success, Is.False);
             await Page.EvaluateExpressionAsync("document.body.appendChild(document.createElement('div'))");
             await watchdog;
         }
@@ -97,7 +97,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
                 .ContinueWith(_ => success = true);
             await startedPolling;
             await Page.EvaluateFunctionAsync("async () => window.__FOO = 'hit'");
-            Assert.False(success);
+            Assert.That(success, Is.False);
             await Page.EvaluateExpressionAsync("document.body.appendChild(document.createElement('div'))");
             await watchdog;
         }
@@ -139,16 +139,16 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var exception = Assert.ThrowsAsync<ArgumentOutOfRangeException>(()
                 => Page.WaitForFunctionAsync("() => !!document.body", new WaitForFunctionOptions { PollingInterval = -10 }));
 
-            StringAssert.Contains("Cannot poll with non-positive interval", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Cannot poll with non-positive interval"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should return the success value as a JSHandle")]
         public async Task ShouldReturnTheSuccessValueAsAJSHandle()
-            => Assert.AreEqual(5, await (await Page.WaitForFunctionAsync("() => 5")).JsonValueAsync<int>());
+            => Assert.That(await (await Page.WaitForFunctionAsync("() => 5")).JsonValueAsync<int>(), Is.EqualTo(5));
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should return the window as a success value")]
         public async Task ShouldReturnTheWindowAsASuccessValue()
-            => Assert.NotNull(await Page.WaitForFunctionAsync("() => window"));
+            => Assert.That(await Page.WaitForFunctionAsync("() => window"), Is.Not.Null);
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should accept ElementHandle arguments")]
         public async Task ShouldAcceptElementHandleArguments()
@@ -158,7 +158,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var resolved = false;
             var waitForFunction = Page.WaitForFunctionAsync("element => !element.parentElement", div)
                 .ContinueWith(_ => resolved = true);
-            Assert.False(resolved);
+            Assert.That(resolved, Is.False);
             await Page.EvaluateFunctionAsync("element => element.remove()", div);
             await waitForFunction;
         }
@@ -169,7 +169,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(()
                 => Page.WaitForExpressionAsync("false", new WaitForFunctionOptions { Timeout = 10 }));
 
-            StringAssert.Contains("Waiting failed: 10ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Waiting failed: 10ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should respect default timeout")]
@@ -179,7 +179,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(()
                 => Page.WaitForExpressionAsync("false"));
 
-            StringAssert.Contains("Waiting failed: 1ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Waiting failed: 1ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should disable timeout when its set to 0")]
@@ -201,14 +201,14 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var waitForFunction = Page.WaitForExpressionAsync("window.__FOO === 1")
                 .ContinueWith(_ => fooFound = true);
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.False(fooFound);
+            Assert.That(fooFound, Is.False);
             await Page.ReloadAsync();
-            Assert.False(fooFound);
+            Assert.That(fooFound, Is.False);
             await Page.GoToAsync(TestConstants.CrossProcessUrl + "/grid.html");
-            Assert.False(fooFound);
+            Assert.That(fooFound, Is.False);
             await Page.EvaluateExpressionAsync("window.__FOO = 1");
             await waitForFunction;
-            Assert.True(fooFound);
+            Assert.That(fooFound, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForFunction", "should survive navigations")]

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -7,7 +8,7 @@ using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp.Tests.WaitTaskTests
 {
-    public class FrameWaitForSelectorTests : PuppeteerPageBaseTest
+    public sealed class FrameWaitForSelectorTests : PuppeteerPageBaseTest, IDisposable
     {
         private const string AddElement = "tag => document.body.appendChild(document.createElement(tag))";
         private PollerInterceptor _pollerInterceptor;
@@ -29,9 +30,8 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             };
         }
 
-        protected override void Dispose(bool disposing)
+        public void Dispose()
         {
-            base.Dispose(disposing);
             _pollerInterceptor.Dispose();
         }
 

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
@@ -55,7 +55,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
                 waitForSelector,
                 Page.SetContentAsync("<div class='zombo'>anything</div>"));
 
-            Assert.AreEqual("anything", await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForSelector));
+            Assert.That(await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForSelector), Is.EqualTo("anything"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should resolve promise when node is added")]
@@ -69,7 +69,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var eHandle = await watchdog;
             var property = await eHandle.GetPropertyAsync("tagName");
             var tagName = await property.JsonValueAsync<string>();
-            Assert.AreEqual("DIV", tagName);
+            Assert.That(tagName, Is.EqualTo("DIV"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should work when node is added through innerHTML")]
@@ -92,7 +92,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             await otherFrame.EvaluateFunctionAsync(AddElement, "div");
             await Page.EvaluateFunctionAsync(AddElement, "div");
             var eHandle = await watchdog;
-            Assert.AreEqual(Page.MainFrame, eHandle.Frame);
+            Assert.That(eHandle.Frame, Is.EqualTo(Page.MainFrame));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should run in specified frame")]
@@ -106,7 +106,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             await frame1.EvaluateFunctionAsync(AddElement, "div");
             await frame2.EvaluateFunctionAsync(AddElement, "div");
             var eHandle = await waitForSelectorPromise;
-            Assert.AreEqual(frame2, eHandle.Frame);
+            Assert.That(eHandle.Frame, Is.EqualTo(frame2));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should throw when frame is detached")]
@@ -118,8 +118,8 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             var waitException = Assert.ThrowsAsync<WaitTaskTimeoutException>(() => waitTask);
 
-            Assert.NotNull(waitException);
-            StringAssert.Contains("waitForFunction failed: frame got detached.", waitException.Message);
+            Assert.That(waitException, Is.Not.Null);
+            Assert.That(waitException.Message, Does.Contain("waitForFunction failed: frame got detached."));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should survive cross-process navigation")]
@@ -128,12 +128,12 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var boxFound = false;
             var waitForSelector = Page.WaitForSelectorAsync(".box").ContinueWith(_ => boxFound = true);
             await Page.GoToAsync(TestConstants.EmptyPage);
-            Assert.False(boxFound);
+            Assert.That(boxFound, Is.False);
             await Page.ReloadAsync();
-            Assert.False(boxFound);
+            Assert.That(boxFound, Is.False);
             await Page.GoToAsync(TestConstants.CrossProcessHttpPrefix + "/grid.html");
             await waitForSelector;
-            Assert.True(boxFound);
+            Assert.That(boxFound, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should wait for element to be visible (display)")]
@@ -144,10 +144,10 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
                 .ContinueWith(_ => divFound = true);
             await Page.SetContentAsync("<div style='display: none;'>text</div>");
             await Task.Delay(100);
-            Assert.False(divFound);
+            Assert.That(divFound, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').style.removeProperty('display')");
-            Assert.True(await waitForSelector);
-            Assert.True(divFound);
+            Assert.That(await waitForSelector, Is.True);
+            Assert.That(divFound, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should wait for element to be visible (visibility)")]
@@ -158,13 +158,13 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
                 .ContinueWith(_ => divFound = true);
             await Page.SetContentAsync("<div style='visibility: hidden;'>text</div>");
             await Task.Delay(100);
-            Assert.False(divFound);
+            Assert.That(divFound, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').style.setProperty('visibility', 'collapse')");
             await Task.Delay(100);
-            Assert.False(divFound);
+            Assert.That(divFound, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').style.removeProperty('visibility')");
-            Assert.True(await waitForSelector);
-            Assert.True(divFound);
+            Assert.That(await waitForSelector, Is.True);
+            Assert.That(divFound, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should wait for element to be visible (bounding box)")]
@@ -175,20 +175,20 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
                 .ContinueWith(_ => divFound = true);
             await Page.SetContentAsync("<div style='width: 0;'>text</div>");
             await Task.Delay(100);
-            Assert.False(divFound);
+            Assert.That(divFound, Is.False);
             await Page.EvaluateFunctionAsync(@"() => {
                 const div = document.querySelector('div');
                 div.style.setProperty('height', '0');
                 div.style.removeProperty('width');
             }");
             await Task.Delay(100);
-            Assert.False(divFound);
+            Assert.That(divFound, Is.False);
             await Page.EvaluateFunctionAsync(@"() => {
                 const div = document.querySelector('div');
                 div.style.removeProperty('height');
             }");
             await Task.Delay(100);
-            Assert.True(divFound);
+            Assert.That(divFound, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should wait for visible recursively")]
@@ -198,12 +198,12 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var waitForSelector = Page.WaitForSelectorAsync("div#inner", new WaitForSelectorOptions { Visible = true })
                 .ContinueWith(_ => divVisible = true);
             await Page.SetContentAsync("<div style='display: none; visibility: hidden;'><div id='inner'>hi</div></div>");
-            Assert.False(divVisible);
+            Assert.That(divVisible, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').style.removeProperty('display')");
-            Assert.False(divVisible);
+            Assert.That(divVisible, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').style.removeProperty('visibility')");
-            Assert.True(await waitForSelector);
-            Assert.True(divVisible);
+            Assert.That(await waitForSelector, Is.True);
+            Assert.That(divVisible, Is.True);
         }
 
         [Test]
@@ -219,10 +219,10 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var waitForSelector = Page.WaitForSelectorAsync("div", new WaitForSelectorOptions { Hidden = true })
                 .ContinueWith(_ => divHidden = true);
             await Page.WaitForSelectorAsync("div"); // do a round trip
-            Assert.False(divHidden);
+            Assert.That(divHidden, Is.False);
             await Page.EvaluateExpressionAsync($"document.querySelector('div').style.setProperty('{propertyName}', '{propertyValue}')");
-            Assert.True(await waitForSelector);
-            Assert.True(divHidden);
+            Assert.That(await waitForSelector, Is.True);
+            Assert.That(divHidden, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should wait for element to be hidden (removal) ")]
@@ -233,17 +233,17 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var waitForSelector = Page.WaitForSelectorAsync("div", new WaitForSelectorOptions { Hidden = true })
                 .ContinueWith(_ => divRemoved = true);
             await Page.WaitForSelectorAsync("div"); // do a round trip
-            Assert.False(divRemoved);
+            Assert.That(divRemoved, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').remove()");
-            Assert.True(await waitForSelector);
-            Assert.True(divRemoved);
+            Assert.That(await waitForSelector, Is.True);
+            Assert.That(divRemoved, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should return null if waiting to hide non-existing element")]
         public async Task ShouldReturnNullIfWaitingToHideNonExistingElement()
         {
             var handle = await Page.WaitForSelectorAsync("non-existing", new WaitForSelectorOptions { Hidden = true });
-            Assert.Null(handle);
+            Assert.That(handle, Is.Null);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should respect timeout")]
@@ -252,7 +252,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(async ()
                 => await Page.WaitForSelectorAsync("div", new WaitForSelectorOptions { Timeout = 10 }));
 
-            StringAssert.Contains("Waiting for selector `div` failed: Waiting failed: 10ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Waiting for selector `div` failed: Waiting failed: 10ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should have an error message specifically for awaiting an element to be hidden")]
@@ -262,7 +262,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(async ()
                 => await Page.WaitForSelectorAsync("div", new WaitForSelectorOptions { Hidden = true, Timeout = 10 }));
 
-            StringAssert.Contains("Waiting for selector `div` failed: Waiting failed: 10ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Waiting for selector `div` failed: Waiting failed: 10ms exceeded"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should respond to node attribute mutation")]
@@ -271,9 +271,9 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var divFound = false;
             var waitForSelector = Page.WaitForSelectorAsync(".zombo").ContinueWith(_ => divFound = true);
             await Page.SetContentAsync("<div class='notZombo'></div>");
-            Assert.False(divFound);
+            Assert.That(divFound, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').className = 'zombo'");
-            Assert.True(await waitForSelector);
+            Assert.That(await waitForSelector, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should return the element handle")]
@@ -281,7 +281,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             var waitForSelector = Page.WaitForSelectorAsync(".zombo");
             await Page.SetContentAsync("<div class='zombo'>anything</div>");
-            Assert.AreEqual("anything", await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForSelector));
+            Assert.That(await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForSelector), Is.EqualTo("anything"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should have correct stack trace for timeout")]
@@ -289,7 +289,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(async ()
                 => await Page.WaitForSelectorAsync(".zombo", new WaitForSelectorOptions { Timeout = 10 }));
-            StringAssert.Contains("WaitForSelectorTests", exception.StackTrace);
+            Assert.That(exception.StackTrace, Does.Contain("WaitForSelectorTests"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should support some fancy xpath")]
@@ -297,7 +297,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             await Page.SetContentAsync("<p>red herring</p><p>hello  world  </p>");
             var waitForXPath = Page.WaitForSelectorAsync("xpath/.//p[normalize-space(.)=\"hello world\"]");
-            Assert.AreEqual("hello  world  ", await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForXPath));
+            Assert.That(await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForXPath), Is.EqualTo("hello  world  "));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should run in specified frame")]
@@ -311,7 +311,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             await frame1.EvaluateFunctionAsync(AddElement, "div");
             await frame2.EvaluateFunctionAsync(AddElement, "div");
             var eHandle = await waitForXPathPromise;
-            Assert.AreEqual(frame2, eHandle.Frame);
+            Assert.That(eHandle.Frame, Is.EqualTo(frame2));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should throw when frame is detached")]
@@ -322,7 +322,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var waitPromise = frame.WaitForSelectorAsync("xpath/.//*[@class=\"box\"]");
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(() => waitPromise);
-            StringAssert.Contains("waitForFunction failed: frame got detached.", exception.Message);
+            Assert.That(exception.Message, Does.Contain("waitForFunction failed: frame got detached."));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "hidden should wait for display: none")]
@@ -334,10 +334,10 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var waitForXPath = Page.WaitForSelectorAsync("xpath/.//div", new WaitForSelectorOptions { Hidden = true })
                 .ContinueWith(_ => divHidden = true);
             await startedPolling;
-            Assert.False(divHidden);
+            Assert.That(divHidden, Is.False);
             await Page.EvaluateExpressionAsync("document.querySelector('div').style.setProperty('display', 'none')");
-            Assert.True(await waitForXPath.WithTimeout());
-            Assert.True(divHidden);
+            Assert.That(await waitForXPath.WithTimeout(), Is.True);
+            Assert.That(divHidden, Is.True);
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should return the element handle")]
@@ -345,7 +345,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             var waitForXPath = Page.WaitForSelectorAsync("xpath/.//*[@class=\"zombo\"]");
             await Page.SetContentAsync("<div class='zombo'>anything</div>");
-            Assert.AreEqual("anything", await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForXPath));
+            Assert.That(await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForXPath), Is.EqualTo("anything"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should allow you to select a text node")]
@@ -353,7 +353,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             await Page.SetContentAsync("<div>some text</div>");
             var text = await Page.WaitForSelectorAsync("xpath/.//div/text()");
-            Assert.AreEqual(3 /* Node.TEXT_NODE */, await (await text.GetPropertyAsync("nodeType")).JsonValueAsync<int>());
+            Assert.That(await (await text.GetPropertyAsync("nodeType")).JsonValueAsync<int>(), Is.EqualTo(3 /* Node.TEXT_NODE */));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should allow you to select an element with single slash")]
@@ -361,7 +361,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             await Page.SetContentAsync("<div>some text</div>");
             var waitForXPath = Page.WaitForSelectorAsync("xpath/html/body/div");
-            Assert.AreEqual("some text", await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForXPath));
+            Assert.That(await Page.EvaluateFunctionAsync<string>("x => x.textContent", await waitForXPath), Is.EqualTo("some text"));
         }
 
         [Test, Retry(2), PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector xpath", "should respect timeout")]
@@ -372,7 +372,7 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(()
                     => Page.WaitForSelectorAsync("xpath/.//div", new WaitForSelectorOptions { Timeout = timeout }));
 
-            StringAssert.Contains($"Waiting failed: {timeout}ms exceeded", exception.Message);
+            Assert.That(exception.Message, Does.Contain($"Waiting failed: {timeout}ms exceeded"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
@@ -24,12 +24,12 @@ namespace PuppeteerSharp.Tests.WorkerTests
                 workerCreatedTcs.Task,
                 Page.GoToAsync(TestConstants.ServerUrl + "/worker/worker.html"));
             var worker = Page.Workers[0];
-            StringAssert.Contains("worker.js", worker.Url);
-            Assert.AreEqual("worker function result", await worker.EvaluateExpressionAsync<string>("self.workerFunction()"));
+            Assert.That(worker.Url, Does.Contain("worker.js"));
+            Assert.That(await worker.EvaluateExpressionAsync<string>("self.workerFunction()"), Is.EqualTo("worker function result"));
 
             await Page.GoToAsync(TestConstants.EmptyPage);
             await workerDestroyedTcs.Task.WithTimeout();
-            Assert.IsEmpty(Page.Workers);
+            Assert.That(Page.Workers, Is.Empty);
         }
 
         [Test, Retry(2), PuppeteerTest("worker.spec", "Workers", "should emit created and destroyed events")]
@@ -43,7 +43,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             var workerDestroyedTcs = new TaskCompletionSource<WebWorker>();
             Page.WorkerDestroyed += (_, e) => workerDestroyedTcs.TrySetResult(e.Worker);
             await Page.EvaluateFunctionAsync("workerObj => workerObj.terminate()", workerObj);
-            Assert.AreSame(worker, await workerDestroyedTcs.Task);
+            Assert.That(await workerDestroyedTcs.Task, Is.SameAs(worker));
         }
 
         [Test, Retry(2), PuppeteerTest("worker.spec", "Workers", "should report console logs")]
@@ -55,13 +55,13 @@ namespace PuppeteerSharp.Tests.WorkerTests
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1)`)");
 
             var log = await consoleTcs.Task;
-            Assert.AreEqual("1", log.Text);
-            Assert.AreEqual(new ConsoleMessageLocation
+            Assert.That(log.Text, Is.EqualTo("1"));
+            Assert.That(log.Location, Is.EqualTo(new ConsoleMessageLocation
             {
                 URL = "",
                 LineNumber = 0,
                 ColumnNumber = 8
-            }, log.Location);
+            }));
         }
 
         [Test, Retry(2), PuppeteerTest("worker.spec", "Workers", "should have JSHandles for console logs")]
@@ -74,10 +74,10 @@ namespace PuppeteerSharp.Tests.WorkerTests
             };
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1, 2, 3, this)`)");
             var log = await consoleTcs.Task;
-            Assert.AreEqual("1 2 3 JSHandle@object", log.Text);
-            Assert.AreEqual(4, log.Args.Count);
+            Assert.That(log.Text, Is.EqualTo("1 2 3 JSHandle@object"));
+            Assert.That(log.Args, Has.Count.EqualTo(4));
             var json = await (await log.Args[3].GetPropertyAsync("origin")).JsonValueAsync<object>();
-            Assert.AreEqual("null", json);
+            Assert.That(json, Is.EqualTo("null"));
         }
 
         [Test, Retry(2), PuppeteerTest("worker.spec", "Workers", "should have an execution context")]
@@ -88,7 +88,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript,console.log(1)`)");
             var worker = await workerCreatedTcs.Task;
-            Assert.AreEqual(2, await worker.EvaluateExpressionAsync<int>("1+1"));
+            Assert.That(await worker.EvaluateExpressionAsync<int>("1+1"), Is.EqualTo(2));
         }
 
         [Test, Retry(2), PuppeteerTest("worker.spec", "Workers", "should report errors")]
@@ -99,7 +99,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
 
             await Page.EvaluateFunctionAsync("() => new Worker(`data:text/javascript, throw new Error('this is my error');`)");
             var errorLog = await errorTcs.Task;
-            StringAssert.Contains("this is my error", errorLog);
+            Assert.That(errorLog, Does.Contain("this is my error"));
         }
 
         [Test, Retry(2), PuppeteerTest("worker.spec", "Workers", "scan be closed")]
@@ -114,9 +114,9 @@ namespace PuppeteerSharp.Tests.WorkerTests
             var workerClosedTcs = new TaskCompletionSource<WebWorker>();
             Page.WorkerDestroyed += (_, e) => workerClosedTcs.TrySetResult(e.Worker);
 
-            StringAssert.Contains("worker.js", worker.Url);
+            Assert.That(worker.Url, Does.Contain("worker.js"));
             await worker.CloseAsync();
-            Assert.AreSame(worker, await workerClosedTcs.Task);
+            Assert.That(await workerClosedTcs.Task, Is.SameAs(worker));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tooling/PuppeteerSharp.Tooling.csproj
+++ b/lib/PuppeteerSharp.Tooling/PuppeteerSharp.Tooling.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit" Version="4.1.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\PuppeteerSharp.Nunit\PuppeteerSharp.Nunit.csproj" />

--- a/lib/PuppeteerSharp.sln
+++ b/lib/PuppeteerSharp.sln
@@ -16,18 +16,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Common\CommonProps.props = Common\CommonProps.props
-		stylecop.json = stylecop.json
-		..\.github\FUNDING.yml = ..\.github\FUNDING.yml
-		..\.github\workflows\dotnet.yml = ..\.github\workflows\dotnet.yml
-		..\.github\workflows\PushNugetPackageToNugetOrg.yml = ..\.github\workflows\PushNugetPackageToNugetOrg.yml
-		..\.github\workflows\sponsors-in-readme.yml = ..\.github\workflows\sponsors-in-readme.yml
-		..\.github\workflows\PushNugetPackageToIntNugetOrg.yml = ..\.github\workflows\PushNugetPackageToIntNugetOrg.yml
 		..\.github\workflows\demo.yml = ..\.github\workflows\demo.yml
+		..\.github\workflows\dotnet.yml = ..\.github\workflows\dotnet.yml
+		..\.github\FUNDING.yml = ..\.github\FUNDING.yml
 		..\.github\workflows\on-push-do-docs.yml = ..\.github\workflows\on-push-do-docs.yml
 		..\.github\workflows\publish-docs.yml = ..\.github\workflows\publish-docs.yml
+		..\.github\workflows\PushNugetPackageToIntNugetOrg.yml = ..\.github\workflows\PushNugetPackageToIntNugetOrg.yml
+		..\.github\workflows\PushNugetPackageToNugetOrg.yml = ..\.github\workflows\PushNugetPackageToNugetOrg.yml
+		..\.github\workflows\sponsors-in-readme.yml = ..\.github\workflows\sponsors-in-readme.yml
+		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PuppeteerSharp.Xunit", "PuppeteerSharp.Nunit\PuppeteerSharp.Nunit.csproj", "{EE53767C-D321-4BCF-B372-57949F38AB40}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PuppeteerSharp.Nunit", "PuppeteerSharp.Nunit\PuppeteerSharp.Nunit.csproj", "{EE53767C-D321-4BCF-B372-57949F38AB40}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PuppeteerSharp.Tooling", "PuppeteerSharp.Tooling\PuppeteerSharp.Tooling.csproj", "{912C1F21-9306-4D6B-A487-47A8FC793E6D}"
 EndProject


### PR DESCRIPTION
The first commit migrates from from NUnit3 to NUnit4.
* [Towards NUnit Version 4](https://docs.nunit.org/articles/nunit/Towards-NUnit4.html) explains what the new syntax offers.
* [Migration Guidance](https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html) mentions breaking changes from NUnit3.

All the changes to the new `Assert.That` syntax (Called the constraint model) where done automatically by the added  [NUnit.Analyzers](https://github.com/nunit/nunit.analyzers).
Their list of [analyzers](https://github.com/nunit/nunit.analyzers/blob/master/documentation/index.md).

In the second commit I went through the warnings from [NUnit1028](https://github.com/nunit/nunit.analyzers/blob/master/documentation/NUnit1028.md) which warns about public methods in test classes that are _not_ marked with `[Test]`.
I've blindly added `[Test]` to all those that had asserts in them.