### PR TITLE
Fix request interception with complex PostData

### DIFF
--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -3,9 +3,13 @@ on:
   push:
 jobs:
   docs:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
     - name: Run MarkdownSnippets
       run: |
         dotnet tool install --global MarkdownSnippets.Tool

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 ## Take screenshots
 
 <!-- snippet: ScreenshotAsync -->
-<a id='snippet-ScreenshotAsync'></a>
+<a id='snippet-screenshotasync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScreenshotAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
 <!-- snippet: SetViewportAsync -->
-<a id='snippet-SetViewportAsync'></a>
+<a id='snippet-setviewportasync'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -74,13 +74,13 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetViewportAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
 
 <!-- snippet: PdfAsync -->
-<a id='snippet-PdfAsync'></a>
+<a id='snippet-pdfasync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,32 +90,32 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-PdfAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
 <!-- snippet: SetContentAsync -->
-<a id='snippet-SetContentAsync'></a>
+<a id='snippet-setcontentasync'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetContentAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
 <!-- snippet: Evaluate -->
-<a id='snippet-Evaluate'></a>
+<a id='snippet-evaluate'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<JsonElement>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.GetProperty("a").GetString());
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-Evaluate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 
 ## Take screenshots
 
-<!-- snippet: ScreenshotAsync -->
-<a id='snippet-screenshotasync'></a>
+<!-- snippet: screenshotasync_example -->
+<a id='snippet-screenshotasync_example'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
-<!-- snippet: SetViewportAsync -->
-<a id='snippet-setviewportasync'></a>
+<!-- snippet: setviewportasync_example -->
+<a id='snippet-setviewportasync_example'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -74,13 +74,13 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
 
-<!-- snippet: PdfAsync -->
-<a id='snippet-pdfasync'></a>
+<!-- snippet: pdfasync_example -->
+<a id='snippet-pdfasync_example'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,32 +90,32 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
-<!-- snippet: SetContentAsync -->
-<a id='snippet-setcontentasync'></a>
+<!-- snippet: setcontentasync_example -->
+<a id='snippet-setcontentasync_example'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
-<!-- snippet: Evaluate -->
-<a id='snippet-evaluate'></a>
+<!-- snippet: evaluate_example -->
+<a id='snippet-evaluate_example'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<JsonElement>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.GetProperty("a").GetString());
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 ## Take screenshots
 
 <!-- snippet: ScreenshotAsync -->
-<a id='snippet-screenshotasync'></a>
+<a id='snippet-ScreenshotAsync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScreenshotAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
 <!-- snippet: SetViewportAsync -->
-<a id='snippet-setviewportasync'></a>
+<a id='snippet-SetViewportAsync'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -74,13 +74,13 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetViewportAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
 
 <!-- snippet: PdfAsync -->
-<a id='snippet-pdfasync'></a>
+<a id='snippet-PdfAsync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,32 +90,32 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-PdfAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
 <!-- snippet: SetContentAsync -->
-<a id='snippet-setcontentasync'></a>
+<a id='snippet-SetContentAsync'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetContentAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
 <!-- snippet: Evaluate -->
-<a id='snippet-evaluate'></a>
+<a id='snippet-Evaluate'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<JsonElement>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.GetProperty("a").GetString());
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-Evaluate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetViewportAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
@@ -115,7 +115,7 @@ var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<JsonElement>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.GetProperty("a").GetString());
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-Evaluate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 
 ## Take screenshots
 
-<!-- snippet: screenshotasync_example -->
-<a id='snippet-screenshotasync_example'></a>
+<!-- snippet: ScreenshotAsync -->
+<a id='snippet-ScreenshotAsync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScreenshotAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
-<!-- snippet: setviewportasync_example -->
-<a id='snippet-setviewportasync_example'></a>
+<!-- snippet: SetViewportAsync -->
+<a id='snippet-SetViewportAsync'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -74,13 +74,13 @@ await Page.SetViewportAsync(new ViewPortOptions
     Height = 500
 });
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-setviewportasync_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetViewportAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Generate PDF files
 
