### PR TITLE
New Feature: Use emulation.setNetworkConditions for offline emulation in BiDi (#14431)

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -894,7 +894,8 @@ public class BidiPage : Page
     {
         if (!BidiBrowser.CdpSupported)
         {
-            throw new NotSupportedException();
+            await BidiMainFrame.BrowsingContext.SetOfflineModeAsync(value).ConfigureAwait(false);
+            return;
         }
 
         _emulatedNetworkConditions ??= new InternalNetworkConditions


### PR DESCRIPTION
## Summary
- Updated `BidiPage.SetOfflineModeAsync` to use the BiDi `emulation.setNetworkConditions` command instead of throwing `NotSupportedException` when CDP is not supported
- This mirrors the upstream change in puppeteer/puppeteer#14431 which enables offline mode emulation through the WebDriver BiDi protocol
- The `BrowsingContext.SetOfflineModeAsync` method (already implemented) sends the appropriate BiDi command

## Upstream PR
puppeteer/puppeteer#14431

## Changes
The only change is in `BidiPage.SetOfflineModeAsync`: when `CdpSupported` is false, instead of throwing, it now delegates to `BidiMainFrame.BrowsingContext.SetOfflineModeAsync(value)`.

Note: `EmulateNetworkConditionsAsync` was already updated in a previous implementation to handle the BiDi case similarly.

## Test plan
- [x] Chrome/CDP offline mode tests pass (2/2)
- [x] Chrome/CDP network conditions tests pass (1/1)
- [x] Firefox/BiDi offline mode tests are skipped per upstream test expectations (still marked as FAIL in upstream)
- [x] Build succeeds for both Chrome/CDP and Firefox/BiDi configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)