### PR TITLE
Replace small dictionaries with switch

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/InstalledBrowser.cs
+++ b/lib/PuppeteerSharp/BrowserData/InstalledBrowser.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace PuppeteerSharp.BrowserData
@@ -9,14 +8,6 @@ namespace PuppeteerSharp.BrowserData
     /// </summary>
     public class InstalledBrowser
     {
-        private static readonly Dictionary<SupportedBrowser, Func<Platform, string, string>> _executablePathByBrowser = new()
-        {
-            [SupportedBrowser.Chrome] = Chrome.RelativeExecutablePath,
-            [SupportedBrowser.ChromeHeadlessShell] = ChromeHeadlessShell.RelativeExecutablePath,
-            [SupportedBrowser.Chromium] = Chromium.RelativeExecutablePath,
-            [SupportedBrowser.Firefox] = Firefox.RelativeExecutablePath,
-        };
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InstalledBrowser"/> class.
         /// </summary>
@@ -62,7 +53,16 @@ namespace PuppeteerSharp.BrowserData
             var installationDir = Cache.GetInstallationDir(Browser, Platform, BuildId);
             return Path.Combine(
                 installationDir,
-                _executablePathByBrowser[Browser](Platform, BuildId));
+                GetExecutablePath(Browser, Platform, BuildId));
         }
+
+        private static string GetExecutablePath(SupportedBrowser browser, Platform platform, string buildId) => browser switch
+        {
+            SupportedBrowser.Chrome => Chrome.RelativeExecutablePath(platform, buildId),
+            SupportedBrowser.ChromeHeadlessShell => ChromeHeadlessShell.RelativeExecutablePath(platform, buildId),
+            SupportedBrowser.Chromium => Chromium.RelativeExecutablePath(platform, buildId),
+            SupportedBrowser.Firefox => Firefox.RelativeExecutablePath(platform, buildId),
+            _ => throw new NotSupportedException(),
+        };
     }
 }

--- a/lib/PuppeteerSharp/Cdp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/Cdp/LifecycleWatcher.cs
@@ -11,15 +11,6 @@ namespace PuppeteerSharp.Cdp
 {
     internal sealed class LifecycleWatcher : IDisposable
     {
-        private static readonly Dictionary<WaitUntilNavigation, string> _puppeteerToProtocolLifecycle =
-            new()
-            {
-                [WaitUntilNavigation.Load] = "load",
-                [WaitUntilNavigation.DOMContentLoaded] = "DOMContentLoaded",
-                [WaitUntilNavigation.Networkidle0] = "networkIdle",
-                [WaitUntilNavigation.Networkidle2] = "networkAlmostIdle",
-            };
-
         private static readonly WaitUntilNavigation[] _defaultWaitUntil = [WaitUntilNavigation.Load];
 
         private readonly NetworkManager _networkManager;
@@ -44,7 +35,7 @@ namespace PuppeteerSharp.Cdp
         {
             _expectedLifecycle = (waitUntil ?? _defaultWaitUntil).Select(w =>
             {
-                var protocolEvent = _puppeteerToProtocolLifecycle.GetValue(w);
+                var protocolEvent = GetProtocolEvent(w);
                 Contract.Assert(protocolEvent != null, $"Unknown value for options.waitUntil: {w}");
                 return protocolEvent;
             });
@@ -86,6 +77,15 @@ namespace PuppeteerSharp.Cdp
             _terminationCancellationToken.Cancel();
             _terminationCancellationToken.Dispose();
         }
+
+        private static string GetProtocolEvent(WaitUntilNavigation waitUntil) => waitUntil switch
+        {
+            WaitUntilNavigation.Load => "load",
+            WaitUntilNavigation.DOMContentLoaded => "DOMContentLoaded",
+            WaitUntilNavigation.Networkidle0 => "networkIdle",
+            WaitUntilNavigation.Networkidle2 => "networkAlmostIdle",
+            _ => null,
+        };
 
         private void Navigated(object sender, FrameNavigatedEventArgs e)
         {

--- a/lib/PuppeteerSharp/ScreenshotOptions.cs
+++ b/lib/PuppeteerSharp/ScreenshotOptions.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Serialization;
 using PuppeteerSharp.Media;
@@ -10,14 +9,6 @@ namespace PuppeteerSharp
     /// </summary>
     public class ScreenshotOptions
     {
-        private static readonly Dictionary<string, ScreenshotType?> _extensionScreenshotTypeMap = new()
-        {
-            ["jpe"] = ScreenshotType.Jpeg,
-            ["jpeg"] = ScreenshotType.Jpeg,
-            ["jpg"] = ScreenshotType.Jpeg,
-            ["png"] = ScreenshotType.Png,
-        };
-
         /// <summary>
         /// Specifies clipping region of the page.
         /// </summary>
@@ -87,8 +78,14 @@ namespace PuppeteerSharp
         internal static ScreenshotType? GetScreenshotTypeFromFile(string file)
         {
             var extension = new FileInfo(file).Extension.Replace(".", string.Empty);
-            _extensionScreenshotTypeMap.TryGetValue(extension, out var result);
-            return result;
+            return GetScreenshotType(extension);
         }
+
+        private static ScreenshotType? GetScreenshotType(string extension) => extension switch
+        {
+            "jpe" or "jpeg" or "jpg" => ScreenshotType.Jpeg,
+            "png" => ScreenshotType.Png,
+            _ => null,
+        };
     }
 }


### PR DESCRIPTION
Instead of initializing and looking up values in small dictionaries, it's faster to simply use a switch expression and we can also (I would say) better name the lookup methods.

I implemented them as private static functions, but they also have been static local functions.