### PR TITLE
Restore runtime compatibility with System.Text.Json 6.0

### DIFF
--- a/lib/PuppeteerSharp/Helpers/Json/LowSurrogateConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/LowSurrogateConverter.cs
@@ -20,12 +20,7 @@ internal class LowSurrogateConverter : JsonConverter<string>
 
         try
         {
-            if (reader.ValueIsEscaped)
-            {
-                value = JsonUnescape(value);
-            }
-
-            return value;
+            return JsonUnescapedValue(reader, value);
         }
         catch
         {
@@ -38,9 +33,16 @@ internal class LowSurrogateConverter : JsonConverter<string>
         writer.WriteStringValue(value);
     }
 
-    private static string JsonUnescape(string jsonString)
+    private static string JsonUnescapedValue(Utf8JsonReader reader, string jsonString)
     {
-        using var doc = JsonDocument.Parse($"\"{jsonString}\"");
-        return doc.RootElement.GetString();
+        if (reader.ValueIsEscaped)
+        {
+            using var doc = JsonDocument.Parse($"\"{jsonString}\"");
+            return doc.RootElement.GetString();
+        }
+        else
+        {
+            return jsonString;
+        }
     }
 }


### PR DESCRIPTION
A few clients started reporting a MethodNotFound since v20.1.2, related to ValueIsEscaped property. Turned out these clients were using System.Text.Json 6.0 at runtime, due to an older dependency.
The MethodNotFound is thrown when Read is invoked (as it has to resolve all method references in its body before executing), so it wasn't caught by the try/catch in Read itself.
Moving the ValueIsEscaped call to another method, causes the MethodNotFound to be thrown only when that method is invoked, and is now caught by the try/catch. IMO this fixes compatibility with older versions of the dll without disrupting the codebase.