### PR TITLE
Fix Invalid referrerPolicy error in latest versions of Chromium

### DIFF
--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageGotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageGotoTests.cs
@@ -507,7 +507,7 @@ namespace PuppeteerSharp.Tests.NavigationTests
                 Server.WaitForRequest("/digits/1.png", r => referer2 = r.Headers["Referer"]),
                 Page.GoToAsync(TestConstants.ServerUrl + "/grid.html", new NavigationOptions
                 {
-                    ReferrerPolicy = "no-referer"
+                    ReferrerPolicy = "no-referrer"
                 })
             );
 

--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Cdp.Messaging;
@@ -114,7 +115,7 @@ public class CdpFrame : Frame
             {
                 Url = url,
                 Referrer = referrer ?? string.Empty,
-                ReferrerPolicy = referrerPolicy,
+                ReferrerPolicy = ReferrerPolicyToProtocol(referrerPolicy),
                 FrameId = Id,
             }).ConfigureAwait(false);
 
@@ -335,4 +336,12 @@ public class CdpFrame : Frame
     /// <inheritdoc />
     protected internal override DeviceRequestPromptManager GetDeviceRequestPromptManager()
         => FrameManager.GetDeviceRequestPromptManager(Client);
+
+    // See https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-ReferrerPolicy.
+    private static string ReferrerPolicyToProtocol(string referrerPolicy)
+    {
+        // Transform kebab-case to camelCase
+        return string.IsNullOrEmpty(referrerPolicy) ? null :
+            Regex.Replace(referrerPolicy, "-(.)", match => match.Groups[1].Value.ToUpperInvariant());
+    }
 }


### PR DESCRIPTION
Calling GoToAsync without specifying a ReferrerPolicy option now raises an exception when used with the latest Chromium builds for Linux:

> PuppeteerSharp.MessageException: Protocol error (Page.navigate): Invalid referrerPolicy
   at Helpers.TaskHelper.WithTimeout[T](Task`1 task, TimeSpan timeout, Func`2 exceptionFactory) in Helpers/TaskHelper.cs:line 188
   at Cdp.CdpCDPSession.SendAsync(String method, Object args, Boolean waitForCallback, CommandOptions options) in Cdp/CdpCDPSession.cs:line 113
   at PuppeteerSharp.CDPSession.SendAsync[T](String method, Object args, CommandOptions options) in PuppeteerSharp/CDPSession.cs:line 48
   at PuppeteerSharp.Cdp.CdpFrame.<>c__DisplayClass15_0.<<GoToAsync>g__NavigateAsync|0>d.MoveNext() in /home/runner/work/puppeteer-sharp/puppeteer-sharp/lib/PuppeteerSharp/Cdp/CdpFrame.cs:line 113
   at Cdp.CdpFrame.GoToAsync(String url, NavigationOptions options) in Cdp/CdpFrame.cs:line 95
   at Cdp.CdpFrame.GoToAsync(String url, NavigationOptions options) in Cdp/CdpFrame.cs:line 106

After researching the Chromium codebase, my understanding is that CDP does not accept empty strings for the ReferrerPolicy parameter. This specific validation message seems to originate from https://github.com/chromium/chromium/commit/57103b9ce6ef77bc1fc31a16cad313a8e03d9b6c