### PR TITLE
Fix ChromeHeadlessShell launch crash with Invalid browser error

### DIFF
--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -79,7 +79,7 @@ namespace PuppeteerSharp
 
             Process = options.Browser switch
             {
-                SupportedBrowser.Chrome or SupportedBrowser.Chromium => new ChromeLauncher(executable, options),
+                SupportedBrowser.Chrome or SupportedBrowser.Chromium or SupportedBrowser.ChromeHeadlessShell => new ChromeLauncher(executable, options),
                 SupportedBrowser.Firefox => new FirefoxLauncher(executable, options),
                 _ => throw new ArgumentException("Invalid browser"),
             };


### PR DESCRIPTION
## Summary
- Add `SupportedBrowser.ChromeHeadlessShell` to the `Process` switch expression in `Launcher.cs` so it uses `ChromeLauncher` instead of throwing `ArgumentException("Invalid browser")`
- The `buildId` switch above already handled this case correctly, but the `Process` switch was missing it

Fixes #2967

## Test plan
- [ ] Launch with `Browser = SupportedBrowser.ChromeHeadlessShell` no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)