### PR TITLE
Fix: typo in accessibility comment (#14169) (#2956)

### DIFF
--- a/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/AXNode.cs
@@ -268,7 +268,7 @@ namespace PuppeteerSharp.PageAccessibility
                 Disabled = properties.GetValue("disabled")?.ToObject<bool>() ?? false,
                 Expanded = properties.GetValue("expanded")?.ToObject<bool>() ?? false,
 
-                // RootWebArea's treat focus differently than other nodes. They report whether their frame  has focus,
+                // RootWebArea's treat focus differently than other nodes. They report whether their frame has focus,
                 // not whether focus is specifically on the root node.
                 Focused = properties.GetValue("focused")?.ToObject<bool>() == true && _role != "RootWebArea",
                 Modal = properties.GetValue("modal")?.ToObject<bool>() ?? false,


### PR DESCRIPTION
## Summary

Ports upstream PR [puppeteer/puppeteer#14169](https://github.com/puppeteer/puppeteer/pull/14169) — "fix(accessibility): reports snapshot with uninteresting root and focusable Document is not a leaf node".

### Changes applied
- Fixed double-space typo in `AXNode.Serialize()` comment about RootWebArea focus behavior

### Already implemented
The main behavioral changes from the upstream PR were already present in the C# codebase:
- **Removal of `interestingNodes.has(needle)` early return**: The C# `SnapshotAsync` method never had this early return — it already passes through to `SerializeTree` which correctly handles uninteresting root nodes by returning their interesting children
- **`interestingOnly` root option test updates**: The `ShouldSupportTheInterestingOnlyOption` test already covers the uninteresting div + div-with-button scenarios

### Reverted upstream
- The `focusable && name && name !== 'Document'` leaf node heuristic added in this PR was **reverted upstream** in [#14313](https://github.com/puppeteer/puppeteer/pull/14313), so it was intentionally not ported

## Test plan
- [x] All 29 accessibility tests pass with Chrome/CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)