### PR TITLE
Remove other nupkg packages when building PuppeteerSharp.Cdp

### DIFF
--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -31,6 +31,7 @@ jobs:
         dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --api-key ${{secrets.NUGET_INT_API_KEY}} --source https://apiint.nugettest.org/v3/index.json
     - name: Build (CDP only)
       run: |
+        rm -f ./lib/PuppeteerSharp/bin/Release/*.nupkg
         dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
         ls ./lib/PuppeteerSharp/bin/Release
     - name: NugetPush to int.nuget.org (CDP only)

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -34,6 +34,7 @@ jobs:
         dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
     - name: Build (CDP only)
       run: |
+        rm -f ./lib/PuppeteerSharp/bin/Release/*.nupkg
         dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
         ls ./lib/PuppeteerSharp/bin/Release
     - name: NugetPush to nuget.org (CDP only)


### PR DESCRIPTION
This should prevent what happened in [this run](https://github.com/hardkoded/puppeteer-sharp/actions/runs/22124548441/job/63951625701). The `PuppeteerSharp.Cdp` package failed to publish because of that failure.