### PR TITLE
Fix: Handle leaf nodes without heuristics that rely on name (#14221)

### DIFF
--- a/lib/PuppeteerSharp.Tests/AccessibilityTests/AccessibilityTests.cs
+++ b/lib/PuppeteerSharp.Tests/AccessibilityTests/AccessibilityTests.cs
@@ -383,6 +383,21 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
                 }));
         }
 
+        [Test, PuppeteerTest("accessibility.spec", "Accessibility", "should not report Document as leaf node")]
+        public async Task ShouldNotReportDocumentAsLeafNode()
+        {
+            await Page.SetContentAsync(@"
+            <main><span>Hello</span><div> </div><div>World</div></main>");
+
+            var snapshot = await Page.Accessibility.SnapshotAsync();
+            Assert.That(snapshot.Role, Is.EqualTo("RootWebArea"));
+            Assert.That(snapshot.Children.Length, Is.EqualTo(2));
+            Assert.That(snapshot.Children[0].Role, Is.EqualTo("StaticText"));
+            Assert.That(snapshot.Children[0].Name, Is.EqualTo("Hello"));
+            Assert.That(snapshot.Children[1].Role, Is.EqualTo("StaticText"));
+            Assert.That(snapshot.Children[1].Name, Is.EqualTo("World"));
+        }
+
         [Test, PuppeteerTest("accessibility.spec", "Accessibility", "should capture new accessibility properties and not prune them")]
         public async Task ShouldCaptureNewAccessibilityPropertiesAndNotPruneThem()
         {

--- a/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
@@ -24,7 +24,6 @@ namespace PuppeteerSharp.PageAccessibility
         private readonly string _roledescription;
         private readonly string _live;
         private readonly bool _ignored;
-        private bool? _cachedHasFocusableChild;
 
         private AXNode(AccessibilityGetFullAXTreeResponse.AXTreeNode payload)
         {
@@ -123,17 +122,6 @@ namespace PuppeteerSharp.PageAccessibility
                 case "separator":
                 case "progressbar":
                     return true;
-            }
-
-            // Here and below: Android heuristics
-            if (HasFocusableChild())
-            {
-                return false;
-            }
-
-            if (Focusable && !string.IsNullOrEmpty(_name))
-            {
-                return true;
             }
 
             if (_role == "heading" && !string.IsNullOrEmpty(_name))
@@ -318,11 +306,6 @@ namespace PuppeteerSharp.PageAccessibility
                 _role == "text" ||
                 _role == "InlineTextBox" ||
                 _role == "StaticText";
-
-        private bool HasFocusableChild()
-        {
-            return _cachedHasFocusableChild ??= Children.Any(c => c.Focusable || c.HasFocusableChild());
-        }
 
         private string GetIfNotFalse(string value) => value != null && value != "false" ? value : null;
 


### PR DESCRIPTION
## Summary
- Ported upstream fix [puppeteer#14221](https://github.com/puppeteer/puppeteer/commit/076cc2e5c1b) that simplifies accessibility leaf node detection
- Removed `HasFocusableChild()` method and `_cachedHasFocusableChild` field from `AXNode`
- Removed "Android heuristics" from `IsLeafNode()`: the focusable child check and focusable+name check, keeping only the heading+name check
- Added new test `ShouldNotReportDocumentAsLeafNode` matching the upstream test

## Test plan
- [x] All 23 accessibility tests pass (Chrome/CDP)
- [ ] Verify no regressions in other test suites

Closes #2990

🤖 Generated with [Claude Code](https://claude.com/claude-code)