### PR TITLE
Fix: detect missing X11 server and report errors (#14306)

### DIFF
--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -166,6 +166,13 @@ namespace PuppeteerSharp
                         ex);
                 }
 
+                if (IsMissingXServer(ex) && options.HeadlessMode == HeadlessMode.False)
+                {
+                    throw new ProcessException(
+                        "Missing X server to start the headful browser. Either set Headless to true or use xvfb-run to run your Puppeteer script.",
+                        ex);
+                }
+
                 throw;
             }
         }
@@ -224,6 +231,9 @@ namespace PuppeteerSharp
 
             return false;
         }
+
+        private static bool IsMissingXServer(Exception ex)
+            => ex.ToString().Contains("Missing X server", StringComparison.Ordinal);
 
 #if !CDP_ONLY
         private static async Task<BiDiDriver> CreateBidiDriverAsync(string browserWSEndpoint, IConnectionOptions options)


### PR DESCRIPTION
## Summary
- Adds detection of "Missing X server" error when launching a headful browser without an X11 display server
- Throws a user-friendly `ProcessException` suggesting to either set `Headless` to `true` or use `xvfb-run`
- Ports upstream puppeteer PR [#14306](https://github.com/puppeteer/puppeteer/pull/14306)

Closes #2984

## Changes
- **`lib/PuppeteerSharp/Launcher.cs`**: Added `IsMissingXServer` helper method and a check in the outer catch block of `LaunchAsync` that detects "Missing X server" in process output when `HeadlessMode.False` is set

## Test plan
- [x] Existing `LauncherTests` pass (40 passed, 7 skipped — same as before)
- [ ] Manual verification: launch headful browser on a headless Linux server to confirm the improved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)