### PR TITLE
Fix flaky prerender tests by waiting for network idle

### DIFF
--- a/lib/PuppeteerSharp.Tests/PrerenderTests/PrerenderTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/PrerenderTests.cs
@@ -14,6 +14,8 @@ public class PrerenderTests : PuppeteerPageBaseTest
         var button = await Page.WaitForSelectorAsync("button");
         await button.ClickAsync();
 
+        await Page.WaitForNetworkIdleAsync();
+
         var link = await Page.WaitForSelectorAsync("a");
         await Task.WhenAll(
             Page.WaitForNavigationAsync(),

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/ViaFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/ViaFrameTests.cs
@@ -14,6 +14,8 @@ public class ViaFrameTests : PuppeteerPageBaseTest
         var button = await Page.WaitForSelectorAsync("button");
         await button.ClickAsync();
 
+        await Page.WaitForNetworkIdleAsync();
+
         var mainFrame = Page.MainFrame;
         var link = await mainFrame.WaitForSelectorAsync("a");
         await Task.WhenAll(

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/WithNetworkRequestsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/WithNetworkRequestsTests.cs
@@ -17,6 +17,8 @@ public class WithNetworkRequestsTests : PuppeteerPageBaseTest
         var button = await Page.WaitForSelectorAsync("button");
         await button.ClickAsync();
 
+        await Page.WaitForNetworkIdleAsync();
+
         var mainFrame = Page.MainFrame;
         var link = await mainFrame.WaitForSelectorAsync("a");
         await Task.WhenAll(


### PR DESCRIPTION
## Summary
- Added `WaitForNetworkIdleAsync()` after clicking the button that adds speculation rules in all 3 prerender test files
- The `<a>` element already exists in the DOM, so `WaitForSelectorAsync("a")` returns immediately — without waiting for network idle, the link gets clicked before the prerender completes, causing flakiness
- Affected tests: `PrerenderTests`, `ViaFrameTests`, and `WithNetworkRequestsTests`

## Test plan
- [x] All 5 prerender tests pass consistently (verified 3 consecutive runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)