### PR TITLE
New Feature: Add page.OpenDevToolsAsync() method

### DIFF
--- a/lib/PuppeteerSharp.Tests/DevtoolsTests/DevtoolsTests.cs
+++ b/lib/PuppeteerSharp.Tests/DevtoolsTests/DevtoolsTests.cs
@@ -79,5 +79,17 @@ namespace PuppeteerSharp.Tests.DevtoolsTests
             Assert.That((await browser.PagesAsync()), Does.Not.Contain(page));
         }
 
+        [Test, PuppeteerTest("devtools.spec", "DevTools", "should support opening DevTools on a page")]
+        public async Task ShouldSupportOpeningDevToolsOnAPage()
+        {
+            var options = TestConstants.DefaultBrowserOptions();
+            await using var browser = await Puppeteer.LaunchAsync(options);
+            var page = await browser.NewPageAsync();
+            await page.GoToAsync("about:blank");
+            var devtoolsPage = await page.OpenDevToolsAsync();
+            await devtoolsPage.WaitForFunctionAsync("() => Boolean(window.DevToolsAPI)");
+            await browser.CloseAsync();
+        }
+
     }
 }

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -881,6 +881,9 @@ public class BidiPage : Page
     public override Task<IJSHandle> QueryObjectsAsync(IJSHandle prototypeHandle) => throw new NotImplementedException();
 
     /// <inheritdoc />
+    public override Task<IPage> OpenDevToolsAsync() => throw new NotImplementedException();
+
+    /// <inheritdoc />
     public override async Task SetRequestInterceptionAsync(bool value)
     {
         _requestInterception = await ToggleInterceptionAsync(

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -181,6 +181,14 @@ public class CdpPage : Page
     }
 
     /// <inheritdoc/>
+    public override async Task<IPage> OpenDevToolsAsync()
+    {
+        var pageTargetId = PrimaryTarget.TargetId;
+        var browser = (CdpBrowser)Browser;
+        return await browser.CreateDevToolsPageAsync(pageTargetId).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
     public override async Task<CookieParam[]> GetCookiesAsync(params string[] urls)
     {
         if (urls == null)

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -368,6 +368,13 @@ namespace PuppeteerSharp
         Task CloseAsync(PageCloseOptions options = null);
 
         /// <summary>
+        /// Opens DevTools for the current Page and returns the DevTools Page.
+        /// This method is only available in Chrome.
+        /// </summary>
+        /// <returns>A <see cref="Task{IPage}"/> that completes with the DevTools page.</returns>
+        Task<IPage> OpenDevToolsAsync();
+
+        /// <summary>
         /// Deletes cookies from the page.
         /// </summary>
         /// <param name="cookies">Cookies to delete.</param>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -614,6 +614,9 @@ namespace PuppeteerSharp
         public abstract Task CloseAsync(PageCloseOptions options = null);
 
         /// <inheritdoc/>
+        public abstract Task<IPage> OpenDevToolsAsync();
+
+        /// <inheritdoc/>
         public abstract Task SetCacheEnabledAsync(bool enabled = true);
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- Adds `page.OpenDevToolsAsync()` method that opens DevTools for the current page and returns the DevTools page instance
- Implements the feature for CDP (Chrome) and adds a `NotImplementedException` stub for BiDi
- Ports the upstream test to verify DevTools can be opened programmatically on a page

## Changes
- **IPage.cs**: Added `OpenDevToolsAsync()` to the interface
- **Page.cs**: Added abstract `OpenDevToolsAsync()` method
- **CdpPage.cs**: Implemented `OpenDevToolsAsync()` using the browser's `CreateDevToolsPageAsync`
- **CdpBrowser.cs**: Added `CreateDevToolsPageAsync()` internal method that sends `Target.openDevTools` CDP command and waits for the DevTools target to be created and initialized
- **BidiPage.cs**: Added `NotImplementedException` stub (not supported in BiDi yet)
- **DevtoolsTests.cs**: Added test `ShouldSupportOpeningDevToolsOnAPage`

## Upstream PR
https://github.com/puppeteer/puppeteer/pull/14396

## Test plan
- [x] Build succeeds
- [x] New test ShouldSupportOpeningDevToolsOnAPage passes
- [x] All existing DevTools tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)