### PR TITLE
Use object for Top / Left / Bottom / Right in MarginOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ await page.GoToAsync("http://www.google.com"); // In case of fonts being loaded 
 await page.EvaluateExpressionHandleAsync("document.fonts.ready"); // Wait for fonts to be loaded. Omitting this might result in no text rendered in pdf.
 await page.PdfAsync(outputFile);
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L23-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs#L24-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-pdfasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Inject HTML

--- a/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
@@ -127,6 +127,8 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var pdfOptions = new PdfOptions
             {
+                Width = 100,
+                Height = 100,
                 Format = PaperFormat.A4,
                 DisplayHeaderFooter = true,
                 MarginOptions = new MarginOptions
@@ -135,28 +137,6 @@ namespace PuppeteerSharp.Tests.PageTests
                     Right = "20px",
                     Bottom = "40px",
                     Left = "20px"
-                },
-                FooterTemplate = "<div id=\"footer-template\" style=\"font-size:10px !important; color:#808080; padding-left:10px\">- <span class=\"pageNumber\"></span> - </div>"
-            };
-
-            var serialized = JsonSerializer.Serialize(pdfOptions);
-            var newPdfOptions = JsonSerializer.Deserialize<PdfOptions>(serialized);
-            Assert.That(newPdfOptions, Is.EqualTo(pdfOptions));
-        }
-
-        [Test]
-        public void PdfOptionsShouldWorkWithMarginWithNoUnits()
-        {
-            var pdfOptions = new PdfOptions
-            {
-                Format = PaperFormat.A4,
-                DisplayHeaderFooter = true,
-                MarginOptions = new MarginOptions
-                {
-                    Top = "0",
-                    Right = "0",
-                    Bottom = "0",
-                    Left = "0"
                 },
                 FooterTemplate = "<div id=\"footer-template\" style=\"font-size:10px !important; color:#808080; padding-left:10px\">- <span class=\"pageNumber\"></span> - </div>"
             };

--- a/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using PuppeteerSharp.Cdp;
 using PuppeteerSharp.Media;
 using PuppeteerSharp.Nunit;
 
@@ -147,25 +148,13 @@ namespace PuppeteerSharp.Tests.PageTests
         }
 
         [Test]
-        public void PdfOptionsShouldWorkWithMarginWithNoUnits()
+        public void ConvertPrintParameterToInchesTests()
         {
-            var pdfOptions = new PdfOptions
-            {
-                Format = PaperFormat.A4,
-                DisplayHeaderFooter = true,
-                MarginOptions = new MarginOptions
-                {
-                    Top = "0",
-                    Right = "0",
-                    Bottom = "0",
-                    Left = "0"
-                },
-                FooterTemplate = "<div id=\"footer-template\" style=\"font-size:10px !important; color:#808080; padding-left:10px\">- <span class=\"pageNumber\"></span> - </div>"
-            };
-
-            var serialized = JsonSerializer.Serialize(pdfOptions);
-            var newPdfOptions = JsonSerializer.Deserialize<PdfOptions>(serialized);
-            Assert.That(newPdfOptions, Is.EqualTo(pdfOptions));
+            Assert.That(CdpPage.ConvertPrintParameterToInches("10"), Is.EqualTo(10m / 96));
+            Assert.That(CdpPage.ConvertPrintParameterToInches("10px"), Is.EqualTo(10m / 96));
+            Assert.That(CdpPage.ConvertPrintParameterToInches("0"), Is.EqualTo(0));
+            Assert.That(CdpPage.ConvertPrintParameterToInches("0px"), Is.EqualTo(0));
+            Assert.That(CdpPage.ConvertPrintParameterToInches("10in"), Is.EqualTo(10));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PdfTests.cs
@@ -145,5 +145,27 @@ namespace PuppeteerSharp.Tests.PageTests
             var newPdfOptions = JsonSerializer.Deserialize<PdfOptions>(serialized);
             Assert.That(newPdfOptions, Is.EqualTo(pdfOptions));
         }
+
+        [Test]
+        public void PdfOptionsShouldWorkWithMarginWithNoUnits()
+        {
+            var pdfOptions = new PdfOptions
+            {
+                Format = PaperFormat.A4,
+                DisplayHeaderFooter = true,
+                MarginOptions = new MarginOptions
+                {
+                    Top = "0",
+                    Right = "0",
+                    Bottom = "0",
+                    Left = "0"
+                },
+                FooterTemplate = "<div id=\"footer-template\" style=\"font-size:10px !important; color:#808080; padding-left:10px\">- <span class=\"pageNumber\"></span> - </div>"
+            };
+
+            var serialized = JsonSerializer.Serialize(pdfOptions);
+            var newPdfOptions = JsonSerializer.Deserialize<PdfOptions>(serialized);
+            Assert.That(newPdfOptions, Is.EqualTo(pdfOptions));
+        }
     }
 }

