### PR TITLE
Use emulation.setUserAgentOverride instead of network interception (#14335)

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
@@ -57,7 +57,7 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
     }
 
     /// <summary>
-    /// Gets the merged headers including extra HTTP headers and user agent headers.
+    /// Gets the merged headers including extra HTTP headers.
     /// </summary>
     public override Dictionary<string, string> Headers
     {
@@ -71,11 +71,6 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
             }
 
             foreach (var kvp in ExtraHttpHeaders)
-            {
-                headers[kvp.Key.ToLowerInvariant()] = kvp.Value;
-            }
-
-            foreach (var kvp in UserAgentHeaders)
             {
                 headers[kvp.Key.ToLowerInvariant()] = kvp.Value;
             }
@@ -98,9 +93,7 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
 
     internal ConcurrentDictionary<string, string> ExtraHttpHeaders => BidiPage.ExtraHttpHeaders;
 
-    internal ConcurrentDictionary<string, string> UserAgentHeaders => BidiPage.UserAgentHeaders;
-
-    internal bool HasInternalHeaderOverwrite => ExtraHttpHeaders.Values.Count != 0 || UserAgentHeaders.Values.Count != 0;
+    internal bool HasInternalHeaderOverwrite => ExtraHttpHeaders.Values.Count != 0;
 
     /// <summary>
     /// Gets whether network interception is enabled at the page level.

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -118,8 +118,6 @@ public class BidiPage : Page
 
     internal ConcurrentDictionary<string, string> ExtraHttpHeaders { get; set; } = new();
 
-    internal ConcurrentDictionary<string, string> UserAgentHeaders { get; set; } = new();
-
     internal bool IsNetworkInterceptionEnabled =>
         _requestInterception != null || _extraHeadersInterception != null || _authInterception != null;
 


### PR DESCRIPTION
## Summary
- Removed `UserAgentHeaders` dictionary from `BidiPage` and its references in `BidiHttpRequest`
- Simplified `HasInternalHeaderOverwrite` to only check `ExtraHttpHeaders` (no longer checks user agent headers)
- Removed user agent header merging from `BidiHttpRequest.Headers` property

The user agent is already set via `emulation.setUserAgentOverride` through `BrowsingContext.SetUserAgentAsync()`, making the network interception-based approach for user agent headers unnecessary.

Upstream PR: https://github.com/puppeteer/puppeteer/pull/14335
Closes #3014

## Test plan
- [x] SetUserAgent tests pass with Firefox/BiDi (3 passed, 2 skipped as Chrome-only)
- [x] SetUserAgent tests pass with Chrome/CDP (5 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)