### PR TITLE
Fix: return the parent's handle for accessibility text nodes instead of the text node

### DIFF
--- a/lib/PuppeteerSharp.Tests/AccessibilityTests/RootOptionTests.cs
+++ b/lib/PuppeteerSharp.Tests/AccessibilityTests/RootOptionTests.cs
@@ -121,6 +121,41 @@ namespace PuppeteerSharp.Tests.AccessibilityTests
             Assert.That(fullSnapshot.Children[0].Children[0].Name, Is.EqualTo("My Button"));
         }
 
+        [Test, PuppeteerTest("accessibility.spec", "root option", "should get the parent ElementHandle from a text node accessibility node")]
+        public async Task ShouldGetTheParentElementHandleFromATextNodeAccessibilityNode()
+        {
+            await Page.SetContentAsync("<div><b>Hello, </b> world!</div>");
+            var div = await Page.QuerySelectorAsync("div");
+
+            var parentSnapshot = await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+            {
+                Root = div,
+                InterestingOnly = false,
+            });
+
+            Assert.That(parentSnapshot.Role, Is.EqualTo("generic"));
+            Assert.That(parentSnapshot.Name, Is.EqualTo(""));
+            Assert.That(parentSnapshot.Children, Has.Length.EqualTo(2));
+            Assert.That(parentSnapshot.Children[0].Role, Is.EqualTo("StaticText"));
+            Assert.That(parentSnapshot.Children[0].Name, Is.EqualTo("Hello, "));
+            Assert.That(parentSnapshot.Children[1].Role, Is.EqualTo("StaticText"));
+            Assert.That(parentSnapshot.Children[1].Name, Is.EqualTo("world!"));
+
+            var textNode = await div.EvaluateFunctionHandleAsync("el => el.lastChild");
+            var snapshot = await Page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions { Root = textNode as IElementHandle ?? (IElementHandle)textNode });
+
+            // Get the element handle from the text node.
+            // This should be the parent's handle, not the text node's.
+            var parentNodeHandle = await parentSnapshot.ElementHandleAsync();
+            var textNodeHandle = await snapshot.ElementHandleAsync();
+
+            var parentInnerHtml = await parentNodeHandle.EvaluateFunctionAsync<string>("el => el.innerHTML");
+            var textNodeInnerHtml = await textNodeHandle.EvaluateFunctionAsync<string>("el => el.innerHTML");
+
+            Assert.That(parentInnerHtml, Is.EqualTo(textNodeInnerHtml));
+            Assert.That(textNodeInnerHtml, Is.EqualTo("<b>Hello, </b> world!"));
+        }
+
         [Test, PuppeteerTest("accessibility.spec", "root option", "should work with nested button inside h1 with interestingOnly:true")]
         public async Task ShouldWorkWithNestedButtonInsideH1WithInterestingOnlyTrue()
         {

--- a/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using PuppeteerSharp.Cdp.Messaging;
 using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Helpers.Json;
@@ -24,10 +25,12 @@ namespace PuppeteerSharp.PageAccessibility
         private readonly string _roledescription;
         private readonly string _live;
         private readonly bool _ignored;
+        private readonly Realm _realm;
         private bool? _cachedHasFocusableChild;
 
-        private AXNode(AccessibilityGetFullAXTreeResponse.AXTreeNode payload)
+        private AXNode(Realm realm, AccessibilityGetFullAXTreeResponse.AXTreeNode payload)
         {
+            _realm = realm;
             Payload = payload;
 
             _role = payload.Role != null ? payload.Role.Value.ToObject<string>() : "Unknown";
@@ -55,12 +58,12 @@ namespace PuppeteerSharp.PageAccessibility
 
         internal AccessibilityGetFullAXTreeResponse.AXTreeNode Payload { get; }
 
-        internal static AXNode CreateTree(IEnumerable<AccessibilityGetFullAXTreeResponse.AXTreeNode> payloads)
+        internal static AXNode CreateTree(Realm realm, IEnumerable<AccessibilityGetFullAXTreeResponse.AXTreeNode> payloads)
         {
             var nodeById = new Dictionary<string, AXNode>();
             foreach (var payload in payloads)
             {
-                nodeById[payload.NodeId] = new AXNode(payload);
+                nodeById[payload.NodeId] = new AXNode(realm, payload);
             }
 
             foreach (var node in nodeById.Values)
@@ -255,8 +258,22 @@ namespace PuppeteerSharp.PageAccessibility
                 properties["description"] = Payload.Description.Value;
             }
 
+            var realm = _realm;
+            var backendDOMNodeId = Payload.BackendDOMNodeId;
+
             var node = new SerializedAXNode
             {
+                ElementHandleFactory = backendDOMNodeId.ValueKind == JsonValueKind.Number && realm != null
+                    ? async () =>
+                    {
+                        var handle = await realm.AdoptBackendNodeAsync(backendDOMNodeId.GetInt32()).ConfigureAwait(false);
+
+                        // Since Text nodes are not elements, we want to
+                        // return a handle to the parent element for them.
+                        return await ((ElementHandle)handle).EvaluateFunctionHandleAsync(
+                            "node => node.nodeType === Node.TEXT_NODE ? node.parentElement : node").ConfigureAwait(false) as IElementHandle;
+                    }
+                : null,
                 Role = _role,
                 Name = properties.GetValue("name")?.ToObject<string>(),
                 Value = properties.GetValue("value")?.ToObject<object>()?.ToString(),

--- a/lib/PuppeteerSharp/PageAccessibility/Accessibility.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/Accessibility.cs
@@ -41,7 +41,8 @@ namespace PuppeteerSharp.PageAccessibility
                 backendNodeId = node.Node.BackendNodeId;
             }
 
-            var defaultRoot = AXNode.CreateTree(nodes);
+            var realm = _realmProvider?.Invoke();
+            var defaultRoot = AXNode.CreateTree(realm, nodes);
             if (defaultRoot == null)
             {
                 return null;

--- a/lib/PuppeteerSharp/PageAccessibility/SerializedAXNode.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/SerializedAXNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace PuppeteerSharp.PageAccessibility
 {
@@ -177,6 +178,16 @@ namespace PuppeteerSharp.PageAccessibility
         /// Child nodes of this node, if any.
         /// </summary>
         public SerializedAXNode[] Children { get; set; }
+
+        internal Func<Task<IElementHandle>> ElementHandleFactory { get; set; }
+
+        /// <summary>
+        /// Gets the element handle for this node.
+        /// For text nodes, returns the parent element's handle instead of the text node's.
+        /// </summary>
+        /// <returns>An <see cref="IElementHandle"/> for this node, or <c>null</c> if no handle is available.</returns>
+        public Task<IElementHandle> ElementHandleAsync()
+            => ElementHandleFactory != null ? ElementHandleFactory() : Task.FromResult<IElementHandle>(null);
 
         /// <inheritdoc/>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Exceptions should not be raised in this type of method.")]


### PR DESCRIPTION
## Summary

- Adds `ElementHandleAsync()` method to `SerializedAXNode` that returns an `IElementHandle` for the accessibility node
- For text nodes (e.g. `StaticText`), the method returns the **parent element's** handle instead of the text node's, enabling easier automation that mimics other query selectors
- Passes the `Realm` through to `AXNode` so it can create element handles via `AdoptBackendNodeAsync`

Upstream PR: https://github.com/puppeteer/puppeteer/pull/14159
Fixes #2957

## Changes

| File | Change |
|------|--------|
| `SerializedAXNode.cs` | Added `ElementHandleAsync()` public method and internal `ElementHandleFactory` delegate |
| `AXNode.cs` | Accepts `Realm` in constructor, wires up `ElementHandleFactory` in `Serialize()` with text node → parent element logic |
| `Accessibility.cs` | Passes `Realm` to `AXNode.CreateTree()` |
| `RootOptionTests.cs` | New test: `ShouldGetTheParentElementHandleFromATextNodeAccessibilityNode` |

## Test plan

- [x] New test `ShouldGetTheParentElementHandleFromATextNodeAccessibilityNode` passes
- [x] All 30 accessibility tests pass with Chrome/CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)