### PR TITLE
New Feature: Add HandleDevToolsAsPage option (#2987)

### DIFF
--- a/lib/PuppeteerSharp.Tests/DevtoolsTests/DevtoolsTests.cs
+++ b/lib/PuppeteerSharp.Tests/DevtoolsTests/DevtoolsTests.cs
@@ -61,6 +61,49 @@ namespace PuppeteerSharp.Tests.DevtoolsTests
             Assert.That(pages, Does.Contain(page));
         }
 
+        [Test, Retry(2),
+         PuppeteerTest("devtools.spec", "DevTools",
+             "browser.pages() should return a DevTools page if handleDevToolsAsPage is provided in connect()")]
+        public async Task BrowserPagesShouldReturnADevToolsPageIfHandleDevToolsAsPageIsProvidedInConnect()
+        {
+            var headfulOptions = TestConstants.DefaultBrowserOptions();
+            headfulOptions.Devtools = true;
+
+            await using var originalBrowser = await Puppeteer.LaunchAsync(
+                headfulOptions,
+                TestConstants.LoggerFactory);
+            var browserWSEndpoint = originalBrowser.WebSocketEndpoint;
+            await using var browser = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserWSEndpoint = browserWSEndpoint,
+                HandleDevToolsAsPage = true,
+            }, TestConstants.LoggerFactory);
+            var devtoolsPageTarget = await browser.WaitForTargetAsync(t => t.Type == TargetType.Other);
+            await using var page = await devtoolsPageTarget.PageAsync();
+            Assert.That(await page.EvaluateExpressionAsync<bool>("Boolean(DevToolsAPI)"), Is.True);
+            var pages = await browser.PagesAsync();
+            Assert.That(pages, Does.Contain(page));
+        }
+
+        [Test, Retry(2),
+         PuppeteerTest("devtools.spec", "DevTools",
+             "browser.pages() should return a DevTools page if handleDevToolsAsPage is provided in launch()")]
+        public async Task BrowserPagesShouldReturnADevToolsPageIfHandleDevToolsAsPageIsProvidedInLaunch()
+        {
+            var headfulOptions = TestConstants.DefaultBrowserOptions();
+            headfulOptions.Devtools = true;
+            headfulOptions.HandleDevToolsAsPage = true;
+
+            await using var browser = await Puppeteer.LaunchAsync(
+                headfulOptions,
+                TestConstants.LoggerFactory);
+            var devtoolsPageTarget = await browser.WaitForTargetAsync(t => t.Type == TargetType.Other);
+            await using var page = await devtoolsPageTarget.PageAsync();
+            Assert.That(await page.EvaluateExpressionAsync<bool>("Boolean(DevToolsAPI)"), Is.True);
+            var pages = await browser.PagesAsync();
+            Assert.That(pages, Does.Contain(page));
+        }
+
         [Test, PuppeteerTest("devtools.spec", "DevTools", "target.page() should return Page when calling asPage on DevTools target")]
         public async Task TargetPageShouldReturnADevToolsPageIfAsPageIsUsed()
         {

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -40,6 +40,7 @@ public class CdpBrowser : Browser
 
     private readonly ConcurrentDictionary<string, CdpBrowserContext> _contexts;
     private readonly ILogger<Browser> _logger;
+    private readonly bool _handleDevToolsAsPage;
     private Task _closeTask;
 
     internal CdpBrowser(
@@ -49,12 +50,14 @@ public class CdpBrowser : Browser
         ViewPortOptions defaultViewport,
         LauncherBase launcher,
         Func<Target, bool> targetFilter = null,
-        Func<Target, bool> isPageTargetFunc = null)
+        Func<Target, bool> isPageTargetFunc = null,
+        bool handleDevToolsAsPage = false)
     {
         BrowserType = browser;
         DefaultViewport = defaultViewport;
         Launcher = launcher;
         Connection = connection;
+        _handleDevToolsAsPage = handleDevToolsAsPage;
         var targetFilterCallback = targetFilter ?? (_ => true);
         _logger = Connection.LoggerFactory.CreateLogger<Browser>();
         IsPageTargetFunc =
@@ -97,6 +100,8 @@ public class CdpBrowser : Browser
     }
 
     internal ITargetManager TargetManager { get; }
