### PR TITLE
Use byte array in message send to avoid some unnecessary encoding

### DIFF
--- a/lib/PuppeteerSharp.Tests/PollerInterceptor.cs
+++ b/lib/PuppeteerSharp.Tests/PollerInterceptor.cs
@@ -6,9 +6,9 @@ namespace PuppeteerSharp.Tests
 {
     public sealed class PollerInterceptor(IConnectionTransport connectionTransport) : IConnectionTransport
     {
-        public event EventHandler<string> MessageSent;
+        public event EventHandler<byte[]> MessageSent;
 
-        public Task SendAsync(string message)
+        public Task SendAsync(byte[] message)
         {
             var task = connectionTransport.SendAsync(message);
             MessageSent?.Invoke(connectionTransport, message);
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.Tests
             // We intercept the poller.start() call to prevent tests from continuing before the polling has started.
             MessageSent += (_, message) =>
             {
-                if (message.Contains("poller.start()"))
+                if (message.AsSpan().IndexOf("poller.start()"u8) != -1)
                 {
                     startedPolling.SetResult(true);
                 }

--- a/lib/PuppeteerSharp/Cdp/Connection.cs
+++ b/lib/PuppeteerSharp/Cdp/Connection.cs
@@ -157,14 +157,18 @@ namespace PuppeteerSharp.Cdp
 
         internal int GetMessageId() => Interlocked.Increment(ref _lastId);
 
-        internal Task RawSendAsync(string message, CommandOptions options = null)
+        internal Task RawSendAsync(byte[] message, CommandOptions options = null)
         {
-            _logger.LogTrace("Send ► {Message}", message);
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                _logger.LogTrace("Send ► {Message}", Encoding.UTF8.GetString(message));
+            }
+
             return Transport.SendAsync(message);
         }
 
-        internal string GetMessage(int id, string method, object args, string sessionId = null)
-            => JsonSerializer.Serialize(
+        internal byte[] GetMessage(int id, string method, object args, string sessionId = null)
+            => JsonSerializer.SerializeToUtf8Bytes(
                 new ConnectionRequest { Id = id, Method = method, Params = args, SessionId = sessionId },
                 JsonHelper.DefaultJsonSerializerSettings.Value);
 

--- a/lib/PuppeteerSharp/MessageTask.cs
+++ b/lib/PuppeteerSharp/MessageTask.cs
@@ -5,7 +5,7 @@ namespace PuppeteerSharp
 {
     internal class MessageTask
     {
-        internal string Message { get; set; }
+        internal byte[] Message { get; set; }
 
         internal TaskCompletionSource<JsonElement?> TaskWrapper { get; set; }
 

--- a/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
+++ b/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
@@ -33,6 +33,6 @@ namespace PuppeteerSharp.Transport
         /// </summary>
         /// <param name="message">Message to send.</param>
         /// <returns>The task.</returns>
-        Task SendAsync(string message);
+        Task SendAsync(byte[] message);
     }
 }

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -70,11 +70,9 @@ namespace PuppeteerSharp.Transport
         public bool IsClosed { get; private set; }
 
         /// <inheritdoc />
-        public Task SendAsync(string message)
+        public Task SendAsync(byte[] message)
         {
-            var encoded = Encoding.UTF8.GetBytes(message);
-            var buffer = new ArraySegment<byte>(encoded, 0, encoded.Length);
-            Task SendCoreAsync() => _client.SendAsync(buffer, WebSocketMessageType.Text, true, default);
+            Task SendCoreAsync() => _client.SendAsync(new ArraySegment<byte>(message), WebSocketMessageType.Text, true, default);
 
             return _queueRequests ? _socketQueue.Enqueue(SendCoreAsync) : SendCoreAsync();
         }


### PR DESCRIPTION
Similar to #2748 System.Text.Json can also serialize directly to bytes to avoid some unnecessary [en](https://github.com/dotnet/runtime/blob/d3154144ae65a77585de29892ec41517f0add61e/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs#L164)/[decoding](https://github.com/campersau/puppeteer-sharp/blob/39f23de3c9b9f71178eb9d612bf66f3531bc0ec5/lib/PuppeteerSharp/Transport/WebSocketTransport.cs#L75).