### PR TITLE
Reduce memory allocations in LowSurrogateConverter for .NET 8

### DIFF
--- a/lib/PuppeteerSharp/Helpers/Json/LowSurrogateConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/LowSurrogateConverter.cs
@@ -15,14 +15,14 @@ internal class LowSurrogateConverter : JsonConverter<string>
             return null;
         }
 
-        var valueSpan = reader.HasValueSequence
+        var span = reader.HasValueSequence
             ? reader.ValueSequence.ToArray()
 #if NET8_0_OR_GREATER
             : reader.ValueSpan;
 #else
             : reader.ValueSpan.ToArray();
 #endif
-        var value = Encoding.UTF8.GetString(valueSpan);
+        var value = Encoding.UTF8.GetString(span);
 
         try
         {

--- a/lib/PuppeteerSharp/Helpers/Json/LowSurrogateConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/LowSurrogateConverter.cs
@@ -15,8 +15,14 @@ internal class LowSurrogateConverter : JsonConverter<string>
             return null;
         }
 
-        var span = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan.ToArray();
-        var value = Encoding.UTF8.GetString(span);
+        var valueSpan = reader.HasValueSequence
+            ? reader.ValueSequence.ToArray()
+#if NET8_0_OR_GREATER
+            : reader.ValueSpan;
+#else
+            : reader.ValueSpan.ToArray();
+#endif
+        var value = Encoding.UTF8.GetString(valueSpan);
 
         try
         {


### PR DESCRIPTION
Reduce memory allocations in `LowSurrogateConverter` for .NET 8