### PR TITLE
Remove duplication of partitionKey that resulted in invalid json

### DIFF
--- a/lib/PuppeteerSharp/Helpers/Json/CookiePartitionKeyConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/CookiePartitionKeyConverter.cs
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Helpers.Json
         {
             if (value != null && writer != null)
             {
-                writer.WriteStartObject("partitionKey");
+                writer.WriteStartObject();
                 writer.WriteString("topLevelSite", value);
                 writer.WriteBoolean("hasCrossSiteAncestor", false);
                 writer.WriteEndObject();


### PR DESCRIPTION
Cookies having Partition Keys are serialized incorrectly leading to errors when sending such cookies to the browser due to invalid json.