### PR TITLE
Fix flaky PageGoBackTests.ShouldWork by awaiting navigation response

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -111,7 +111,7 @@ public class CdpFrame : Frame
             throw new NavigationException(ex.Message, ex);
         }
 
-        return watcher.NavigationResponse;
+        return await watcher.NavigationResponseAsync().ConfigureAwait(false);
 
         async Task NavigateAsync()
         {
@@ -149,7 +149,7 @@ public class CdpFrame : Frame
 
         await raceTask.ConfigureAwait(false);
 
-        return watcher.NavigationResponse;
+        return await watcher.NavigationResponseAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/lib/PuppeteerSharp/Cdp/LifecycleWatcher.cs
+++ b/lib/PuppeteerSharp/Cdp/LifecycleWatcher.cs
@@ -26,6 +26,7 @@ namespace PuppeteerSharp.Cdp
         private IRequest _navigationRequest;
         private bool _hasSameDocumentNavigation;
         private bool _swapped;
+        private TaskCompletionSource<bool> _navigationResponseReceived;
 
         public LifecycleWatcher(
             NetworkManager networkManager,
@@ -53,6 +54,8 @@ namespace PuppeteerSharp.Cdp
             frame.FrameSwappedByActivation += FrameSwapped;
             frame.FrameDetached += OnFrameDetached;
             _networkManager.Request += OnRequest;
+            _networkManager.Response += OnResponse;
+            _networkManager.RequestFailed += OnRequestFailed;
             CheckLifecycleComplete();
         }
 
@@ -60,14 +63,23 @@ namespace PuppeteerSharp.Cdp
 
         public Task<bool> NewDocumentNavigationTask => _newDocumentNavigationTaskWrapper.Task;
 
-        public CdpHttpResponse NavigationResponse => (CdpHttpResponse)_navigationRequest?.Response;
-
         public Task TerminationTask => _terminationTaskWrapper.Task.WithTimeout(
             _timeout,
             t => new TimeoutException($"Navigation timeout of {t.TotalMilliseconds} ms exceeded"),
             _terminationCancellationToken.Token);
 
         public Task LifecycleTask => _lifecycleTaskWrapper.Task;
+
+        public async Task<IResponse> NavigationResponseAsync()
+        {
+            // Continue with a possibly null response.
+            if (_navigationResponseReceived != null)
+            {
+                await _navigationResponseReceived.Task.ConfigureAwait(false);
+            }
+
+            return _navigationRequest?.Response;
+        }
 
         public void Dispose()
         {
@@ -77,6 +89,8 @@ namespace PuppeteerSharp.Cdp
             _frame.FrameDetached -= OnFrameDetached;
             _frame.FrameSwapped -= FrameSwapped;
             _networkManager.Request -= OnRequest;
+            _networkManager.Response -= OnResponse;
+            _networkManager.RequestFailed -= OnRequestFailed;
             _terminationCancellationToken.Cancel();
             _terminationCancellationToken.Dispose();
         }
@@ -95,6 +109,7 @@ namespace PuppeteerSharp.Cdp
             if (e.Type == NavigationType.BackForwardCacheRestore)
             {
                 FrameSwapped(sender, EventArgs.Empty);
+                return;
             }
 
             CheckLifecycleComplete();
@@ -158,6 +173,37 @@ namespace PuppeteerSharp.Cdp
             }
 
             _navigationRequest = e.Request;
+
+            // Resolve previous navigation response in case there are multiple
+            // navigation requests reported by the backend. This generally should not
+            // happen but it looks like it's possible.
+            _navigationResponseReceived?.TrySetResult(true);
+            _navigationResponseReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (e.Request.Response != null)
+            {
+                _navigationResponseReceived.TrySetResult(true);
+            }
+        }
+
+        private void OnResponse(object sender, ResponseCreatedEventArgs e)
+        {
+            if (_navigationRequest?.Id != e.Response.Request.Id)
+            {
+                return;
+            }
+
+            _navigationResponseReceived?.TrySetResult(true);
+        }
+
+        private void OnRequestFailed(object sender, RequestEventArgs e)
+        {
+            if (_navigationRequest?.Id != e.Request.Id)
+            {
+                return;
+            }
+
+            _navigationResponseReceived?.TrySetResult(true);
         }
 
         private void NavigatedWithinDocument(object sender, EventArgs e)


### PR DESCRIPTION
LifecycleWatcher.NavigationResponse was a synchronous property that read _navigationRequest?.Response immediately when the navigation lifecycle completed. This caused a race condition where the HTTP response hadn't been attached to the request object yet, returning null and causing NullReferenceException in tests.

Aligned with upstream Puppeteer by making NavigationResponse async, adding Response/RequestFailed event listeners to properly wait for the HTTP response to arrive before returning it.