### PR TITLE
New Feature: Support offline parameter in emulateNetworkConditions

### DIFF
--- a/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateNetworkConditionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateNetworkConditionsTests.cs
@@ -10,6 +10,23 @@ namespace PuppeteerSharp.Tests.EmulationTests
         {
         }
 
+        [Test, PuppeteerTest("emulation.spec", "Emulation Page.emulateNetworkConditions", "should support offline")]
+        public async Task ShouldSupportOffline()
+        {
+            await Page.EmulateNetworkConditionsAsync(new NetworkConditions
+            {
+                Offline = true,
+                Download = 0,
+                Upload = 0,
+                Latency = 0,
+            });
+
+            Assert.ThrowsAsync<NavigationException>(async () =>
+            {
+                await Page.GoToAsync(TestConstants.EmptyPage);
+            });
+        }
+
         [Test, PuppeteerTest("emulation.spec", "Emulation Page.emulateNetworkConditions", "should change navigator.connection.effectiveType")]
         public async Task ShouldChangeNavigatorConnectionEffectiveType()
         {

--- a/lib/PuppeteerSharp/Cdp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/Cdp/NetworkManager.cs
@@ -156,6 +156,7 @@ namespace PuppeteerSharp.Cdp
         internal Task EmulateNetworkConditionsAsync(NetworkConditions networkConditions)
         {
             _emulatedNetworkConditions ??= new InternalNetworkConditions();
+            _emulatedNetworkConditions.Offline = networkConditions?.Offline ?? false;
             _emulatedNetworkConditions.Upload = networkConditions?.Upload ?? -1;
             _emulatedNetworkConditions.Download = networkConditions?.Download ?? -1;
             _emulatedNetworkConditions.Latency = networkConditions?.Latency ?? 0;


### PR DESCRIPTION
## Summary

- Propagates the `Offline` property from `NetworkConditions` in the CDP `NetworkManager.EmulateNetworkConditionsAsync` method
- Previously, calling `EmulateNetworkConditionsAsync` with `Offline = true` did not actually set the browser to offline mode because the `Offline` property was not being copied to the internal network conditions state
- Adds a test verifying that navigating while offline via `EmulateNetworkConditionsAsync` throws a `NavigationException`

## Upstream Reference

- Upstream PR: [puppeteer/puppeteer#14184](https://github.com/puppeteer/puppeteer/pull/14184)
- Issue: [#2955](https://github.com/hardkoded/puppeteer-sharp/issues/2955)

## Changes

### `lib/PuppeteerSharp/Cdp/NetworkManager.cs`
Added `_emulatedNetworkConditions.Offline = networkConditions?.Offline ?? false;` to `EmulateNetworkConditionsAsync`. The BiDi implementation (`BidiPage.cs`) already handled this correctly.

### `lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateNetworkConditionsTests.cs`
Added `ShouldSupportOffline` test matching upstream's `should support offline` test.

## Test plan

- [x] `PageEmulateNetworkConditionsTests` pass with Chrome/CDP
- [x] `OfflineMode` tests still pass with Chrome/CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)