### PR TITLE
Enhance accessibility tree snapshot with more properties (#14643)

### DIFF
--- a/lib/PuppeteerSharp.Tests/AccessibilityTests/AccessibilityTests.cs
+++ b/lib/PuppeteerSharp.Tests/AccessibilityTests/AccessibilityTests.cs
@@ -403,6 +403,89 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                 }));
         }
 
+        [Test, PuppeteerTest("accessibility.spec", "Accessibility", "should capture new accessibility properties and not prune them")]
+        public async Task ShouldCaptureNewAccessibilityPropertiesAndNotPruneThem()
+        {
+            await Page.SetContentAsync(@"
+                <div role=""alert"" aria-busy=""true"">This is an alert</div>
+                <div aria-live=""polite"" aria-atomic=""true"" aria-relevant=""additions text"">
+                  This is polite live region
+                </div>
+                <div aria-modal=""true"" role=""dialog"" aria-roledescription=""My Modal"">
+                  Modal content
+                </div>
+                <div id=""error"">Error message</div>
+                <input aria-invalid=""true"" aria-errormessage=""error"" value=""invalid input"">
+                <div id=""details"">Additional details</div>
+                <div aria-details=""details"">Element with details</div>
+                <div aria-description=""This is a description""></div>");
+
+            var snapshot = await Page.Accessibility.SnapshotAsync();
+
+            Assert.That(snapshot.Role, Is.EqualTo("RootWebArea"));
+            Assert.That(snapshot.Children.Length, Is.GreaterThanOrEqualTo(8));
+
+            // alert node with busy, live, atomic
+            var alertNode = snapshot.Children[0];
+            Assert.That(alertNode.Role, Is.EqualTo("alert"));
+            Assert.That(alertNode.Name, Is.EqualTo(string.Empty));
+            Assert.That(alertNode.Busy, Is.True);
+            Assert.That(alertNode.Live, Is.EqualTo("assertive"));
+            Assert.That(alertNode.Atomic, Is.True);
+            Assert.That(alertNode.Children, Has.Length.EqualTo(1));
+            Assert.That(alertNode.Children[0].Role, Is.EqualTo("StaticText"));
+            Assert.That(alertNode.Children[0].Name, Is.EqualTo("This is an alert"));
+
+            // polite live region with atomic and relevant
+            var liveRegionNode = snapshot.Children[1];
+            Assert.That(liveRegionNode.Role, Is.EqualTo("generic"));
+            Assert.That(liveRegionNode.Name, Is.EqualTo(string.Empty));
+            Assert.That(liveRegionNode.Live, Is.EqualTo("polite"));
+            Assert.That(liveRegionNode.Atomic, Is.True);
+            Assert.That(liveRegionNode.Relevant, Is.EqualTo("additions text"));
+            Assert.That(liveRegionNode.Children, Has.Length.EqualTo(1));
+            Assert.That(liveRegionNode.Children[0].Role, Is.EqualTo("StaticText"));
+            Assert.That(liveRegionNode.Children[0].Name, Is.EqualTo("This is polite live region"));
+
+            // dialog with modal and roledescription
+            var dialogNode = snapshot.Children[2];
+            Assert.That(dialogNode.Role, Is.EqualTo("dialog"));
+            Assert.That(dialogNode.Name, Is.EqualTo(string.Empty));
+            Assert.That(dialogNode.Modal, Is.True);
+            Assert.That(dialogNode.RoleDescription, Is.EqualTo("My Modal"));
+            Assert.That(dialogNode.Children, Has.Length.EqualTo(1));
+            Assert.That(dialogNode.Children[0].Role, Is.EqualTo("StaticText"));
+            Assert.That(dialogNode.Children[0].Name, Is.EqualTo("Modal content"));
+
+            // Error message static text
+            Assert.That(snapshot.Children[3].Role, Is.EqualTo("StaticText"));
+            Assert.That(snapshot.Children[3].Name, Is.EqualTo("Error message"));
+
+            // input with invalid and errormessage
+            var inputNode = snapshot.Children[4];
+            Assert.That(inputNode.Role, Is.EqualTo("textbox"));
+            Assert.That(inputNode.Value, Is.EqualTo("invalid input"));
+            Assert.That(inputNode.Invalid, Is.EqualTo("true"));
+            Assert.That(inputNode.Errormessage, Is.EqualTo("error"));
+
+            // Additional details static text
+            Assert.That(snapshot.Children[5].Role, Is.EqualTo("StaticText"));
+            Assert.That(snapshot.Children[5].Name, Is.EqualTo("Additional details"));
+
+            // element with details
+            var detailsNode = snapshot.Children[6];
+            Assert.That(detailsNode.Role, Is.EqualTo("generic"));
+            Assert.That(detailsNode.Details, Is.EqualTo("details"));
+            Assert.That(detailsNode.Children, Has.Length.EqualTo(1));
+            Assert.That(detailsNode.Children[0].Role, Is.EqualTo("StaticText"));
+            Assert.That(detailsNode.Children[0].Name, Is.EqualTo("Element with details"));
+
+            // element with description only (no name)
+            var descriptionNode = snapshot.Children[7];
+            Assert.That(descriptionNode.Role, Is.EqualTo("generic"));
+            Assert.That(descriptionNode.Description, Is.EqualTo("This is a description"));
+        }
+
         private SerializedAXNode FindFocusedNode(SerializedAXNode serializedAXNode)
         {
             if (serializedAXNode.Focused)

--- a/lib/PuppeteerSharp/PageAccessibility/SerializedAXNode.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/SerializedAXNode.cs
@@ -139,6 +139,36 @@ namespace PuppeteerSharp.PageAccessibility
         public string Orientation { get; set; }
 
         /// <summary>
+        /// Whether the node is <see href="https://www.w3.org/TR/wai-aria/#aria-busy">busy</see>.
+        /// </summary>
+        public bool Busy { get; set; }
+
+        /// <summary>
+        /// The <see href="https://www.w3.org/TR/wai-aria/#aria-live">live</see> status of the node.
+        /// </summary>
+        public string Live { get; set; }
+
+        /// <summary>
+        /// Whether the live region is <see href="https://www.w3.org/TR/wai-aria/#aria-atomic">atomic</see>.
+        /// </summary>
+        public bool Atomic { get; set; }
+
+        /// <summary>
+        /// The <see href="https://www.w3.org/TR/wai-aria/#aria-relevant">relevant</see> changes for the live region.
+        /// </summary>
+        public string Relevant { get; set; }
+
+        /// <summary>
+        /// The <see href="https://www.w3.org/TR/wai-aria/#aria-errormessage">error message</see> for the node.
+        /// </summary>
+        public string Errormessage { get; set; }
+
+        /// <summary>
+        /// The <see href="https://www.w3.org/TR/wai-aria/#aria-details">details</see> for the node.
+        /// </summary>
+        public string Details { get; set; }
+
+        /// <summary>
         /// Child nodes of this node, if any.
         /// </summary>
         public SerializedAXNode[] Children { get; set; }
@@ -158,6 +188,12 @@ namespace PuppeteerSharp.PageAccessibility
                     AutoComplete == other.AutoComplete &&
                     HasPopup == other.HasPopup &&
                     Orientation == other.Orientation &&
+                    Busy == other.Busy &&
+                    Live == other.Live &&
+                    Atomic == other.Atomic &&
+                    Relevant == other.Relevant &&
+                    Errormessage == other.Errormessage &&
+                    Details == other.Details &&
                     Disabled == other.Disabled &&
                     Expanded == other.Expanded &&
                     Focused == other.Focused &&
@@ -189,6 +225,12 @@ namespace PuppeteerSharp.PageAccessibility
                 AutoComplete.GetHashCode() ^
                 HasPopup.GetHashCode() ^
                 Orientation.GetHashCode() ^
+                Busy.GetHashCode() ^
+                Live.GetHashCode() ^
+                Atomic.GetHashCode() ^
+                Relevant.GetHashCode() ^
+                Errormessage.GetHashCode() ^
+                Details.GetHashCode() ^
                 Disabled.GetHashCode() ^
                 Expanded.GetHashCode() ^
                 Focused.GetHashCode() ^


### PR DESCRIPTION
## Summary

Ports upstream Puppeteer PR [#14643](https://github.com/puppeteer/puppeteer/pull/14643) which enhances the accessibility tree snapshot with additional properties and improves pruning logic.

### Changes

- **New `SerializedAXNode` properties**: `Busy`, `Live`, `Atomic`, `Relevant`, `Errormessage`, `Details` — exposing live region attributes, relationship attributes, and more from the CDP accessibility tree
- **Improved `IsInteresting` logic**: Nodes with `busy`, `live` (non-off), `modal`, `errormessage`, `details`, or `roledescription` properties are no longer pruned when `interestingOnly` is enabled
- **Leaf node description check**: Leaf nodes with a `description` (but no `name`) are now considered interesting and retained in the snapshot
- **Robust boolean parsing**: Added helper methods to handle CDP boolean properties that may arrive as JSON numbers (e.g., `booleanOrUndefined` AX value types)

### Files changed

- `SerializedAXNode.cs` — 6 new properties, updated `Equals`/`GetHashCode`
- `AXNode.cs` — New fields, updated constructor/`IsInteresting`/`Serialize`, added boolean parsing helpers
- `AccessibilityTests.cs` — New test `ShouldCaptureNewAccessibilityPropertiesAndNotPruneThem`

## Test plan

- [x] New test `ShouldCaptureNewAccessibilityPropertiesAndNotPruneThem` passes
- [x] All 22 accessibility tests pass (Chrome/CDP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)