### PR TITLE
Disable ReadAnythingOmniboxChip by default

### DIFF
--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -45,6 +45,8 @@ namespace PuppeteerSharp
                 "AcceptCHFrame",
                 "MediaRouter",
                 "OptimizationHints",
+                "IPH_ReadingModePageActionLabel",
+                "ReadAnythingOmniboxChip",
                 "ProcessPerSiteUpToMainFrameThreshold",
             };
 


### PR DESCRIPTION
## Summary
- Port of upstream puppeteer [PR #14621](https://github.com/puppeteer/puppeteer/pull/14621)
- Adds `IPH_ReadingModePageActionLabel` and `ReadAnythingOmniboxChip` to the default disabled Chrome features list
- These features cause Chrome to execute scripts on pages to determine readability, which interferes with JS coverage measurements

## Test plan
- [x] Launcher tests pass (40 passed)
- [x] ChromeLauncher tests pass (9 passed)
- [x] Coverage tests pass (24 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)