### PR TITLE
Fix: Improve Chrome installation detection on Windows (#14304)

### DIFF
--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -119,8 +119,10 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
         public void ShouldResolveSystemExecutablePathWindows()
         {
             var paths = BrowserData.Chrome.ResolveSystemExecutablePaths(Platform.Win32, ChromeReleaseChannel.Dev);
-            Assert.That(paths, Has.Length.GreaterThanOrEqualTo(1));
-            Assert.That(paths, Has.All.EndsWith("\\Google\\Chrome Dev\\Application\\chrome.exe"));
+            // Should include env-based paths plus fallback paths
+            Assert.That(paths, Has.Length.GreaterThanOrEqualTo(5));
+            var suffix = Path.Combine("Google", "Chrome Dev", "Application", "chrome.exe");
+            Assert.That(paths, Has.All.EndsWith(suffix));
         }
 
         [Test, PuppeteerTest("chrome-data.spec", "Chrome", "should resolve system executable path")]


### PR DESCRIPTION
## Summary
- Adds `LOCALAPPDATA` to the list of environment variables checked when searching for Chrome installations on Windows (supports user profile installations)
- Adds hardcoded fallback paths (`C:\Program Files`, `C:\Program Files (x86)`, `D:\Program Files`, `D:\Program Files (x86)`) in case environment variables are misconfigured
- Uses `Path.Combine` instead of string concatenation for building executable paths (more idiomatic .NET)
- Removes the exception thrown when no env-based prefixes are found, since fallback paths are now always present

## Upstream PR
[puppeteer/puppeteer#14304](https://github.com/puppeteer/puppeteer/pull/14304)

Closes #2983

## Changes
| File | Change |
|------|--------|
| `Chrome.cs` | Added `LOCALAPPDATA` env check, fallback paths, switched to `Path.Combine` |
| `ChromeDataTests.cs` | Updated Windows path test to expect at least 5 paths and use `Path.Combine` suffix |

## Test plan
- [x] `ChromeDataTests` pass (Windows test skipped on macOS as expected)
- [ ] Verify on Windows that Chrome is detected via `LOCALAPPDATA` path
- [ ] Verify fallback paths work when env vars are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)