### PR TITLE
Implement IAsyncDisposable / IDisposable on IBrowserContext

### DIFF
--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -87,7 +87,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         public async Task ShouldIsolatePermissionsBetweenBrowserContexts()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
-            var otherContext = await Browser.CreateBrowserContextAsync();
+            await using var otherContext = await Browser.CreateBrowserContextAsync();
             var otherPage = await otherContext.NewPageAsync();
             await otherPage.GoToAsync(TestConstants.EmptyPage);
             Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
@@ -101,8 +101,6 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             await Context.ClearPermissionOverridesAsync();
             Assert.That(await GetPermissionAsync(Page, "geolocation"), Is.EqualTo("prompt"));
             Assert.That(await GetPermissionAsync(otherPage, "geolocation"), Is.EqualTo("granted"));
-
-            await otherContext.CloseAsync();
         }
 
         [Test, Ignore("Fails on Firefox")]

--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextTests.cs
@@ -47,7 +47,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "window.open should use parent tab context")]
         public async Task WindowOpenShouldUseParentTabContext()
         {
-            var context = await Browser.CreateBrowserContextAsync();
+            await using var context = await Browser.CreateBrowserContextAsync();
             var page = await context.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
             var popupTargetCompletion = new TaskCompletionSource<ITarget>();
@@ -60,13 +60,12 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
 
             var popupTarget = await popupTargetCompletion.Task;
             Assert.That(popupTarget.BrowserContext, Is.SameAs(context));
-            await context.CloseAsync();
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "should fire target events")]
         public async Task ShouldFireTargetEvents()
         {
-            var context = await Browser.CreateBrowserContextAsync();
+            await using var context = await Browser.CreateBrowserContextAsync();
             var events = new List<string>();
             context.TargetCreated += (_, e) => events.Add("CREATED: " + e.Target.Url);
             context.TargetChanged += (_, e) => events.Add("CHANGED: " + e.Target.Url);
@@ -82,7 +81,6 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
                 $"CHANGED: {TestConstants.EmptyPage}",
                 $"DESTROYED: {TestConstants.EmptyPage}"
             }));
-            await context.CloseAsync();
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "should isolate localStorage and cookies")]
@@ -135,7 +133,7 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
         public async Task ShouldWorkAcrossSessions()
         {
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
-            var context = await Browser.CreateBrowserContextAsync();
+            await using var context = await Browser.CreateBrowserContextAsync();
             Assert.That(Browser.BrowserContexts(), Has.Length.EqualTo(2));
 
             var remoteBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
@@ -145,7 +143,6 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             var contexts = remoteBrowser.BrowserContexts();
             Assert.That(contexts, Has.Length.EqualTo(2));
             remoteBrowser.Disconnect();
-            await context.CloseAsync();
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "should provide a context id")]
@@ -154,32 +151,29 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             Assert.That(Browser.BrowserContexts(), Has.Exactly(1).Items);
             Assert.That(Browser.BrowserContexts()[0].Id, Is.Null);
 
-            var context = await Browser.CreateBrowserContextAsync();
+            await using var context = await Browser.CreateBrowserContextAsync();
             Assert.That(Browser.BrowserContexts(), Has.Length.EqualTo(2));
             Assert.That(Browser.BrowserContexts()[1].Id, Is.Not.Null);
-            await context.CloseAsync();
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "should wait for a target")]
         public async Task ShouldWaitForTarget()
         {
-            var context = await Browser.CreateBrowserContextAsync();
+            await using var context = await Browser.CreateBrowserContextAsync();
             var targetPromise = context.WaitForTargetAsync((target) => target.Url == TestConstants.EmptyPage);
             var page = await context.NewPageAsync();
             await page.GoToAsync(TestConstants.EmptyPage);
             var promiseTarget = await targetPromise;
             var targetPage = await promiseTarget.PageAsync();
             Assert.That(page, Is.EqualTo(targetPage));
-            await context.CloseAsync();
         }
 
         [Test, Retry(2), PuppeteerTest("browsercontext.spec", "BrowserContext", "should timeout waiting for a non-existent target")]
         public async Task ShouldTimeoutWaitingForNonExistentTarget()
         {
-            var context = await Browser.CreateBrowserContextAsync();
+            await using var context = await Browser.CreateBrowserContextAsync();
             Assert.ThrowsAsync<TimeoutException>(()
                 => context.WaitForTargetAsync((target) => target.Url == TestConstants.EmptyPage, new WaitForOptions(1)));
-            await context.CloseAsync();
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Tests.CookiesTests
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should isolate cookies in browser contexts")]
         public async Task ShouldIsolateCookiesInBrowserContexts()
         {
-            var anotherContext = await Browser.CreateBrowserContextAsync();
+            await using var anotherContext = await Browser.CreateBrowserContextAsync();
             var anotherPage = await anotherContext.NewPageAsync();
 
             await Page.GoToAsync(TestConstants.EmptyPage);
@@ -53,8 +53,6 @@ namespace PuppeteerSharp.Tests.CookiesTests
             Assert.That(cookies1[0].Value, Is.EqualTo("page1value"));
             Assert.That(cookies2[0].Name, Is.EqualTo("page2cookie"));
             Assert.That(cookies2[0].Value, Is.EqualTo("page2value"));
-
-            await anotherContext.CloseAsync();
         }
 
         [Test, Retry(2), PuppeteerTest("cookies.spec", "Cookie specs Page.setCookie", "should set multiple cookies")]

--- a/lib/PuppeteerSharp/BrowserContext.cs
+++ b/lib/PuppeteerSharp/BrowserContext.cs
@@ -51,10 +51,33 @@ namespace PuppeteerSharp
         /// <inheritdoc/>
         public abstract Task ClearPermissionOverridesAsync();
 
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Closes the browser context. All the targets that belong to the browser context will be closed.
+        /// </summary>
+        /// <returns>ValueTask.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            await CloseAsync().ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
         internal void OnTargetCreated(Browser browser, TargetChangedArgs args) => TargetCreated?.Invoke(browser, args);
 
         internal void OnTargetDestroyed(Browser browser, TargetChangedArgs args) => TargetDestroyed?.Invoke(browser, args);
 
         internal void OnTargetChanged(Browser browser, TargetChangedArgs args) => TargetChanged?.Invoke(browser, args);
+
+        /// <summary>
+        /// Closes the browser context. All the targets that belong to the browser context will be closed.
+        /// </summary>
+        /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
+        protected virtual void Dispose(bool disposing) => _ = CloseAsync();
     }
 }

--- a/lib/PuppeteerSharp/IBrowserContext.cs
+++ b/lib/PuppeteerSharp/IBrowserContext.cs
@@ -8,7 +8,7 @@ namespace PuppeteerSharp
     /// BrowserContexts provide a way to operate multiple independent browser sessions. When a browser is launched, it has
     /// a single <see cref="IBrowserContext"/> used by default. The method <see cref="IBrowser.NewPageAsync"/> creates a <see cref="IPage"/> in the default <see cref="IBrowserContext"/>.
     /// </summary>
-    public interface IBrowserContext
+    public interface IBrowserContext : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Raised when the url of a target changes


### PR DESCRIPTION
Makes it more convenient to use and aligns with upstream implementation:

https://github.com/puppeteer/puppeteer/blob/3ad2e45c295083de6fc72a5041138c620615b755/packages/puppeteer-core/src/api/BrowserContext.ts#L260-L268

In the second commit I also updated some tests. Looks like this wasn't done upstream so please let me know if I should remove it.