### PR TITLE
New Feature: Implement page.emulateFocusedPage() (#14501) (#3049)

### DIFF
--- a/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateFocusedPageTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateFocusedPageTests.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.EmulationTests
+{
+    public class PageEmulateFocusedPageTests : PuppeteerPageBaseTest
+    {
+        public PageEmulateFocusedPageTests() : base()
+        {
+        }
+
+        [Test, PuppeteerTest("emulation.spec", "Emulation Page.emulateFocusedPage", "should emulate focus")]
+        public async Task ShouldEmulateFocus()
+        {
+            await Page.EmulateFocusedPageAsync(true);
+            Assert.That(
+                await Page.EvaluateFunctionAsync<bool>("() => document.hasFocus()"),
+                Is.True);
+
+            var page2 = await Context.NewPageAsync();
+            // Move page into background by focusing page2.
+            await page2.BringToFrontAsync();
+
+            Assert.That(
+                await Page.EvaluateFunctionAsync<bool>("() => document.hasFocus()"),
+                Is.True);
+        }
+
+        [Test, PuppeteerTest("emulation.spec", "Emulation Page.emulateFocusedPage", "should reset focus")]
+        public async Task ShouldResetFocus()
+        {
+            await Page.EmulateFocusedPageAsync(true);
+
+            var page2 = await Context.NewPageAsync();
+            // Move page into background by focusing page2.
+            await page2.BringToFrontAsync();
+
+            Assert.That(
+                await Page.EvaluateFunctionAsync<bool>("() => document.hasFocus()"),
+                Is.True);
+
+            await Page.EmulateFocusedPageAsync(false);
+            Assert.That(
+                await Page.EvaluateFunctionAsync<bool>("() => document.hasFocus()"),
+                Is.False);
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -245,6 +245,10 @@ public class BidiPage : Page
         => _cdpEmulationManager.EmulateCPUThrottlingAsync(factor);
 
     /// <inheritdoc />
+    public override Task EmulateFocusedPageAsync(bool enabled)
+        => _cdpEmulationManager.EmulateFocusAsync(enabled);
+
+    /// <inheritdoc />
     public override async Task<IResponse> ReloadAsync(NavigationOptions options)
     {
         // Clear the events trackers on navigation to allow fresh events

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -652,6 +652,10 @@ public class CdpPage : Page
         => _emulationManager.EmulateCPUThrottlingAsync(factor);
 
     /// <inheritdoc/>
+    public override Task EmulateFocusedPageAsync(bool enabled)
+        => _emulationManager.EmulateFocusAsync(enabled);
+
+    /// <inheritdoc/>
     public override Task<IResponse> GoBackAsync(NavigationOptions options = null) => GoAsync(-1, options);
 
     /// <inheritdoc/>

--- a/lib/PuppeteerSharp/Cdp/Messaging/EmulationSetFocusEmulationEnabledRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/EmulationSetFocusEmulationEnabledRequest.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class EmulationSetFocusEmulationEnabledRequest
+    {
+        public bool Enabled { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/CdpEmulationManager.cs
+++ b/lib/PuppeteerSharp/CdpEmulationManager.cs
@@ -153,6 +153,11 @@ namespace PuppeteerSharp
                 },
             });
 
+        internal Task EmulateFocusAsync(bool enabled)
+            => _client.SendAsync(
+                "Emulation.setFocusEmulationEnabled",
+                new EmulationSetFocusEmulationEnabledRequest { Enabled = enabled, });
+
         internal Task SetJavaScriptEnabledAsync(bool enabled)
         {
             if (enabled == JavascriptEnabled)

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -401,6 +401,13 @@ namespace PuppeteerSharp
         Task EmulateCPUThrottlingAsync(decimal? factor = null);
 
         /// <summary>
+        /// Emulates focus state of the page.
+        /// </summary>
+        /// <param name="enabled">Whether to emulate focus.</param>
+        /// <returns>A task that resolves when the message has been sent to the browser.</returns>
+        Task EmulateFocusedPageAsync(bool enabled);
+
+        /// <summary>
         /// Emulates the idle state.
         /// If no arguments set, clears idle state emulation.
         /// </summary>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -744,6 +744,9 @@ namespace PuppeteerSharp
         /// <inheritdoc/>
         public abstract Task EmulateCPUThrottlingAsync(decimal? factor = null);
 
+        /// <inheritdoc/>
+        public abstract Task EmulateFocusedPageAsync(bool enabled);
+
         /// <inheritdoc />
         public void Dispose()
         {


### PR DESCRIPTION
## Summary
- Ports upstream Puppeteer feature [feat: emulate focused page (puppeteer/puppeteer#14501)](https://github.com/puppeteer/puppeteer/pull/14501) to PuppeteerSharp
- Adds `EmulateFocusedPageAsync(bool enabled)` to `IPage` interface, allowing emulation of the page focus state via the CDP `Emulation.setFocusEmulationEnabled` command
- Implemented for both CDP and BiDi pages (BiDi delegates to CDP emulation manager)
- Includes two tests: `ShouldEmulateFocus` and `ShouldResetFocus`

## Changes
| File | Change |
|------|--------|
| `IPage.cs` | Added `EmulateFocusedPageAsync` method signature |
| `Page.cs` | Added abstract `EmulateFocusedPageAsync` |
| `CdpEmulationManager.cs` | Added `EmulateFocusAsync` sending `Emulation.setFocusEmulationEnabled` |
| `CdpPage.cs` | Override delegating to emulation manager |
| `BidiPage.cs` | Override delegating to CDP emulation manager |
| `EmulationSetFocusEmulationEnabledRequest.cs` | New CDP messaging request class |
| `PageEmulateFocusedPageTests.cs` | Two tests ported from upstream |

## Test plan
- [x] Chrome/CDP: Both new tests pass
- [x] Firefox/BiDi: Tests correctly skipped (not supported in Firefox per upstream expectations)
- [x] All existing emulation tests continue to pass (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)