### PR TITLE
Fix: Ignore wasn't found errors in NetworkManager (#14399)

### DIFF
--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
@@ -651,6 +651,18 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Assert.That(cached, Has.Count.GreaterThanOrEqualTo(1));
         }
 
+        [Test, PuppeteerTest("requestinterception.spec", "request interception Page.setRequestInterception", "should work with worker")]
+        public async Task ShouldWorkWithWorker()
+        {
+            var workerCreatedTcs = new TaskCompletionSource<bool>();
+            Page.WorkerCreated += (_, _) => workerCreatedTcs.TrySetResult(true);
+
+            await Page.GoToAsync(TestConstants.ServerUrl + "/worker/worker.html");
+            await workerCreatedTcs.Task.WithTimeout();
+
+            await Page.SetRequestInterceptionAsync(true);
+        }
+
         [Test, PuppeteerTest("requestinterception.spec", "request interception Page.setRequestInterception", "should load fonts if cache enabled")]
         public async Task ShouldLoadFontsIfCacheEnabled()
         {


### PR DESCRIPTION
## Summary
- Adds error handling in `NetworkManager.AddClientAsync` to gracefully ignore protocol errors when enabling network features on targets that don't support them (e.g., workers receiving `'Fetch.enable' wasn't found`)
- The `CanIgnoreError` method ignores `TargetClosedException`, "Not supported", and "wasn't found" errors, matching the upstream behavior
- Adds a new test `ShouldWorkWithWorker` to verify request interception works when workers are present

Upstream PR: https://github.com/puppeteer/puppeteer/pull/14399
Closes #3010

## Test plan
- [x] New test `ShouldWorkWithWorker` passes on Chrome/CDP
- [x] All 77 request interception tests pass (1 skipped as expected)
- [x] Firefox skip expectation already exists in upstream expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)