### PR TITLE
Fix: Respect isBlocked in request interception (#14264)

### DIFF
--- a/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/PageSetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionExperimentalTests/PageSetRequestInterceptionTests.cs
@@ -720,6 +720,7 @@ public class PageSetRequestInterceptionTests : PuppeteerPageBaseTest
             }
         });
         await Page.GoToAsync(TestConstants.EmptyPage);
+        Assert.That(exception, Is.Not.Null);
         Assert.That(exception.Message, Does.Contain("Request Interception is not enabled"));
     }
 

--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/SetRequestInterceptionTests.cs
@@ -598,6 +598,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
                 }
             };
             await Page.GoToAsync(TestConstants.EmptyPage);
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception.Message, Does.Contain("Request Interception is not enabled"));
         }
 

--- a/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
@@ -101,16 +101,11 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
     /// </summary>
     private bool PageLevelInterceptionEnabled => BidiPage.IsNetworkInterceptionEnabled;
 
-    /// <summary>
-    /// Gets whether this specific request can be intercepted (i.e., is blocked by the browser).
-    /// </summary>
-    private bool CanBeIntercepted => _request.IsBlocked;
-
     private InterceptResolutionState InterceptResolutionState
     {
         get
         {
-            if (!CanBeIntercepted)
+            if (!CanBeIntercepted())
             {
                 return new InterceptResolutionState(InterceptResolutionAction.Disabled);
             }
@@ -124,19 +119,9 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
     /// <inheritdoc />
     public override async Task ContinueAsync(Payload payloadOverrides = null, int? priority = null)
     {
-        // First verify that page-level interception is enabled
-        if (!PageLevelInterceptionEnabled)
-        {
-            throw new PuppeteerException("Request Interception is not enabled!");
-        }
+        VerifyInterception();
 
-        if (_isInterceptResolutionHandled)
-        {
-            throw new PuppeteerException("Request is already handled!");
-        }
-
-        // If this specific request is not blocked, return early (don't throw)
-        if (!CanBeIntercepted)
+        if (!CanBeIntercepted())
         {
             return;
         }
@@ -175,19 +160,9 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
             throw new ArgumentNullException(nameof(response));
         }
 
-        // First verify that page-level interception is enabled
-        if (!PageLevelInterceptionEnabled)
-        {
-            throw new PuppeteerException("Request Interception is not enabled!");
-        }
+        VerifyInterception();
 
-        if (_isInterceptResolutionHandled)
-        {
-            throw new PuppeteerException("Request is already handled!");
-        }
-
-        // If this specific request is not blocked, return early (don't throw)
-        if (!CanBeIntercepted)
+        if (!CanBeIntercepted())
         {
             return;
         }
@@ -220,19 +195,9 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
     /// <inheritdoc />
     public override async Task AbortAsync(RequestAbortErrorCode errorCode = RequestAbortErrorCode.Failed, int? priority = null)
     {
-        // First verify that page-level interception is enabled
-        if (!PageLevelInterceptionEnabled)
-        {
-            throw new PuppeteerException("Request Interception is not enabled!");
-        }
+        VerifyInterception();
 
-        if (_isInterceptResolutionHandled)
-        {
-            throw new PuppeteerException("Request is already handled!");
-        }
-
-        // If this specific request is not blocked, return early (don't throw)
-        if (!CanBeIntercepted)
+        if (!CanBeIntercepted())
         {
             return;
         }
@@ -311,7 +276,7 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
                 // we need to continue it to allow the browser to proceed.
                 // This happens when interception is enabled but no handler called
                 // ContinueAsync, AbortAsync, or RespondAsync.
-                if (CanBeIntercepted)
+                if (CanBeIntercepted())
                 {
                     await ContinueInternalAsync().ConfigureAwait(false);
                 }
@@ -322,6 +287,23 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
 
     internal override void EnqueueInterceptionActionCore(Func<IRequest, Task> pendingHandler)
         => _interceptHandlers.Add(pendingHandler);
+
+    /// <inheritdoc/>
+    protected override void VerifyInterception()
+    {
+        if (!PageLevelInterceptionEnabled)
+        {
+            throw new PuppeteerException("Request Interception is not enabled!");
+        }
+
+        if (_isInterceptResolutionHandled)
+        {
+            throw new PuppeteerException("Request is already handled!");
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override bool CanBeIntercepted() => _request.IsBlocked;
 
     private static List<Header> ConvertToBidiHeaders(Dictionary<string, string> headers)
     {
@@ -629,7 +611,7 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
             BidiPage.OnRequest(this);
         }
 
-        if (HasInternalHeaderOverwrite && CanBeIntercepted)
+        if (HasInternalHeaderOverwrite && CanBeIntercepted())
         {
             _interception.Handlers.Add(async () =>
             {

--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -99,5 +99,17 @@ namespace PuppeteerSharp
         /// </summary>
         /// <param name="pendingHandler">The handler to execute.</param>
         internal abstract void EnqueueInterceptionActionCore(Func<IRequest, Task> pendingHandler);
+
+        /// <summary>
+        /// Verifies that request interception is enabled and the request has not been handled yet.
+        /// </summary>
+        /// <exception cref="PuppeteerException">Thrown when interception is not enabled or request is already handled.</exception>
+        protected abstract void VerifyInterception();
+
+        /// <summary>
+        /// Determines whether this request can be intercepted.
+        /// </summary>
+        /// <returns><c>true</c> if the request can be intercepted; otherwise, <c>false</c>.</returns>
+        protected abstract bool CanBeIntercepted();
     }
 }


### PR DESCRIPTION
## Summary
- Adds abstract `VerifyInterception()` and `CanBeIntercepted()` methods to the base `Request` class
- Reorders checks in `ContinueAsync`/`RespondAsync`/`AbortAsync`: verify interception is enabled first, then check if the request can actually be intercepted
- **CdpHttpRequest**: `CanBeIntercepted()` checks for `data:` URLs and memory cache; removes assertions from property getters
- **BidiHttpRequest**: `CanBeIntercepted()` returns `_request.IsBlocked` (the key fix - respects the BiDi blocked state)
- Adds `Assert.That(exception, Is.Not.Null)` guard to interception-not-enabled tests

## Upstream PR
[puppeteer/puppeteer#14264](https://github.com/puppeteer/puppeteer/pull/14264)

Closes #2966

## Changes
| File | Change |
|------|--------|
| `Request.cs` | Added `VerifyInterception()` and `CanBeIntercepted()` abstract methods |
| `CdpHttpRequest.cs` | Simplified property getters, implemented abstract methods, reordered checks |
| `BidiHttpRequest.cs` | Implemented abstract methods using `_request.IsBlocked`, reordered checks |
| `SetRequestInterceptionTests.cs` | Added null check before accessing exception message |
| `PageSetRequestInterceptionTests.cs` | Added null check before accessing exception message |

## Test plan
- [x] 66 `SetRequestInterceptionTests` pass
- [x] 46 `RequestInterceptionExperimentalTests` pass (1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)