### PR TITLE
Close page on disposal

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -752,12 +752,6 @@ namespace PuppeteerSharp
         {
             try
             {
-                // We don't want to close the page if we're connected to the browser using `Connect`.
-                if (Browser.Launcher == null)
-                {
-                    return;
-                }
-
                 await CloseAsync().ConfigureAwait(false);
             }
             catch

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,7 +12,7 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>18.1.0-beta1</PackageVersion>
+    <PackageVersion>18.1.0</PackageVersion>
     <ReleaseVersion>18.1.0</ReleaseVersion>
     <AssemblyVersion>18.1.0</AssemblyVersion>
     <FileVersion>18.1.0</FileVersion>


### PR DESCRIPTION
Puppeteer always closes the page on disposal.