### PR TITLE
Fix flaky ShouldProvideAccessToElements OOPIF test

### DIFF
--- a/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
+++ b/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
@@ -239,7 +239,7 @@ namespace PuppeteerSharp.Tests.OOPIFTests
               "frame1",
               TestConstants.CrossProcessHttpPrefix + "/empty.html"
             );
-            var frame = await frameTask.WithTimeout(5_000);
+            var frame = await frameTask.WithTimeout(30_000);
             await frame.EvaluateFunctionAsync(@"() => {
                 const button = document.createElement('button');
                 button.id = 'test-button';


### PR DESCRIPTION
## Summary
- Increased `WithTimeout` from 5s to 30s in `ShouldProvideAccessToElements` OOPIF test
- The upstream Puppeteer test has no explicit timeout (uses test framework default ~25-30s), so the 5s limit was too aggressive for resource-constrained CI environments where OOPIF process spawning can be slow

## Test plan
- [x] `ShouldProvideAccessToElements` test passes locally
- [x] All 20 OOPIF tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)