### PR TITLE
Fix: support multiple paths for system executables on Windows (#14286)

### DIFF
--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -115,30 +115,24 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
                 Is.EqualTo(BrowserData.Chrome.RelativeExecutablePath(Platform.Win64, "12372323")));
         }
 
-        // This has a custom name
         [Test, PuppeteerTest("chrome-data.spec", "Chrome", "should resolve system executable path (windows)")]
         public void ShouldResolveSystemExecutablePathWindows()
         {
-            Assert.That(
-                BrowserData.Chrome.ResolveSystemExecutablePath(Platform.Win32, ChromeReleaseChannel.Dev),
-                Is.EqualTo("C:\\Program Files\\Google\\Chrome Dev\\Application\\chrome.exe"));
+            var paths = BrowserData.Chrome.ResolveSystemExecutablePaths(Platform.Win32, ChromeReleaseChannel.Dev);
+            Assert.That(paths, Has.Length.GreaterThanOrEqualTo(1));
+            Assert.That(paths, Has.All.EndsWith("\\Google\\Chrome Dev\\Application\\chrome.exe"));
         }
 
         [Test, PuppeteerTest("chrome-data.spec", "Chrome", "should resolve system executable path")]
         public void ShouldResolveSystemExecutablePath()
         {
             Assert.That(
-                BrowserData.Chrome.ResolveSystemExecutablePath(Platform.MacOS, ChromeReleaseChannel.Beta),
-                Is.EqualTo("/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta"));
+                BrowserData.Chrome.ResolveSystemExecutablePaths(Platform.MacOS, ChromeReleaseChannel.Beta),
+                Is.EqualTo(new[] { "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta" }));
 
-            var ex = Assert.Throws<PuppeteerException>(() =>
-            {
-                BrowserData.Chrome.ResolveSystemExecutablePath(
-                    Platform.Linux,
-                    ChromeReleaseChannel.Canary);
-            });
-
-            Assert.That(ex.Message, Is.EqualTo("Canary is not supported"));
+            Assert.That(
+                BrowserData.Chrome.ResolveSystemExecutablePaths(Platform.Linux, ChromeReleaseChannel.Canary),
+                Is.EqualTo(new[] { "/opt/google/chrome-canary/chrome" }));
         }
 
         [Test]

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -340,10 +340,24 @@ namespace PuppeteerSharp
         }
 
         private string ComputeSystemExecutablePath(SupportedBrowser browser, ChromeReleaseChannel channel)
-            => browser switch
+        {
+            if (browser != SupportedBrowser.Chrome)
             {
-                SupportedBrowser.Chrome => Chrome.ResolveSystemExecutablePath(BrowserFetcher.GetCurrentPlatform(), channel),
-                _ => throw new PuppeteerException($"System browser detection is not supported for {browser} yet."),
-            };
+                throw new PuppeteerException($"System browser detection is not supported for {browser} yet.");
+            }
+
+            var paths = Chrome.ResolveSystemExecutablePaths(BrowserFetcher.GetCurrentPlatform(), channel);
+
+            foreach (var path in paths)
+            {
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            throw new PuppeteerException(
+                $"Could not find Google Chrome executable for channel '{channel}' at:\n - {string.Join("\n - ", paths)}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Ports upstream Puppeteer fix [#14286](https://github.com/puppeteer/puppeteer/pull/14286) to PuppeteerSharp.

This fixes Chrome executable detection on Windows by checking multiple Program Files directories instead of just one, improving reliability across different system configurations (32-bit process on 64-bit OS, non-standard installations, etc.).

### Changes

- **`Chrome.cs`**: Renamed `ResolveSystemExecutablePath` to `ResolveSystemExecutablePaths`, returning `string[]` instead of `string`
  - On Windows, checks `ProgramFiles`, `ProgramFilesX86`, and `ProgramW6432` environment paths using a `HashSet` to deduplicate
  - On macOS and Linux, returns single-element arrays (no behavioral change)
  - Added Linux Canary channel support (`/opt/google/chrome-canary/chrome`)
- **`Launcher.cs`**: Updated `ComputeSystemExecutablePath` to iterate through all candidate paths and return the first one that exists on disk, with an improved error message listing all checked paths
- **Tests**: Updated to use the new plural API

### Not ported

The WSL (Windows Subsystem for Linux) support from the upstream change was intentionally not ported, since .NET applications run natively on both Windows and Linux — there's no need to detect Windows Chrome from within WSL.

## Test plan

- [x] ChromeDataTests pass (4 passed, 1 skipped - Windows test skipped on macOS)
- [x] LauncherTests pass (40 passed, 7 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)