### PR TITLE
Add function shorthands eval test to WontImplement list (#2961)

### DIFF
--- a/lib/PuppeteerSharp.Tests/WontImplementTests.cs
+++ b/lib/PuppeteerSharp.Tests/WontImplementTests.cs
@@ -46,6 +46,7 @@ namespace PuppeteerSharp.Tests
         [PuppeteerTest("tracing.spec", "Tracing", "should return undefined in case of Buffer error")]
         [PuppeteerTest("DeviceRequestPrompt.test.ts", "waitForDevicePrompt", "should listen and shortcut when there are no watchdogs")]
         [PuppeteerTest("DeviceRequestPrompt.test.ts", "DeviceRequestPrompt.waitForDevice", "should listen and shortcut when there are no watchdogs")]
+        [PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should work with function shorthands and nested arrow functions")]
         public void TheseTestWontBeImplemented()
         {
         }


### PR DESCRIPTION
## Summary
- Adds upstream test "should work with function shorthands and nested arrow functions" from `evaluation.spec` to the WontImplement list
- This is a JS-specific fix for parsing function expressions (puppeteer/puppeteer#14226) that doesn't apply to C#

Closes #2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)