+
+    internal bool HandleDevToolsAsPage => _handleDevToolsAsPage;
 
     internal override ProtocolType Protocol => ProtocolType.Cdp;
 
@@ -193,7 +198,8 @@ public class CdpBrowser : Browser
         LauncherBase launcher,
         Func<Target, bool> targetFilter = null,
         Func<Target, bool> isPageTargetCallback = null,
-        Action<IBrowser> initAction = null)
+        Action<IBrowser> initAction = null,
+        bool handleDevToolsAsPage = false)
     {
         var browser = new CdpBrowser(
             browserToCreate,
@@ -202,7 +208,8 @@ public class CdpBrowser : Browser
             defaultViewPort,
             launcher,
             targetFilter,
-            isPageTargetCallback);
+            isPageTargetCallback,
+            handleDevToolsAsPage);
 
         try
         {

--- a/lib/PuppeteerSharp/Cdp/CdpBrowserContext.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowserContext.cs
@@ -51,7 +51,10 @@ public class CdpBrowserContext : BrowserContext
                 Targets()
                     .Where(t =>
                         t.Type == TargetType.Page ||
-                        (t.Type == TargetType.Other && Browser.IsPageTargetFunc(t as Target)))
+                        (t.Type == TargetType.Other && Browser.IsPageTargetFunc(t as Target)) ||
+                        (_browser.HandleDevToolsAsPage &&
+                            t.Type == TargetType.Other &&
+                            t.Url.StartsWith("devtools://devtools/bundled/devtools_app.html", StringComparison.OrdinalIgnoreCase)))
                     .Select(t => t.PageAsync())).ConfigureAwait(false))
             .Where(p => p != null).ToArray();
 

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -82,6 +82,11 @@ namespace PuppeteerSharp
         /// </summary>
         public Action<IBrowser> InitAction { get; set; }
 
+        /// <summary>
+        /// Whether to handle the DevTools windows as pages in Puppeteer. Supported only in Chrome with CDP.
+        /// </summary>
+        public bool HandleDevToolsAsPage { get; set; }
+
         // TODO: Restore when it's usable
         internal ProtocolType Protocol { get; set; } = ProtocolType.Cdp;
 

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -204,6 +204,11 @@ namespace PuppeteerSharp
         /// </summary>
         public bool WaitForInitialPage { get; set; } = true;
 
+        /// <summary>
+        /// Whether to handle the DevTools windows as pages in Puppeteer. Supported only in Chrome with CDP.
+        /// </summary>
+        public bool HandleDevToolsAsPage { get; set; }
+
         // Internal until is usable
         internal ProtocolType Protocol { get; set; }
 

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -126,7 +126,8 @@ namespace PuppeteerSharp
                                 options.DefaultViewport,
                                 Process,
                                 options.TargetFilter,
-                                options.IsPageTarget)
+                                options.IsPageTarget,
+                                handleDevToolsAsPage: options.HandleDevToolsAsPage)
                             .ConfigureAwait(false);
                     }
 
@@ -265,7 +266,8 @@ namespace PuppeteerSharp
                         null,
                         options.TargetFilter,
                         options.IsPageTarget,
-                        options.InitAction)
+                        options.InitAction,
+                        options.HandleDevToolsAsPage)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Adds `HandleDevToolsAsPage` boolean property to `ConnectOptions` and `LaunchOptions`
- When set to `true`, DevTools windows (with URLs starting with `devtools://devtools/bundled/devtools_app.html`) are included in `browser.PagesAsync()` results
- Ports upstream [puppeteer/puppeteer#14296](https://github.com/puppeteer/puppeteer/pull/14296) and follow-up fix [#14472](https://github.com/puppeteer/puppeteer/pull/14472)

## Changes
- **ConnectOptions.cs / LaunchOptions.cs**: Added `HandleDevToolsAsPage` public bool property
- **CdpBrowser.cs**: Added `_handleDevToolsAsPage` field, threaded through constructor and `CreateAsync`
- **CdpBrowserContext.cs**: Updated `PagesAsync()` to include DevTools targets when the option is enabled
- **Launcher.cs**: Passes the option through to `CdpBrowser.CreateAsync` for both launch and connect paths
- **DevtoolsTests.cs**: Added two new tests for connect and launch scenarios

## Test plan
- [x] All 7 devtools tests pass (5 existing + 2 new)
- [ ] CI validates no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)