### PR TITLE
Handle shadow DOM in Frame.frameElement (#13156)

### DIFF
--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameElementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameElementTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.FrameTests
+{
+    public class FrameElementTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("frame.spec", "Frame specs Frame.prototype.frameElement", "should handle shadow roots")]
+        public async Task ShouldHandleShadowRoots()
+        {
+            await Page.SetContentAsync(@"
+                <div id=""shadow-host""></div>
+                <script>
+                    const host = document.getElementById('shadow-host');
+                    const shadowRoot = host.attachShadow({ mode: 'closed' });
+                    const frame = document.createElement('iframe');
+                    frame.srcdoc = '<p>Inside frame</p>';
+                    shadowRoot.appendChild(frame);
+                </script>
+            ");
+            // Wait for the iframe to load inside shadow DOM
+            await Page.WaitForFrameAsync(f => f != Page.MainFrame);
+            Assert.That(Page.Frames, Has.Length.EqualTo(2));
+            var frame = Page.Frames[1];
+            await using var frameElement = await frame.FrameElementAsync();
+            Assert.That(frameElement, Is.Not.Null);
+            Assert.That(
+                await frameElement.EvaluateFunctionAsync<string>("el => el.tagName.toLocaleLowerCase()"),
+                Is.EqualTo("iframe"));
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -243,6 +243,23 @@ public class CdpFrame : Frame
         return (await MainRealm.TransferHandleAsync(handle).ConfigureAwait(false)) as IElementHandle;
     }
 
+    /// <inheritdoc/>
+    public override async Task<ElementHandle> FrameElementAsync()
+    {
+        var parentFrame = ParentFrame;
+        if (parentFrame == null)
+        {
+            return null;
+        }
+
+        var response = await parentFrame.Client.SendAsync<DomGetFrameOwnerResponse>("DOM.getFrameOwner", new DomGetFrameOwnerRequest
+        {
+            FrameId = Id,
+        }).ConfigureAwait(false);
+
+        return (ElementHandle)await parentFrame.MainRealm.AdoptBackendNodeAsync(response.BackendNodeId).ConfigureAwait(false);
+    }
+
     internal void UpdateClient(CDPSession client, bool keepWorlds = false)
     {
         Client = client;

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -362,7 +362,7 @@ namespace PuppeteerSharp
         }
 
         /// <inheritdoc />
-        public async Task<ElementHandle> FrameElementAsync()
+        public virtual async Task<ElementHandle> FrameElementAsync()
         {
             var parentFrame = ParentFrame;
             if (parentFrame == null)


### PR DESCRIPTION
## Summary
- Adds a CDP-specific override for `FrameElementAsync()` in `CdpFrame` that uses `DOM.getFrameOwner` to resolve frame owner elements, enabling discovery of frames inside shadow DOM trees
- Makes `Frame.FrameElementAsync()` virtual to allow protocol-specific overrides
- Falls back to the base implementation (querying all iframes/frames) for Firefox, which doesn't support `DOM.getFrameOwner`
- Adds test for shadow root frame element resolution

Upstream PR: https://github.com/puppeteer/puppeteer/pull/13156

## Test plan
- [x] New test `ShouldHandleShadowRoots` passes with Chrome+CDP
- [x] All existing FrameTests pass (22/22)
- [x] All OOPIFTests pass (20/20) — these also use `FrameElementAsync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)