### PR TITLE
Deprecate Cookie attribute SameParty (#14550)

### DIFF
--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -134,7 +134,9 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Value = "123456",
                 Domain = "localhost",
                 Path = "/",
+#pragma warning disable CS0618 // SameParty is deprecated
                 SameParty = false,
+#pragma warning restore CS0618
                 Expires = -1,
                 HttpOnly = false,
                 Secure = false,

--- a/lib/PuppeteerSharp/Bidi/BidiCookieHelper.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiCookieHelper.cs
@@ -80,10 +80,12 @@ internal static class BidiCookieHelper
         }
 
         // Add CDP-specific properties if needed
+#pragma warning disable CS0618 // SameParty is deprecated
         if (cookie.SameParty.HasValue)
         {
             bidiCookie.AdditionalData["goog:sameParty"] = cookie.SameParty.Value;
         }
+#pragma warning restore CS0618
 
         if (cookie.SourceScheme.HasValue)
         {

--- a/lib/PuppeteerSharp/CookieParam.cs
+++ b/lib/PuppeteerSharp/CookieParam.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 using PuppeteerSharp.Helpers.Json;
 
@@ -82,8 +83,9 @@ namespace PuppeteerSharp
         public CookiePriority? Priority { get; set; }
 
         /// <summary>
-        /// True if cookie is SameParty. Supported only in Chrome.
+        /// Always set to false. Supported only in Chrome.
         /// </summary>
+        [Obsolete("SameParty is deprecated and always ignored.")]
         public bool? SameParty { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Marks `CookieParam.SameParty` as `[Obsolete]` since Chrome deprecated the SameParty cookie attribute in 2022
- Updates XML doc comment to indicate the property is always set to false and always ignored
- Suppresses obsolete warnings in internal code (`BidiCookieHelper`) and tests that still reference the property

Upstream PR: https://github.com/puppeteer/puppeteer/pull/14550

## Test plan
- [x] All 26 cookie tests pass with Chrome/CDP
- [x] Library builds with zero warnings and zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)