### PR TITLE
Fix: DevTools worker targets should not end up as DevToolsTarget (#14505) (#3053)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -271,6 +271,11 @@ public class CdpBrowser : Browser
         _contexts.TryRemove(contextId, out var _);
     }
 
+    private static bool IsDevToolsPageTarget(string url)
+    {
+        return url?.StartsWith("devtools://devtools/bundled/devtools_app.html", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
     private Task AttachAsync()
     {
         Connection.Disconnected += Connection_Disconnected;
@@ -309,7 +314,7 @@ public class CdpBrowser : Browser
             CreateSession,
             ScreenshotTaskQueue);
 
-        if (targetInfo.Url?.StartsWith("devtools://", StringComparison.OrdinalIgnoreCase) == true)
+        if (IsDevToolsPageTarget(targetInfo.Url))
         {
             return new CdpDevToolsTarget(
                 targetInfo,


### PR DESCRIPTION
## Summary
- Tightened the URL check in `CdpBrowser.CreateTarget` from `devtools://` to `devtools://devtools/bundled/devtools_app.html`
- Extracted the URL check into a dedicated `IsDevToolsPageTarget` helper method for clarity and reuse
- Prevents DevTools worker targets (e.g. `devtools://devtools/bundled/worker_app.html`) from being incorrectly classified as `DevToolsTarget` instances

## Upstream Reference
- Upstream issue: https://github.com/puppeteer/puppeteer/issues/14505
- Upstream fix commit: `e37f1a44e51689e0aedbb8f6a36a79a421d6264b`
- PuppeteerSharp issue: #3053

## Changes
| File | Change |
|------|--------|
| `lib/PuppeteerSharp/Cdp/CdpBrowser.cs` | Added `IsDevToolsPageTarget` static helper; tightened URL prefix check in `CreateTarget` |

## Test plan
- [x] BrowserTests pass (11 passed, 1 skipped)
- [x] TargetTests pass (17 passed)
- [x] Project builds cleanly with no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)