### PR TITLE
Use type forwarding for IsExternalInit on .net8 target

### DIFF
--- a/lib/PuppeteerSharp/IsExternalInit.cs
+++ b/lib/PuppeteerSharp/IsExternalInit.cs
@@ -1,6 +1,13 @@
+#if !NETSTANDARD2_0
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+#else
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
+    [EditorBrowsable(EditorBrowsableState.Never)]
     internal static class IsExternalInit
     {
     }
 }
+#endif


### PR DESCRIPTION
Added conditional compilation to use type forwarding for net8.0 target as suggested here - https://github.com/dotnet/runtime/issues/79082#issuecomment-1333716389. Required to correctly handle public init properties.