### PR TITLE
Fix: use the correct type for pageerror event (#14349) (#2976)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/error-primitive.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/error-primitive.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script>
+a();
+
+function a() {
+    throw undefined;
+}
+</script>

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsPageErrorTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsPageErrorTests.cs
@@ -29,5 +29,26 @@ namespace PuppeteerSharp.Tests.PageTests
             var error = await errorTask.Task;
             Assert.That(error, Does.Contain("Fancy"));
         }
+
+        [Test, PuppeteerTest("page.spec", "Page Page.Events.PageError", "should fire for all value types")]
+        public async Task ShouldFireForAllValueTypes()
+        {
+            var errorTask = new TaskCompletionSource<PageErrorEventArgs>();
+            void EventHandler(object sender, PageErrorEventArgs e)
+            {
+                errorTask.TrySetResult(e);
+                Page.PageError -= EventHandler;
+            }
+
+            Page.PageError += EventHandler;
+
+            await Task.WhenAll(
+                errorTask.Task,
+                Page.GoToAsync(TestConstants.ServerUrl + "/error-primitive.html")
+            );
+
+            var error = await errorTask.Task;
+            Assert.That(error.Error, Is.Null);
+        }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -1252,7 +1252,30 @@ public class CdpPage : Page
         => OnMetrics(new MetricEventArgs(metrics.Title, BuildMetricsObject(metrics.Metrics)));
 
     private void HandleException(EvaluateExceptionResponseDetails exceptionDetails)
-        => OnPageError(new PageErrorEventArgs(GetExceptionMessage(exceptionDetails)));
+    {
+        var exception = exceptionDetails.Exception;
+
+        if (exception != null &&
+            (exception.Type != RemoteObjectType.Object || exception.Subtype != RemoteObjectSubtype.Error) &&
+            string.IsNullOrEmpty(exception.ObjectId))
+        {
+            var primitiveValue = GetPrimitiveValueFromException(exception);
+            OnPageError(new PageErrorEventArgs(exceptionDetails.Text, primitiveValue));
+            return;
+        }
+
+        OnPageError(new PageErrorEventArgs(GetExceptionMessage(exceptionDetails)));
+    }
+
+    private object GetPrimitiveValueFromException(EvaluateExceptionResponseInfo exception)
+    {
+        if (exception.Type == RemoteObjectType.Undefined)
+        {
+            return null;
+        }
+
+        return exception.Value;
+    }
 
     private Dictionary<string, decimal> BuildMetricsObject(List<Metric> metrics)
     {

--- a/lib/PuppeteerSharp/Cdp/Messaging/EvaluateExceptionResponseInfo.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/EvaluateExceptionResponseInfo.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using PuppeteerSharp.Helpers.Json;
 
@@ -6,6 +7,12 @@ namespace PuppeteerSharp.Cdp.Messaging
     internal class EvaluateExceptionResponseInfo
     {
         public string Description { get; set; }
+
+        public RemoteObjectType Type { get; set; }
+
+        public RemoteObjectSubtype Subtype { get; set; }
+
+        public string ObjectId { get; set; }
 
         [JsonConverter(typeof(AnyTypeToStringConverter))]
         public string Value { get; set; }

--- a/lib/PuppeteerSharp/PageErrorEventArgs.cs
+++ b/lib/PuppeteerSharp/PageErrorEventArgs.cs
@@ -11,12 +11,33 @@ namespace PuppeteerSharp
         /// Initializes a new instance of the <see cref="PageErrorEventArgs"/> class.
         /// </summary>
         /// <param name="message">Message.</param>
-        public PageErrorEventArgs(string message) => Message = message;
+        public PageErrorEventArgs(string message)
+        {
+            Message = message;
+            Error = message;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageErrorEventArgs"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="error">Raw error value.</param>
+        public PageErrorEventArgs(string message, object error)
+        {
+            Message = message;
+            Error = error;
+        }
 
         /// <summary>
         /// Error Message.
         /// </summary>
         /// <value>The message.</value>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Gets the raw error value. This can be an <see cref="string"/> for standard errors,
+        /// or any other type (including <c>null</c>) when the page throws a primitive value.
+        /// </summary>
+        public object Error { get; }
     }
 }


### PR DESCRIPTION
## Summary
- Handles primitive thrown values (like `undefined`) in the `PageError` event, matching upstream puppeteer PR #14349
- Added `Type`, `Subtype`, and `ObjectId` properties to `EvaluateExceptionResponseInfo` to detect primitive vs Error exceptions
- Added `Error` property to `PageErrorEventArgs` to expose the raw error value (can be `null` for `undefined`, a string, or other primitive)
- When a page throws a non-Error value, `HandleException` in `CdpPage` now returns the primitive value instead of building an error message
- Added test asset `error-primitive.html` and test `ShouldFireForAllValueTypes`

## Upstream PR
https://github.com/puppeteer/puppeteer/pull/14349

## Test plan
- [x] `ShouldFire` test passes (Chrome+CDP)
- [x] `ShouldFireForAllValueTypes` test passes (Chrome+CDP)
- [x] Firefox+BiDi correctly skips the new test per upstream expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)