### PR TITLE
Apply the Type-Dictionary Trick

### DIFF
--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -111,7 +111,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Context.OverridePermissionsAsync(
                 TestConstants.EmptyPage,
-                Enum.GetValues(typeof(OverridePermission)).Cast<OverridePermission>().ToArray());
+                Enum.GetValues<OverridePermission>());
             Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("granted"));
             await Context.ClearPermissionOverridesAsync();
             Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));

--- a/lib/PuppeteerSharp/BrowserData/Cache.cs
+++ b/lib/PuppeteerSharp/BrowserData/Cache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.BrowserData
 {
@@ -27,12 +28,12 @@ namespace PuppeteerSharp.BrowserData
                 return Array.Empty<InstalledBrowser>();
             }
 
-            var browserNames = Enum.GetNames(typeof(SupportedBrowser)).Select(browser => browser.ToUpperInvariant());
+            var browserNames = EnumHelper.GetNames<SupportedBrowser>().Select(browser => browser.ToUpperInvariant());
             var browsers = rootInfo.GetDirectories().Where(browser => browserNames.Contains(browser.Name.ToUpperInvariant()));
 
             return browsers.SelectMany(browser =>
             {
-                var browserEnum = (SupportedBrowser)Enum.Parse(typeof(SupportedBrowser), browser.Name, ignoreCase: true);
+                var browserEnum = EnumHelper.Parse<SupportedBrowser>(browser.Name, ignoreCase: true);
                 var dirInfo = new DirectoryInfo(GetBrowserRoot(browserEnum));
                 var dirs = dirInfo.GetDirectories();
 
@@ -45,7 +46,7 @@ namespace PuppeteerSharp.BrowserData
                         return null;
                     }
 
-                    var platformEnum = (Platform)Enum.Parse(typeof(Platform), result.Value.Platform, ignoreCase: true);
+                    var platformEnum = EnumHelper.Parse<Platform>(result.Value.Platform, ignoreCase: true);
                     return new InstalledBrowser(this, browserEnum, result.Value.BuildId, platformEnum);
                 })
                 .Where(item => item != null);

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -131,7 +131,7 @@ namespace PuppeteerSharp.BrowserData
         private static (FirefoxChannel Channel, string BuildId) ParseBuildId(string buildId)
         {
             // Iterate through all the FirefoxChannel enum values as string
-            foreach (var value in Enum.GetValues(typeof(FirefoxChannel)).Cast<FirefoxChannel>().Select(v => v.ToValueString()))
+            foreach (var value in EnumHelper.GetValues<FirefoxChannel>().Select(v => v.ToValueString()))
             {
                 if (buildId.StartsWith(value, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
First proposed in https://github.com/hardkoded/puppeteer-sharp/pull/2713#discussion_r1703996482

This avoid constructing the instances of `ConcurrentDictionary` in `EnumHelper` by applying the "Type-Dictionary Trick" from https://mariusgundersen.net/type-dictionary-trick/.

In addition this PR changes the .NET 8 TFM to use generic `Enum` variants.