--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -13,7 +13,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "128.0.6613.119";
+        public static string DefaultBuildId => "129.0.6668.100";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;

--- a/lib/PuppeteerSharp/Helpers/Json/PrimitiveTypeConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/PrimitiveTypeConverter.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PuppeteerSharp.Helpers.Json
+{
+    // Support types used in PdfOptions / MarginOptions: string, decimal, int
+    internal sealed class PrimitiveTypeConverter : JsonConverter<object>
+    {
+        public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+            else if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var i))
+                {
+                    return i;
+                }
+                else if (reader.TryGetDecimal(out var dec))
+                {
+                    return dec;
+                }
+            }
+
+            return JsonSerializer.Deserialize(ref reader, typeToConvert, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else if (value is string str)
+            {
+                writer.WriteStringValue(str);
+            }
+            else if (value is decimal dec)
+            {
+                writer.WriteNumberValue(dec);
+            }
+            else if (value is int i)
+            {
+                writer.WriteNumberValue(i);
+            }
+            else
+            {
+                JsonSerializer.Serialize(writer, value, options);
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Helpers/Json/PrimitiveTypeConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/PrimitiveTypeConverter.cs
@@ -6,7 +6,11 @@ using System.Text.Json.Serialization;
 
 namespace PuppeteerSharp.Helpers.Json
 {
-    // Support types used in PdfOptions / MarginOptions: string, decimal, int
+    /// <summary>
+    /// Support types (<see cref="decimal"/>, <see cref="int"/> and <see cref="string"/>)
+    /// used by <see cref="PdfOptions"/> and <see cref="Media.MarginOptions"/> for serialization / deserialization.
+    /// For usecases like <see href="https://github.com/hardkoded/puppeteer-sharp/issues/1001"/>.
+    /// </summary>
     internal sealed class PrimitiveTypeConverter : JsonConverter<object>
     {
         public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/lib/PuppeteerSharp/Media/MarginOptions.cs
+++ b/lib/PuppeteerSharp/Media/MarginOptions.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Media
 {
     /// <summary>
     /// margin options used in <see cref="PdfOptions"/>.
     /// </summary>
-    public class MarginOptions : IEquatable<MarginOptions>
+    public record MarginOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PuppeteerSharp.Media.MarginOptions"/> class.
@@ -18,61 +18,25 @@ namespace PuppeteerSharp.Media
         /// <summary>
         /// Top margin, accepts values labeled with units.
         /// </summary>
-        public string Top { get; set; }
+        [JsonConverter(typeof(PrimitiveTypeConverter))]
+        public object Top { get; set; }
 
         /// <summary>
         /// Left margin, accepts values labeled with units.
         /// </summary>
-        public string Left { get; set; }
+        [JsonConverter(typeof(PrimitiveTypeConverter))]
+        public object Left { get; set; }
 
         /// <summary>
         /// Bottom margin, accepts values labeled with units.
         /// </summary>
-        public string Bottom { get; set; }
+        [JsonConverter(typeof(PrimitiveTypeConverter))]
+        public object Bottom { get; set; }
 
         /// <summary>
         /// Right margin, accepts values labeled with units.
         /// </summary>
-        public string Right { get; set; }
-
-        /// <summary>Overriding == operator for <see cref="MarginOptions"/>.</summary>
-        /// <param name="left">the value to compare against <paramref name="right" />.</param>
-        /// <param name="right">the value to compare against <paramref name="left" />.</param>
-        /// <returns><c>true</c> if the two instances are equal to the same value.</returns>
-        public static bool operator ==(MarginOptions left, MarginOptions right)
-            => EqualityComparer<MarginOptions>.Default.Equals(left, right);
-
-        /// <summary>Overriding != operator for <see cref="MarginOptions"/>.</summary>
-        /// <param name="left">the value to compare against <paramref name="right" />.</param>
-        /// <param name="right">the value to compare against <paramref name="left" />.</param>
-        /// <returns><c>true</c> if the two instances are not equal to the same value.</returns>
-        public static bool operator !=(MarginOptions left, MarginOptions right) => !(left == right);
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj)
-        {
-            if (obj == null || GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            return Equals((MarginOptions)obj);
-        }
-
-        /// <inheritdoc/>
-        public bool Equals(MarginOptions options)
-            => options != null &&
-                   Top == options.Top &&
-                   Left == options.Left &&
-                   Bottom == options.Bottom &&
-                   Right == options.Right;
-
-        /// <inheritdoc/>
-        public override int GetHashCode()
-            => -481391125
-                ^ EqualityComparer<string>.Default.GetHashCode(Top)
-                ^ EqualityComparer<string>.Default.GetHashCode(Left)
-                ^ EqualityComparer<string>.Default.GetHashCode(Bottom)
-                ^ EqualityComparer<string>.Default.GetHashCode(Right);
+        [JsonConverter(typeof(PrimitiveTypeConverter))]
+        public object Right { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -1,13 +1,10 @@
-using System;
-using System.Collections.Generic;
-
 namespace PuppeteerSharp.Media
 {
     /// <summary>
     /// Paper format.
     /// </summary>
     /// <seealso cref="PdfOptions.Format"/>
-    public class PaperFormat : IEquatable<PaperFormat>
+    public record PaperFormat
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PaperFormat"/> class.
@@ -87,41 +84,5 @@ namespace PuppeteerSharp.Media
         /// </summary>
         /// <value>The Height.</value>
         public decimal Height { get; set; }
-
-        /// <summary>Overriding == operator for <see cref="PaperFormat"/>. </summary>
-        /// <param name="left">the value to compare against <paramref name="right" />.</param>
-        /// <param name="right">the value to compare against <paramref name="left" />.</param>
-        /// <returns><c>true</c> if the two instances are equal to the same value.</returns>
-        public static bool operator ==(PaperFormat left, PaperFormat right)
-            => EqualityComparer<PaperFormat>.Default.Equals(left, right);
-
-        /// <summary>Overriding != operator for <see cref="PaperFormat"/>. </summary>
-        /// <param name="left">the value to compare against <paramref name="right" />.</param>
-        /// <param name="right">the value to compare against <paramref name="left" />.</param>
-        /// <returns><c>true</c> if the two instances are not equal to the same value.</returns>
-        public static bool operator !=(PaperFormat left, PaperFormat right) => !(left == right);
-
-        /// <inheritdoc/>
-        public override bool Equals(object obj)
-        {
-            if (obj == null || GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            return Equals((PaperFormat)obj);
-        }
-
-        /// <inheritdoc/>
-        public bool Equals(PaperFormat format)
-            => format != null &&
-                   Width == format.Width &&
-                   Height == format.Height;
-
-        /// <inheritdoc/>
-        public override int GetHashCode()
-            => 859600377
-                ^ Width.GetHashCode()
-                ^ Height.GetHashCode();
     }
 }

--- a/lib/PuppeteerSharp/PdfOptions.cs
+++ b/lib/PuppeteerSharp/PdfOptions.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Media;
 
 namespace PuppeteerSharp
@@ -67,11 +69,13 @@ namespace PuppeteerSharp
         /// <summary>
         /// Paper width, accepts values labeled with units.
         /// </summary>
+        [JsonConverter(typeof(PrimitiveTypeConverter))]
         public object Width { get; set; }
 
         /// <summary>
         /// Paper height, accepts values labeled with units.
         /// </summary>
+        [JsonConverter(typeof(PrimitiveTypeConverter))]
         public object Height { get; set; }
 
         /// <summary>

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />


### PR DESCRIPTION
Because:

1. [Upstream `PDFMargin` uses `string | number`](https://github.com/puppeteer/puppeteer/blob/3ad2e45c295083de6fc72a5041138c620615b755/packages/puppeteer-core/src/common/PDFOptions.ts#L10-L15)
2. [`PDFOptions.Width` / `PDFOptions.Height` also use `string | number` upstream](https://github.com/puppeteer/puppeteer/blob/3ad2e45c295083de6fc72a5041138c620615b755/packages/puppeteer-core/src/common/PDFOptions.ts#L125-L132)
3. `PdfOptions.Width` / `PdfOptions.Height` using `object` https://github.com/hardkoded/puppeteer-sharp/blob/e14f59da8d95536e0002efa13f451f2dc5c1c762/lib/PuppeteerSharp/PdfOptions.cs#L67-L75
4. All of these properties were already going to `ConvertPrintParameterToInches` https://github.com/hardkoded/puppeteer-sharp/blob/e14f59da8d95536e0002efa13f451f2dc5c1c762/lib/PuppeteerSharp/Cdp/CdpPage.cs#L791-L807

---

`PdfOptionsShouldBeSerializable` didn't actually test `Width` / `Height` which meant that serialisation was broken by the migration to `System.Text.Json`.
I added a simple `PrimitiveTypeConverter` to support https://github.com/hardkoded/puppeteer-sharp/issues/1001

---

`PdfOptionsShouldWorkWithMarginWithNoUnits` didn't actually test the `ConvertPrintParameterToInches` logic so I have removed it. It was just testing what `PdfOptionsShouldBeSerializable` already did.

---

Also made `MarginOptions` / `PaperFormat` records.