-<!-- snippet: pdfasync_example -->
-<a id='snippet-pdfasync_example'></a>
+<!-- snippet: PdfAsync -->
+<a id='snippet-PdfAsync'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,32 +90,32 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-PdfAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
-<!-- snippet: setcontentasync_example -->
-<a id='snippet-setcontentasync_example'></a>
+<!-- snippet: SetContentAsync -->
+<a id='snippet-SetContentAsync'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetContentAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
-<!-- snippet: evaluate_example -->
-<a id='snippet-evaluate_example'></a>
+<!-- snippet: Evaluate -->
+<a id='snippet-Evaluate'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
 var someObject = await page.EvaluateFunctionAsync<JsonElement>("(value) => ({a: value})", 5);
 Console.WriteLine(someObject.GetProperty("a").GetString());
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-evaluate_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-Evaluate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Wait For Selector

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ See [this document](https://github.com/hardkoded/puppeteer-sharp/blob/master/CON
 
 ## Take screenshots
 
-<!-- snippet: ScreenshotAsync -->
-<a id='snippet-ScreenshotAsync'></a>
+<!-- snippet: screenshotasync_example -->
+<a id='snippet-screenshotasync_example'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -60,13 +60,13 @@ await using var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
 await page.ScreenshotAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScreenshotAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs#L54-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-screenshotasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also change the view port before generating the screenshot
 
-<!-- snippet: SetViewportAsync -->
-<a id='snippet-SetViewportAsync'></a>
+<!-- snippet: setviewportasync_example -->
+<a id='snippet-setviewportasync_example'></a>
 ```cs
 await Page.SetViewportAsync(new ViewPortOptions
 {
@@ -79,8 +79,8 @@ await Page.SetViewportAsync(new ViewPortOptions
 
 ### Generate PDF files
 
-<!-- snippet: PdfAsync -->
-<a id='snippet-PdfAsync'></a>
+<!-- snippet: pdfasync_example -->
+<a id='snippet-pdfasync_example'></a>
 ```cs
 var browserFetcher = new BrowserFetcher();
 await browserFetcher.DownloadAsync();
@@ -90,25 +90,25 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-PdfAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML
 
-<!-- snippet: SetContentAsync -->
-<a id='snippet-SetContentAsync'></a>
+<!-- snippet: setcontentasync_example -->
+<a id='snippet-setcontentasync_example'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-SetContentAsync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript
 
-<!-- snippet: Evaluate -->
-<a id='snippet-Evaluate'></a>
+<!-- snippet: evaluate_example -->
+<a id='snippet-evaluate_example'></a>
 ```cs
 await using var page = await browser.NewPageAsync();
 var seven = await page.EvaluateExpressionAsync<int>("4 + 3");

--- a/docfx_project/docs/DownloadFetcher.Download.md
+++ b/docfx_project/docs/DownloadFetcher.Download.md
@@ -13,8 +13,8 @@ You will find the available versions [here](https://googlechromelabs.github.io/c
 Once you have the version you want, you can download it using the `BrowserFetcher` class.
 
 ```cs
-<!-- snippet: CustomVersionsExample -->
-<a id='snippet-customversionsexample'></a>
+<!-- snippet: custom_version_example -->
+<a id='snippet-custom_version_example'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-customversionsexample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-custom_version_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/docs/DownloadFetcher.Download.md
+++ b/docfx_project/docs/DownloadFetcher.Download.md
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-CustomVersionsExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-customversions_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/docs/DownloadFetcher.Download.md
+++ b/docfx_project/docs/DownloadFetcher.Download.md
@@ -13,8 +13,8 @@ You will find the available versions [here](https://googlechromelabs.github.io/c
 Once you have the version you want, you can download it using the `BrowserFetcher` class.
 
 ```cs
-<!-- snippet: CustomVersionsExample -->
-<a id='snippet-CustomVersionsExample'></a>
+<!-- snippet: customversions_example -->
+<a id='snippet-customversions_example'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 

--- a/docfx_project/docs/DownloadFetcher.Download.md
+++ b/docfx_project/docs/DownloadFetcher.Download.md
@@ -14,7 +14,7 @@ Once you have the version you want, you can download it using the `BrowserFetche
 
 ```cs
 <!-- snippet: CustomVersionsExample -->
-<a id='snippet-customversionsexample'></a>
+<a id='snippet-CustomVersionsExample'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-customversionsexample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-CustomVersionsExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/docs/DownloadFetcher.Download.md
+++ b/docfx_project/docs/DownloadFetcher.Download.md
@@ -13,8 +13,8 @@ You will find the available versions [here](https://googlechromelabs.github.io/c
 Once you have the version you want, you can download it using the `BrowserFetcher` class.
 
 ```cs
-<!-- snippet: custom_version_example -->
-<a id='snippet-custom_version_example'></a>
+<!-- snippet: CustomVersionsExample -->
+<a id='snippet-CustomVersionsExample'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-custom_version_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-CustomVersionsExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/docs/DownloadFetcher.Download.md
+++ b/docfx_project/docs/DownloadFetcher.Download.md
@@ -14,7 +14,7 @@ Once you have the version you want, you can download it using the `BrowserFetche
 
 ```cs
 <!-- snippet: CustomVersionsExample -->
-<a id='snippet-CustomVersionsExample'></a>
+<a id='snippet-customversionsexample'></a>
 ```cs
 Console.WriteLine("Downloading browsers");
 
@@ -51,6 +51,6 @@ await using (var browser = await Puppeteer.LaunchAsync(new()
     Console.WriteLine("Export completed");
 }
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-CustomVersionsExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L24-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-customversionsexample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 ```

--- a/docfx_project/docs/ReuseChrome.md
+++ b/docfx_project/docs/ReuseChrome.md
@@ -11,15 +11,15 @@ from a location where it was previously downloaded instead of from the default l
 
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
-<!-- snippet: reuse_chrome_example -->
-<a id='snippet-reuse_chrome_example'></a>
+<!-- snippet: ReuseChromeExample -->
+<a id='snippet-ReuseChromeExample'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reuse_chrome_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ReuseChromeExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/docfx_project/docs/ReuseChrome.md
+++ b/docfx_project/docs/ReuseChrome.md
@@ -11,8 +11,8 @@ from a location where it was previously downloaded instead of from the default l
 
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
-<!-- snippet: ReuseChromeExample -->
-<a id='snippet-ReuseChromeExample'></a>
+<!-- snippet: reusechrome_example -->
+<a id='snippet-reusechrome_example'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };

--- a/docfx_project/docs/ReuseChrome.md
+++ b/docfx_project/docs/ReuseChrome.md
@@ -12,14 +12,14 @@ from a location where it was previously downloaded instead of from the default l
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
 <!-- snippet: ReuseChromeExample -->
-<a id='snippet-reusechromeexample'></a>
+<a id='snippet-ReuseChromeExample'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reusechromeexample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ReuseChromeExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/docfx_project/docs/ReuseChrome.md
+++ b/docfx_project/docs/ReuseChrome.md
@@ -11,15 +11,15 @@ from a location where it was previously downloaded instead of from the default l
 
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
-<!-- snippet: ReuseChromeExample -->
-<a id='snippet-reusechromeexample'></a>
+<!-- snippet: reuse_chrome_example -->
+<a id='snippet-reuse_chrome_example'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reusechromeexample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reuse_chrome_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/docfx_project/docs/ReuseChrome.md
+++ b/docfx_project/docs/ReuseChrome.md
@@ -12,14 +12,14 @@ from a location where it was previously downloaded instead of from the default l
 Use `BrowserFetcherOptions` to specify the full path for where to download Chrome.
 
 <!-- snippet: ReuseChromeExample -->
-<a id='snippet-ReuseChromeExample'></a>
+<a id='snippet-reusechromeexample'></a>
 ```cs
 var downloadPath = "/Users/dario/chrome";
 var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ReuseChromeExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reusechromeexample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/docfx_project/docs/ReuseChrome.md
+++ b/docfx_project/docs/ReuseChrome.md
@@ -19,7 +19,7 @@ var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
 var browserFetcher = new BrowserFetcher(browserFetcherOptions);
 var installedBrowser = await browserFetcher.DownloadAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ReuseChromeExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-reusechrome_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `Puppeteer.LaunchAsync()` with `LaunchOptions` with the `LaunchOptions.ExecutablePath` property set to the

--- a/lib/PuppeteerSharp.AspNetFramework/AspNetWebSocketTransport.cs
+++ b/lib/PuppeteerSharp.AspNetFramework/AspNetWebSocketTransport.cs
@@ -9,8 +9,6 @@ namespace PuppeteerSharp.AspNetFramework
 {
     public class AspNetWebSocketTransport : WebSocketTransport
     {
-        #region Static fields
-
         /// <summary>
         /// Gets a <see cref="TransportFactory"/> that creates <see cref="AspNetWebSocketTransport"/> instances.
         /// </summary>
@@ -21,10 +19,6 @@ namespace PuppeteerSharp.AspNetFramework
         /// for scheduling of tasks.
         /// </summary>
         public static readonly TransportTaskScheduler AspNetTransportScheduler = ScheduleBackgroundTask;
-
-        #endregion
-
-        #region Static methods
 
         private static async Task<IConnectionTransport> CreateAspNetTransport(Uri url, IConnectionOptions connectionOptions, CancellationToken cancellationToken)
         {
@@ -40,15 +34,9 @@ namespace PuppeteerSharp.AspNetFramework
             HostingEnvironment.QueueBackgroundWorkItem(ExecuteAsync);
         }
 
-        #endregion
-
-        #region Constructor(s)
-
         /// <inheritdoc />
         public AspNetWebSocketTransport(WebSocket client, bool queueRequests)
             : base(client, AspNetTransportScheduler, queueRequests)
         { }
-
-        #endregion
     }
 }

--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
 
         public async Task Usage()
         {
-            #region custom_version_example
+            #region customversions_example
             Console.WriteLine("Downloading browsers");
 
             var browserFetcher = new BrowserFetcher(SupportedBrowser.Chrome);

--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -11,7 +11,7 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
     {
         public async Task ReuseChromeExample()
         {
-            #region ReuseChromeExample
+            #region reuse_chrome_example
             var downloadPath = "/Users/dario/chrome";
             var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
             var browserFetcher = new BrowserFetcher(browserFetcherOptions);
@@ -21,7 +21,7 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
 
         public async Task Usage()
         {
-            #region CustomVersionsExample
+            #region custom_version_example
             Console.WriteLine("Downloading browsers");
 
             var browserFetcher = new BrowserFetcher(SupportedBrowser.Chrome);

--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -11,7 +11,7 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
     {
         public async Task ReuseChromeExample()
         {
-            #region reuse_chrome_example
+            #region reusechrome_example
             var downloadPath = "/Users/dario/chrome";
             var browserFetcherOptions = new BrowserFetcherOptions { Path = downloadPath };
             var browserFetcher = new BrowserFetcher(browserFetcherOptions);

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/WaitForDevicePromptTests.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/WaitForDevicePromptTests.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
     {
         public async Task Usage()
         {
-            #region DeviceRequestPromptUsage
+            #region devicerequestprompt_usage
             var promptTask = Page.WaitForDevicePromptAsync();
             await Task.WhenAll(
                 promptTask,
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
 
         public async Task PageUsage()
         {
-            #region IPageWaitForDevicePromptAsyncUsage
+            #region ipagewaitfordevicepromptasync_usage
             var promptTask = Page.WaitForDevicePromptAsync();
             await Task.WhenAll(
                 promptTask,
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.Tests.DeviceRequestPromptTests
         public async Task FrameUsage()
         {
             var frame = Page.MainFrame;
-            #region IFrameWaitForDevicePromptAsyncUsage
+            #region iframewaitfordevicepromptasync_usage
             var promptTask = frame.WaitForDevicePromptAsync();
             await Task.WhenAll(
                 promptTask,

--- a/lib/PuppeteerSharp.Tests/NetworkManagerTests/NetworkManagerTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkManagerTests/NetworkManagerTests.cs
@@ -32,11 +32,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "7760711DEFCFA23132D98ABA6B4E175C",
                     LoaderId = "7760711DEFCFA23132D98ABA6B4E175C",
-                    Request = new Payload() { Url = "http://localhost:8907/redirect/1.html", Method = HttpMethod.Get },
+                    Request = new Request() { Url = "http://localhost:8907/redirect/1.html", Method = HttpMethod.Get },
                     Initiator = new Initiator { Type = InitiatorType.Other },
                     RedirectHasExtraInfo = false,
                     Type = ResourceType.Document,
@@ -49,11 +49,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "7760711DEFCFA23132D98ABA6B4E175C",
                     LoaderId = "7760711DEFCFA23132D98ABA6B4E175C",
-                    Request = new Payload() { Url = "http://localhost:8907/redirect/2.html", Method = HttpMethod.Get, },
+                    Request = new Request() { Url = "http://localhost:8907/redirect/2.html", Method = HttpMethod.Get, },
                     Initiator = new Initiator { Type = InitiatorType.Other },
                     RedirectHasExtraInfo = true,
                     RedirectResponse = new ResponsePayload
@@ -76,11 +76,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "7760711DEFCFA23132D98ABA6B4E175C",
                     LoaderId = "7760711DEFCFA23132D98ABA6B4E175C",
-                    Request = new Payload { Url = "http://localhost:8907/redirect/3.html", Method = HttpMethod.Get, },
+                    Request = new Request { Url = "http://localhost:8907/redirect/3.html", Method = HttpMethod.Get, },
                     Initiator = new Initiator { Type = InitiatorType.Other },
                     RedirectHasExtraInfo = true,
                     RedirectResponse = new ResponsePayload
@@ -123,11 +123,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "11ACE9783588040D644B905E8B55285B",
                     LoaderId = "11ACE9783588040D644B905E8B55285B",
-                    Request = new Payload()
+                    Request = new Request()
                     {
                         Url = "https://www.google.com/",
                         Method = HttpMethod.Get,
@@ -148,7 +148,7 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 MessageData = JsonSerializer.SerializeToElement(new FetchRequestPausedResponse
                 {
                     RequestId = "interception-job-1.0",
-                    Request = new Payload
+                    Request = new Request
                     {
                         Url = "https://www.google.com/",
                         Method = HttpMethod.Get,
@@ -168,7 +168,7 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
                 MessageData = JsonSerializer.SerializeToElement(new FetchRequestPausedResponse
                 {
                     RequestId = "interception-job-2.0",
-                    Request = new Payload()
+                    Request = new Request()
                     {
                         Url = "https://www.google.com/",
                         Method = HttpMethod.Get,
@@ -206,11 +206,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "1360.2",
                     LoaderId = "9E86B0282CC98B77FB0ABD49156DDFDD",
-                    Request = new Payload { Url = "http://this.is.a.test.com:1080/test.js", Method = HttpMethod.Get, },
+                    Request = new Request { Url = "http://this.is.a.test.com:1080/test.js", Method = HttpMethod.Get, },
                     Initiator = new Initiator()
                     {
                         Type = InitiatorType.Parser,
@@ -300,11 +300,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload()
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse()
                 {
                     RequestId = "LOADERID",
                     LoaderId = "LOADERID",
-                    Request = new Payload()
+                    Request = new Request()
                     {
                         Url = "http://10.1.0.39:42915/empty.html",
                         Method = HttpMethod.Get,
@@ -410,11 +410,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "94051D839ACF29E53A3D1273FB20B4C4",
                     LoaderId = "94051D839ACF29E53A3D1273FB20B4C4",
-                    Request = new Payload
+                    Request = new Request
                     {
                         Url = "http://localhost:8080/iframe.html",
                         Method = HttpMethod.Get,
@@ -497,11 +497,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse
                 {
                     RequestId = "E18BEB94B486CA8771F9AFA2030FEA37",
                     LoaderId = "E18BEB94B486CA8771F9AFA2030FEA37",
-                    Request = new Payload
+                    Request = new Request
                     {
                         Url = "http://localhost:8080/iframe.html",
                         Method = HttpMethod.Get,
@@ -592,11 +592,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload()
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse()
                 {
                     RequestId = "6D76C8ACAECE880C722FA515AD380015",
                     LoaderId = "6D76C8ACAECE880C722FA515AD380015",
-                    Request = new Payload()
+                    Request = new Request()
                     {
                         Url = "http://10.1.0.39:42915/empty.html",
                         Method = HttpMethod.Get,
@@ -680,11 +680,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload()
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse()
                 {
                     RequestId = "4C2CC44FB6A6CAC5BE2780BCC9313105",
                     LoaderId = "4C2CC44FB6A6CAC5BE2780BCC9313105",
-                    Request = new Payload()
+                    Request = new Request()
                     {
                         Url = "http://10.1.0.39:42915/empty.html",
                         Method = HttpMethod.Get,
@@ -725,11 +725,11 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
             new MessageEventArgs()
             {
                 MessageID = "Network.requestWillBeSent",
-                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentPayload()
+                MessageData = JsonSerializer.SerializeToElement(new RequestWillBeSentResponse()
                 {
                     RequestId = "4C2CC44FB6A6CAC5BE2780BCC9313105",
                     LoaderId = "4C2CC44FB6A6CAC5BE2780BCC9313105",
-                    Request = new Payload()
+                    Request = new Request()
                     {
                         Url = "http://10.1.0.39:42915/empty.html",
                         Method = HttpMethod.Get,

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
@@ -2,7 +2,6 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Nunit;
-using PuppeteerSharp.Tests.EvaluationTests;
 
 namespace PuppeteerSharp.Tests.NetworkTests
 {
@@ -17,7 +16,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.EvaluateExpressionHandleAsync("fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar'})})");
             var request = await requestTask.WithTimeout();
             Assert.That(request, Is.Not.Null);
-            Assert.That(((EvaluateTests.ComplexObjectTestClass)request.PostData).Foo, Is.EqualTo("bar"));
+            Assert.That(request.PostData, Is.EqualTo("{\"foo\":\"bar\"}"));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.postData", "should be |undefined| when there is no post data")]

--- a/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/RequestPostDataTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Nunit;
+using PuppeteerSharp.Tests.EvaluationTests;
 
 namespace PuppeteerSharp.Tests.NetworkTests
 {
@@ -16,7 +17,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             await Page.EvaluateExpressionHandleAsync("fetch('./post', { method: 'POST', body: JSON.stringify({ foo: 'bar'})})");
             var request = await requestTask.WithTimeout();
             Assert.That(request, Is.Not.Null);
-            Assert.That(request.PostData, Is.EqualTo("{\"foo\":\"bar\"}"));
+            Assert.That(((EvaluateTests.ComplexObjectTestClass)request.PostData).Foo, Is.EqualTo("bar"));
         }
 
         [Test, Retry(2), PuppeteerTest("network.spec", "network Request.postData", "should be |undefined| when there is no post data")]

--- a/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
@@ -20,7 +20,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 fileInfo.Delete();
             }
 
-            #region PdfAsync
+            #region pdfasync_example
 
             var browserFetcher = new BrowserFetcher();
             await browserFetcher.DownloadAsync();

--- a/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
@@ -11,7 +11,7 @@ namespace PuppeteerSharp.Tests.PageTests
 
         public async Task Usage(IBrowser browser)
         {
-            #region SetContentAsync
+            #region setcontentasync_example
 
             await using var page = await browser.NewPageAsync();
             await page.SetContentAsync("<div>My Receipt</div>");

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2" PrivateAssets="All" />
+		<PackageReference Include="MarkdownSnippets.MsBuild" Version="27.0.2" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 		<PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
@@ -24,7 +24,7 @@
 	<Import Project="../Common/CommonProps.props" />
 	<ItemGroup>
 		<ProjectReference Include="..\PuppeteerSharp.TestServer\PuppeteerSharp.TestServer.csproj" />
-		<ProjectReference Include="..\PuppeteerSharp\PuppeteerSharp.csproj" />
+		<ProjectReferenc1e Include="..\PuppeteerSharp\PuppeteerSharp.csproj" />
 		<ProjectReference Include="..\PuppeteerSharp.Nunit\PuppeteerSharp.Nunit.csproj" />
 	</ItemGroup>
 	<ItemGroup>

--- a/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/QuerySelectorTests/ElementHandleQuerySelectorEvalTests.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.Tests.QuerySelectorTests
 
         public async Task Usage(Browser browser)
         {
-            #region Evaluate
+            #region evaluate_example
             await using var page = await browser.NewPageAsync();
             var seven = await page.EvaluateExpressionAsync<int>("4 + 3");
             var someObject = await page.EvaluateFunctionAsync<JsonElement>("(value) => ({a: value})", 5);

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/ElementHandleScreenshotTests.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
         [Test, Retry(2), PuppeteerTest("screenshot.spec", "Screenshots ElementHandle.screenshot", "should work")]
         public async Task ShouldWork()
         {
-            #region SetViewportAsync
+            #region setviewportasync_example
             await Page.SetViewportAsync(new ViewPortOptions
             {
                 Width = 500,

--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             {
                 fileInfo.Delete();
             }
-            #region ScreenshotAsync
+            #region screenshotasync_example
             var browserFetcher = new BrowserFetcher();
             await browserFetcher.DownloadAsync();
             await using var browser = await Puppeteer.LaunchAsync(

--- a/lib/PuppeteerSharp/BrowserData/JsonUtils.cs
+++ b/lib/PuppeteerSharp/BrowserData/JsonUtils.cs
@@ -5,7 +5,7 @@ using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.BrowserData
 {
-    internal class JsonUtils
+    internal static class JsonUtils
     {
         public static async Task<T> GetAsync<T>(string url)
         {

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -31,6 +31,9 @@ namespace PuppeteerSharp
         public string Id { get; init; }
 
         /// <inheritdoc/>
+        public string CloseReason { get; protected set; }
+
+        /// <inheritdoc/>
         public ILoggerFactory LoggerFactory => Connection.LoggerFactory;
 
         internal Connection Connection { get; set; }

--- a/lib/PuppeteerSharp/Cdp/CdpCDPSession.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpCDPSession.cs
@@ -40,7 +40,6 @@ public class CdpCDPSession : CDPSession
     private readonly ConcurrentDictionary<int, MessageTask> _callbacks = new();
     private readonly string _parentSessionId;
     private readonly TargetType _targetType;
-    private string _closeReason;
     private int _lastId;
 
     internal CdpCDPSession(Connection connection, TargetType targetType, string sessionId, string parentSessionId)
@@ -79,8 +78,8 @@ public class CdpCDPSession : CDPSession
             throw new TargetClosedException(
                 $"Protocol error ({method}): Session closed. " +
                 $"Most likely the {_targetType} has been closed." +
-                $"Close reason: {_closeReason}",
-                _closeReason);
+                $"Close reason: {CloseReason}",
+                CloseReason);
         }
 
         var id = GetMessageId();
@@ -147,7 +146,7 @@ public class CdpCDPSession : CDPSession
             return;
         }
 
-        _closeReason = closeReason;
+        CloseReason = closeReason;
         IsClosed = true;
 
         foreach (var callback in _callbacks.Values.ToArray())

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -29,7 +29,7 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         IFrame frame,
         string interceptionId,
         bool allowInterception,
-        RequestWillBeSentPayload data,
+        RequestWillBeSentResponse data,
         List<IRequest> redirectChain,
         ILoggerFactory loggerFactory)
     {

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -42,7 +42,7 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         Url = data.Request.Url;
         ResourceType = data.Type ?? ResourceType.Other;
         Method = data.Request.Method;
-        PostData = data.Request.PostData.ToString();
+        PostData = data.Request.PostData?.ToString();
         HasPostData = data.Request.HasPostData ?? false;
 
         Frame = frame;

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -42,7 +42,7 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         Url = data.Request.Url;
         ResourceType = data.Type ?? ResourceType.Other;
         Method = data.Request.Method;
-        PostData = data.Request.PostData;
+        PostData = data.Request.PostData.ToString();
         HasPostData = data.Request.HasPostData ?? false;
 
         Frame = frame;

--- a/lib/PuppeteerSharp/Cdp/Connection.cs
+++ b/lib/PuppeteerSharp/Cdp/Connection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/lib/PuppeteerSharp/Cdp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/Cdp/LifecycleWatcher.cs
@@ -110,7 +110,14 @@ namespace PuppeteerSharp.Cdp
             var frame = sender as Frame;
             if (_frame == frame)
             {
-                Terminate(new PuppeteerException("Navigating frame was detached"));
+                var message = "Navigating frame was detached";
+
+                if (!string.IsNullOrEmpty(frame?.Client?.CloseReason))
+                {
+                    message += $": {frame.Client.CloseReason}";
+                }
+
+                Terminate(new PuppeteerException(message));
                 return;
             }
 

--- a/lib/PuppeteerSharp/Cdp/Messaging/FetchRequestPausedResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/FetchRequestPausedResponse.cs
@@ -1,6 +1,6 @@
 namespace PuppeteerSharp.Cdp.Messaging
 {
-    internal class FetchRequestPausedResponse : RequestWillBeSentPayload
+    internal class FetchRequestPausedResponse : RequestWillBeSentResponse
     {
         public ResourceType? ResourceType { get; set; }
     }

--- a/lib/PuppeteerSharp/Cdp/Messaging/Request.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/Request.cs
@@ -1,0 +1,39 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+namespace PuppeteerSharp.Cdp.Messaging;
+
+using System.Collections.Generic;
+using System.Net.Http;
+
+internal class Request
+{
+    public HttpMethod Method { get; set; }
+
+    public object PostData { get; set; }
+
+    public Dictionary<string, string> Headers { get; set; } = [];
+
+    public string Url { get; set; }
+
+    public bool? HasPostData { get; set; }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/RequestWillBeSentResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/RequestWillBeSentResponse.cs
@@ -1,12 +1,12 @@
 namespace PuppeteerSharp.Cdp.Messaging
 {
-    internal class RequestWillBeSentPayload
+    internal class RequestWillBeSentResponse
     {
         public string RequestId { get; set; }
 
         public string LoaderId { get; set; }
 
-        public Payload Request { get; set; }
+        public Request Request { get; set; }
 
         public ResponsePayload RedirectResponse { get; set; }
 

--- a/lib/PuppeteerSharp/Cdp/NetworkEventManager.cs
+++ b/lib/PuppeteerSharp/Cdp/NetworkEventManager.cs
@@ -7,7 +7,7 @@ namespace PuppeteerSharp.Cdp
 {
     internal class NetworkEventManager
     {
-        private readonly ConcurrentDictionary<string, RequestWillBeSentPayload> _requestWillBeSentMap = new();
+        private readonly ConcurrentDictionary<string, RequestWillBeSentResponse> _requestWillBeSentMap = new();
         private readonly ConcurrentDictionary<string, FetchRequestPausedResponse> _requestPausedMap = new();
         private readonly ConcurrentDictionary<string, CdpHttpRequest> _httpRequestsMap = new();
         private readonly ConcurrentDictionary<string, QueuedEventGroup> _queuedEventGroupMap = new();
@@ -59,10 +59,10 @@ namespace PuppeteerSharp.Cdp
             return result;
         }
 
-        internal void StoreRequestWillBeSent(string networkRequestId, RequestWillBeSentPayload e)
+        internal void StoreRequestWillBeSent(string networkRequestId, RequestWillBeSentResponse e)
             => _requestWillBeSentMap.AddOrUpdate(networkRequestId, e, (_, _) => e);
 
-        internal RequestWillBeSentPayload GetRequestWillBeSent(string networkRequestId)
+        internal RequestWillBeSentResponse GetRequestWillBeSent(string networkRequestId)
         {
             _requestWillBeSentMap.TryGetValue(networkRequestId, out var result);
             return result;

--- a/lib/PuppeteerSharp/Cdp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/Cdp/NetworkManager.cs
@@ -173,7 +173,7 @@ namespace PuppeteerSharp.Cdp
                         await OnAuthRequiredAsync(client, e.MessageData.ToObject<FetchAuthRequiredResponse>()).ConfigureAwait(false);
                         break;
                     case "Network.requestWillBeSent":
-                        await OnRequestWillBeSentAsync(client, e.MessageData.ToObject<RequestWillBeSentPayload>()).ConfigureAwait(false);
+                        await OnRequestWillBeSentAsync(client, e.MessageData.ToObject<RequestWillBeSentResponse>()).ConfigureAwait(false);
                         break;
                     case "Network.requestServedFromCache":
                         OnRequestServedFromCache(e.MessageData.ToObject<RequestServedFromCacheResponse>());
@@ -462,7 +462,7 @@ namespace PuppeteerSharp.Cdp
             _ = request.FinalizeInterceptionsAsync();
         }
 
-        private async Task OnRequestAsync(CDPSession client, RequestWillBeSentPayload e, string fetchRequestId)
+        private async Task OnRequestAsync(CDPSession client, RequestWillBeSentResponse e, string fetchRequestId)
         {
             CdpHttpRequest request;
             var redirectChain = new List<IRequest>();
@@ -549,7 +549,7 @@ namespace PuppeteerSharp.Cdp
             RequestFinished?.Invoke(this, new RequestEventArgs(request));
         }
 
-        private async Task OnRequestWillBeSentAsync(CDPSession client, RequestWillBeSentPayload e)
+        private async Task OnRequestWillBeSentAsync(CDPSession client, RequestWillBeSentResponse e)
         {
             // Request interception doesn't happen for data URLs with Network Service.
             if (_userRequestInterceptionEnabled && !e.Request.Url.StartsWith("data:", StringComparison.InvariantCultureIgnoreCase))
@@ -571,7 +571,7 @@ namespace PuppeteerSharp.Cdp
             await OnRequestAsync(client, e, null).ConfigureAwait(false);
         }
 
-        private void PatchRequestEventHeaders(RequestWillBeSentPayload requestWillBeSentEvent, FetchRequestPausedResponse requestPausedEvent)
+        private void PatchRequestEventHeaders(RequestWillBeSentResponse requestWillBeSentEvent, FetchRequestPausedResponse requestPausedEvent)
         {
             foreach (var kv in requestPausedEvent.Request.Headers)
             {

--- a/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
@@ -165,7 +165,7 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(RemoteObjectSubtype))]
 [JsonSerializable(typeof(RemoteObjectType))]
 [JsonSerializable(typeof(RequestServedFromCacheResponse))]
-[JsonSerializable(typeof(RequestWillBeSentPayload))]
+[JsonSerializable(typeof(RequestWillBeSentResponse))]
 [JsonSerializable(typeof(ResponsePayload))]
 [JsonSerializable(typeof(ResponseReceivedExtraInfoResponse))]
 [JsonSerializable(typeof(ResponseReceivedResponse))]

--- a/lib/PuppeteerSharp/ICDPSession.cs
+++ b/lib/PuppeteerSharp/ICDPSession.cs
@@ -61,6 +61,11 @@ namespace PuppeteerSharp
         string Id { get; }
 
         /// <summary>
+        /// Close reason if the session has been closed.
+        /// </summary>
+        string CloseReason { get; }
+
+        /// <summary>
         /// Detaches session from target. Once detached, session won't emit any events and can't be used to send messages.
         /// </summary>
         /// <returns>A Task that when awaited detaches from the session target.</returns>

--- a/lib/PuppeteerSharp/IRequest.cs
+++ b/lib/PuppeteerSharp/IRequest.cs
@@ -67,7 +67,7 @@ namespace PuppeteerSharp
         /// Gets the post data.
         /// </summary>
         /// <value>The post data.</value>
-        object PostData { get; }
+        string PostData { get; }
 
         /// <summary>
         /// Gets the HTTP headers.

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>19.0.2</PackageVersion>
-    <ReleaseVersion>19.0.2</ReleaseVersion>
-    <AssemblyVersion>19.0.2</AssemblyVersion>
-    <FileVersion>19.0.2</FileVersion>
+    <PackageVersion>19.0.3</PackageVersion>
+    <ReleaseVersion>19.0.3</ReleaseVersion>
+    <AssemblyVersion>19.0.3</AssemblyVersion>
+    <FileVersion>19.0.3</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>19.0.3</PackageVersion>
-    <ReleaseVersion>19.0.3</ReleaseVersion>
-    <AssemblyVersion>19.0.3</AssemblyVersion>
-    <FileVersion>19.0.3</FileVersion>
+    <PackageVersion>20.0.0</PackageVersion>
+    <ReleaseVersion>20.0.0</ReleaseVersion>
+    <AssemblyVersion>20.0.0</AssemblyVersion>
+    <FileVersion>20.0.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>

--- a/lib/PuppeteerSharp/RedirectInfo.cs
+++ b/lib/PuppeteerSharp/RedirectInfo.cs
@@ -4,7 +4,7 @@ namespace PuppeteerSharp
 {
     internal class RedirectInfo
     {
-        public RequestWillBeSentPayload Event { get; set; }
+        public RequestWillBeSentResponse Event { get; set; }
 
         public string FetchRequestId { get; set; }
     }

--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -38,7 +38,7 @@ namespace PuppeteerSharp
         public HttpMethod Method { get; internal init; }
 
         /// <inheritdoc/>
-        public object PostData { get; internal init; }
+        public string PostData { get; internal init; }
 
         /// <inheritdoc/>
         public Dictionary<string, string> Headers { get; internal init; }


### PR DESCRIPTION
# Description

We are adding the close reason to the `Navigating frame was detached`  exception to improve debugging.
A new `Request` class was created for the CDP protocol to separate it from the `Payload` used in the API. This internal class has the `PostData` as an object instead of a string to handle Unicode messages. This property is used to initialize `Request.PostData`, which is already an `object`.

closes #2693