### PR TITLE
Fix dotnet-retest not retrying failed tests on Linux

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -104,7 +104,7 @@ jobs:
           export DISPLAY=:1.5
           cd lib/PuppeteerSharp.Tests
           dotnet tool update -g dotnet-retest
-          dotnet retest --verbosity normal -- -s test.runsettings -c Debug --logger "trx;LogFileName=TestResults.xml" --blame-hang-timeout 300000
+          dotnet retest --verbosity normal -- -s test.runsettings --blame-hang-timeout 300000
     - name: Test (Windows)
       if: matrix.os == 'windows-latest'
       env:


### PR DESCRIPTION
## Summary
- The Linux CI test command had extra flags (`-c Debug --logger "trx;LogFileName=TestResults.xml"`) that caused the TRX results file to be written to a temp directory where dotnet-retest couldn't locate it
- This made dotnet-retest report "Retrying 0 failed test" and re-run the entire suite (~9 min) on each retry instead of just the single failed test
- Removed the extra flags to align with the Windows command, which correctly retries only failed tests

## Test plan
- [ ] Verify Linux CI jobs now show "Retrying 1 failed test" (instead of 0) when a flaky test fails
- [ ] Verify retries run only the failed test(s), not the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)