### PR TITLE
feat(bidi): Improve window management error handling

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -679,7 +679,7 @@
   {
     "testIdPattern": "[page.spec] Page Page.newPage should open pages in a new window at the specified position",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["firefox"],
     "expectations": ["FAIL"],
     "comment": "Not supported by WebDriver BiDi"
   },
@@ -693,7 +693,7 @@
   {
     "testIdPattern": "[page.spec] Page Page.newPage should open pages in a new window in maximized state",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["firefox"],
     "expectations": ["FAIL"],
     "comment": "Not supported by WebDriver BiDi"
   },

--- a/lib/PuppeteerSharp/Bidi/BidiBrowserContext.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowserContext.cs
@@ -40,12 +40,14 @@ public class BidiBrowserContext : BrowserContext
     private readonly ConcurrentDictionary<BrowsingContext, BidiPage> _pages = [];
     private readonly ConcurrentDictionary<BidiPage, BidiPageTargetInfo> _targets = new();
     private readonly List<(string Origin, OverridePermission Permission)> _overrides = [];
+    private readonly ILogger<BidiBrowserContext> _logger;
 
     private BidiBrowserContext(BidiBrowser browser, UserContext userContext, BidiBrowserContextOptions options)
     {
         UserContext = userContext;
         Browser = browser;
         DefaultViewport = options.DefaultViewport;
+        _logger = browser.LoggerFactory?.CreateLogger<BidiBrowserContext>();
     }
 
     internal ViewPortOptions DefaultViewport { get; set; }
@@ -144,16 +146,25 @@ public class BidiBrowserContext : BrowserContext
             {
                 await page.SetViewportAsync(DefaultViewport).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
-                // No support for setViewport in Firefox.
+                // Tolerate not supporting browsingContext.setViewport. Only log it.
+                _logger?.LogDebug(ex, "Failed to set viewport");
             }
         }
 
         if (options?.Type == CreatePageType.Window && options?.WindowBounds != null)
         {
-            var windowId = await page.WindowIdAsync().ConfigureAwait(false);
-            await Browser.SetWindowBoundsAsync(windowId, options.WindowBounds).ConfigureAwait(false);
+            try
+            {
+                var windowId = await page.WindowIdAsync().ConfigureAwait(false);
+                await Browser.SetWindowBoundsAsync(windowId, options.WindowBounds).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Tolerate not supporting browser.setClientWindowState. Only log it.
+                _logger?.LogDebug(ex, "Failed to set window bounds");
+            }
         }
 
         return page;


### PR DESCRIPTION
## Summary
- Ports upstream puppeteer PR [#14618](https://github.com/puppeteer/puppeteer/pull/14618) (feat(webdriver): Implement window management)
- Adds try/catch with debug logging around `SetWindowBoundsAsync` in `BidiBrowserContext.NewPageAsync()` to tolerate browsers that don't support `browser.setClientWindowState`
- Improves the existing `setViewport` catch to log errors via `ILogger` instead of silently swallowing them
- Updates upstream test expectations from `webDriverBiDi` to `firefox` for window management tests, since BiDi now supports them on Chrome

## Test plan
- [x] Build succeeds with zero errors
- [x] `NewPageTests` pass with Chrome/CDP (3 passed, 1 skipped)

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)