### PR TITLE
Fix: throw on history entry not found (#14160)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NavigationTests/PageGoBackTests.cs
+++ b/lib/PuppeteerSharp.Tests/NavigationTests/PageGoBackTests.cs
@@ -20,9 +20,16 @@ namespace PuppeteerSharp.Tests.NavigationTests
             response = await Page.GoForwardAsync();
             Assert.That(response.Ok, Is.True);
             Assert.That(response.Url, Does.Contain("grid"));
+        }
 
-            response = await Page.GoForwardAsync();
-            Assert.That(response, Is.Null);
+        [Test, PuppeteerTest("navigation.spec", "navigation Page.goBack", "should error if no history is found")]
+        public async Task ShouldErrorIfNoHistoryIsFound()
+        {
+            var exception = Assert.CatchAsync<PuppeteerException>(async () => await Page.GoBackAsync());
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(
+                exception.Message,
+                Does.Contain("History entry to navigate to not found.").Or.Contain("no such history entry"));
         }
 
         [Test, PuppeteerTest("navigation.spec", "navigation Page.goBack", "should work with HistoryAPI")]
@@ -35,11 +42,13 @@ namespace PuppeteerSharp.Tests.NavigationTests
             ");
             Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/second.html"));
 
-            await Page.GoBackAsync();
+            var response = await Page.GoBackAsync();
+            Assert.That(response, Is.Null);
             Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/first.html"));
             await Page.GoBackAsync();
             Assert.That(Page.Url, Is.EqualTo(TestConstants.EmptyPage));
-            await Page.GoForwardAsync();
+            response = await Page.GoForwardAsync();
+            Assert.That(response, Is.Null);
             Assert.That(Page.Url, Is.EqualTo(TestConstants.ServerUrl + "/first.html"));
         }
     }

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -1342,11 +1342,6 @@ public class BidiPage : Page
         }
         catch (Exception ex)
         {
-            if (ex.Message.Contains("no such history entry"))
-            {
-                return null;
-            }
-
             throw new NavigationException(ex.Message, ex);
         }
 

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -1397,7 +1397,7 @@ public class CdpPage : Page
 
         if (history.Entries.Count <= history.CurrentIndex + delta || history.CurrentIndex + delta < 0)
         {
-            return null;
+            throw new PuppeteerException("History entry to navigate to not found.");
         }
 
         var entry = history.Entries[history.CurrentIndex + delta];


### PR DESCRIPTION
## Summary
- Ports upstream [puppeteer/puppeteer#14160](https://github.com/puppeteer/puppeteer/commit/f660ef8e520c9d2356df6aee7d7b01b7f9882016) to PuppeteerSharp
- `GoBackAsync()` and `GoForwardAsync()` now throw instead of returning `null` when no history entry exists
- **CdpPage**: Changed `return null` to `throw new PuppeteerException("History entry to navigate to not found.")`
- **BidiPage**: Removed the catch block that swallowed "no such history entry" errors, letting them propagate as `NavigationException`
- Added new test `ShouldErrorIfNoHistoryIsFound` matching upstream
- Updated `ShouldWork` test to remove the `null` assertion on forward with no history
- Updated `ShouldWorkWithHistoryAPI` test to assert `null` response for same-document history navigation (matching upstream)

## Test plan
- [x] Run `PageGoBackTests` with Chrome/CDP — 3/3 pass
- [x] Run `PageGoBackTests` with Firefox/BiDi — 3/3 pass
- [x] Run full `NavigationTests` suite with Chrome/CDP — 56/56 pass
- [x] Run full `NavigationTests` suite with Firefox/BiDi — 49 pass, 7 skipped (pre-existing skips)

Closes #2958

🤖 Generated with [Claude Code](https://claude.com/claude-code)