### PR TITLE
Fix: Disable browser.backup for Firefox (#14200)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -234,6 +234,12 @@ namespace PuppeteerSharp.BrowserData
                 // Increase the APZ content response timeout to 1 minute
                 ["apz.content_response_timeout"] = 60000,
 
+                // Disables backup service to improve startup performance and stability. See
+                // https://github.com/puppeteer/puppeteer/issues/14194. TODO: can be removed
+                // once the service is disabled on the Firefox side for WebDriver (see
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1988250).
+                ["browser.backup.enabled"] = false,
+
                 // Prevent various error message on the console
                 // jest-puppeteer asserts that no error message is emitted by the console
                 ["browser.contentblocking.features.standard"] = "-tp,tpPrivate,cookieBehavior0,-cm,-fp",


### PR DESCRIPTION
## Summary

- Adds `browser.backup.enabled = false` to Firefox default profile preferences to improve startup performance and stability
- Ports upstream fix from [puppeteer/puppeteer#14200](https://github.com/puppeteer/puppeteer/pull/14200)
- Addresses [#14194](https://github.com/puppeteer/puppeteer/issues/14194) where the Firefox backup service was causing issues during automation

## Changes

Single-line addition in `lib/PuppeteerSharp/BrowserData/Firefox.cs` — adds the `browser.backup.enabled` preference set to `false` in the default Firefox profile preferences dictionary, matching the upstream change exactly.

## Test plan

- [x] Build succeeds
- [ ] Firefox BiDi tests pass (no test changes needed — this is a configuration preference)

Closes #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)