### PR TITLE
Implement page.captureHeapSnapshot() (#3114)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -112,6 +112,13 @@
     "comment": "Spawns headful browser, needs display or `xvfb` like which is not required for other headless tests"
   },
   {
+    "testIdPattern": "[heapSnapshot.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported in WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[interventionHeaders.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/lib/PuppeteerSharp.Tests/HeapSnapshotTests/HeapSnapshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/HeapSnapshotTests/HeapSnapshotTests.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.HeapSnapshotTests
+{
+    public class HeapSnapshotTests : PuppeteerPageBaseTest
+    {
+        public HeapSnapshotTests() : base()
+        {
+        }
+
+        [Test, PuppeteerTest("heapSnapshot.spec", "Heap Snapshot", "should capture heap snapshot")]
+        public async Task ShouldCaptureHeapSnapshot()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var filePath = Path.Combine(tempDir, "heap.heapsnapshot");
+
+                await Page.CaptureHeapSnapshotAsync(new HeapSnapshotOptions { Path = filePath });
+
+                Assert.That(File.Exists(filePath), Is.True);
+                var content = File.ReadAllText(filePath);
+                var snapshot = JsonSerializer.Deserialize<JsonElement>(content);
+                Assert.That(snapshot.TryGetProperty("snapshot", out _), Is.True);
+                Assert.That(snapshot.TryGetProperty("nodes", out _), Is.True);
+                Assert.That(snapshot.TryGetProperty("edges", out _), Is.True);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -830,6 +830,10 @@ public class BidiPage : Page
         => throw new NotSupportedException("Metrics is not supported in BiDi protocol");
 
     /// <inheritdoc />
+    public override Task CaptureHeapSnapshotAsync(HeapSnapshotOptions options)
+        => throw new NotSupportedException("CaptureHeapSnapshot is not supported in BiDi protocol");
+
+    /// <inheritdoc />
     public override async Task<NewDocumentScriptEvaluation> EvaluateFunctionOnNewDocumentAsync(string pageFunction, params object[] args)
     {
         var expression = EvaluationExpression(pageFunction, args);

--- a/lib/PuppeteerSharp/Cdp/Messaging/HeapProfilerAddHeapSnapshotChunkResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/HeapProfilerAddHeapSnapshotChunkResponse.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class HeapProfilerAddHeapSnapshotChunkResponse
+    {
+        public string Chunk { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/HeapProfilerTakeHeapSnapshotRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/HeapProfilerTakeHeapSnapshotRequest.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class HeapProfilerTakeHeapSnapshotRequest
+    {
+        public bool ReportProgress { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/HeapSnapshotOptions.cs
+++ b/lib/PuppeteerSharp/HeapSnapshotOptions.cs
@@ -1,0 +1,13 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Options for <see cref="IPage.CaptureHeapSnapshotAsync(HeapSnapshotOptions)"/>.
+    /// </summary>
+    public class HeapSnapshotOptions
+    {
+        /// <summary>
+        /// Gets or sets the file path to save the heap snapshot to.
+        /// </summary>
+        public string Path { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -852,6 +852,13 @@ namespace PuppeteerSharp
         Task<Dictionary<string, decimal>> MetricsAsync();
 
         /// <summary>
+        /// Captures a snapshot of the JavaScript heap and writes it to a file.
+        /// </summary>
+        /// <param name="options">Heap snapshot options.</param>
+        /// <returns>A Task which resolves after the heap snapshot is captured and written to disk.</returns>
+        Task CaptureHeapSnapshotAsync(HeapSnapshotOptions options);
+
+        /// <summary>
         /// generates a pdf of the page with <see cref="MediaType.Print"/> css media. To generate a pdf with <see cref="MediaType.Screen"/> media call <see cref="EmulateMediaTypeAsync(MediaType)"/> with <see cref="MediaType.Screen"/>.
         /// </summary>
         /// <param name="file">The file path to save the PDF to. paths are resolved using <see cref="Path.GetFullPath(string)"/>.</param>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -238,6 +238,9 @@ namespace PuppeteerSharp
         public abstract Task<Dictionary<string, decimal>> MetricsAsync();
 
         /// <inheritdoc/>
+        public abstract Task CaptureHeapSnapshotAsync(HeapSnapshotOptions options);
+
+        /// <inheritdoc/>
         public Task TapAsync(string selector)
             => MainFrame.TapAsync(selector);
 


### PR DESCRIPTION
## Summary
- Implements `CaptureHeapSnapshotAsync(HeapSnapshotOptions)` on `IPage`/`Page`, porting upstream Puppeteer's `page.captureHeapSnapshot()` feature ([puppeteer#14610](https://github.com/puppeteer/puppeteer/issues/14610))
- CDP implementation uses the `HeapProfiler` domain to stream heap snapshot chunks directly to a file via `StreamWriter`
- BiDi implementation throws `NotSupportedException` as this feature is not supported in WebDriver BiDi protocol
- Added upstream test expectation marking BiDi as expected failure

## Test plan
- [x] `ShouldCaptureHeapSnapshot` test passes with Chrome/CDP
- [x] Test verifies the snapshot file is created and contains valid JSON with `snapshot`, `nodes`, and `edges` properties
- [ ] CI validates all existing tests still pass

Closes #3114

🤖 Generated with [Claude Code](https://claude.com/claude-code)