### PR TITLE
Check executable path exists before skipping download

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -248,7 +248,7 @@ namespace PuppeteerSharp
 
             var outputPath = cache.GetInstallationDir(browser, Platform, buildId);
 
-            if (new DirectoryInfo(outputPath).Exists)
+            if (new FileInfo(GetExecutablePath(buildId)).Exists)
             {
                 var existingBrowser = new InstalledBrowser(cache, browser, buildId, Platform);
                 existingBrowser.PermissionsFixed = RunSetup(existingBrowser);


### PR DESCRIPTION
Came across an issue where the output directory existed but the executable didn't exist, so BrowserFetcher skipped the download.