### PR TITLE
New Feature: Add Browser.DeleteMatchingCookiesAsync() method

### DIFF
--- a/lib/PuppeteerSharp.Tests/CookiesTests/BrowserContextCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/BrowserContextCookiesTests.cs
@@ -1,0 +1,157 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.CookiesTests
+{
+    public class BrowserContextCookiesTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("browsercontext-cookies.spec", "BrowserContext cookies BrowserContext.deleteMatchingCookies", "should delete cookies matching {\"name\":\"cookie1\"}")]
+        public async Task ShouldDeleteCookiesMatchingName()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            Assert.That(await Context.GetCookiesAsync(), Is.Empty);
+            await Context.SetCookieAsync(
+                new CookieParam
+                {
+                    Name = "cookie1",
+                    Value = "secret",
+                    Domain = "localhost",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = false,
+                },
+                new CookieParam
+                {
+                    Name = "cookie2",
+                    Value = "secret",
+                    Domain = "localhost",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = false,
+                });
+            Assert.That(await Context.GetCookiesAsync(), Has.Length.EqualTo(2));
+            await Context.DeleteMatchingCookiesAsync(new DeleteCookiesRequest
+            {
+                Name = "cookie1",
+            });
+            var cookies = await Context.GetCookiesAsync();
+            Assert.That(cookies, Has.Length.EqualTo(1));
+            Assert.That(cookies[0].Name, Is.EqualTo("cookie2"));
+        }
+
+        [Test, PuppeteerTest("browsercontext-cookies.spec", "BrowserContext cookies BrowserContext.deleteMatchingCookies", "should delete cookies matching {\"url\":\"https://example.test/test\",\"name\":\"cookie1\"}")]
+        public async Task ShouldDeleteCookiesMatchingUrl()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            Assert.That(await Context.GetCookiesAsync(), Is.Empty);
+            await Context.SetCookieAsync(
+                new CookieParam
+                {
+                    Name = "cookie1",
+                    Value = "secret",
+                    Domain = "example.test",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = true,
+                },
+                new CookieParam
+                {
+                    Name = "cookie2",
+                    Value = "secret",
+                    Domain = "example.test",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = true,
+                });
+            Assert.That(await Context.GetCookiesAsync(), Has.Length.EqualTo(2));
+            await Context.DeleteMatchingCookiesAsync(new DeleteCookiesRequest
+            {
+                Url = "https://example.test/test",
+                Name = "cookie1",
+            });
+            var cookies = await Context.GetCookiesAsync();
+            Assert.That(cookies, Has.Length.EqualTo(1));
+            Assert.That(cookies[0].Name, Is.EqualTo("cookie2"));
+        }
+
+        [Test, PuppeteerTest("browsercontext-cookies.spec", "BrowserContext cookies BrowserContext.deleteMatchingCookies", "should delete cookies matching {\"domain\":\"example.test\",\"name\":\"cookie1\"}")]
+        public async Task ShouldDeleteCookiesMatchingDomain()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            Assert.That(await Context.GetCookiesAsync(), Is.Empty);
+            await Context.SetCookieAsync(
+                new CookieParam
+                {
+                    Name = "cookie1",
+                    Value = "secret",
+                    Domain = "example.test",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = true,
+                },
+                new CookieParam
+                {
+                    Name = "cookie2",
+                    Value = "secret",
+                    Domain = "example.test",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = true,
+                });
+            Assert.That(await Context.GetCookiesAsync(), Has.Length.EqualTo(2));
+            await Context.DeleteMatchingCookiesAsync(new DeleteCookiesRequest
+            {
+                Domain = "example.test",
+                Name = "cookie1",
+            });
+            var cookies = await Context.GetCookiesAsync();
+            Assert.That(cookies, Has.Length.EqualTo(1));
+            Assert.That(cookies[0].Name, Is.EqualTo("cookie2"));
+        }
+
+        [Test, PuppeteerTest("browsercontext-cookies.spec", "BrowserContext cookies BrowserContext.deleteMatchingCookies", "should delete cookies matching {\"path\":\"/test\",\"name\":\"cookie1\"}")]
+        public async Task ShouldDeleteCookiesMatchingPath()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            Assert.That(await Context.GetCookiesAsync(), Is.Empty);
+            await Context.SetCookieAsync(
+                new CookieParam
+                {
+                    Name = "cookie1",
+                    Value = "secret",
+                    Domain = "example.test",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = true,
+                },
+                new CookieParam
+                {
+                    Name = "cookie2",
+                    Value = "secret",
+                    Domain = "example.test",
+                    Path = "/test",
+                    Expires = -1,
+                    HttpOnly = false,
+                    Secure = true,
+                });
+            Assert.That(await Context.GetCookiesAsync(), Has.Length.EqualTo(2));
+            await Context.DeleteMatchingCookiesAsync(new DeleteCookiesRequest
+            {
+                Path = "/test",
+                Name = "cookie1",
+            });
+            var cookies = await Context.GetCookiesAsync();
+            Assert.That(cookies, Has.Length.EqualTo(1));
+            Assert.That(cookies[0].Name, Is.EqualTo("cookie2"));
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/Core/UserContext.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/UserContext.cs
@@ -25,9 +25,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using WebDriverBiDi.Browser;
 using WebDriverBiDi.BrowsingContext;
+using WebDriverBiDi.Storage;
+using BidiCookie = WebDriverBiDi.Network.Cookie;
 using BidiPermissionState = WebDriverBiDi.Permissions.PermissionState;
 using SetPermissionCommandParameters = WebDriverBiDi.Permissions.SetPermissionCommandParameters;
 
@@ -128,6 +131,33 @@ internal class UserContext : IDisposable
         {
             Dispose("User context already closed.");
         }
+    }
+
+    public async Task<BidiCookie[]> GetCookiesAsync(string sourceOrigin = null)
+    {
+        var result = await Session.Driver.Storage.GetCookiesAsync(
+            new GetCookiesCommandParameters
+            {
+                Partition = new StorageKeyPartitionDescriptor
+                {
+                    UserContextId = Id,
+                    SourceOrigin = sourceOrigin,
+                },
+            }).ConfigureAwait(false);
+        return result.Cookies.ToArray();
+    }
+
+    public async Task SetCookieAsync(PartialCookie cookie, string sourceOrigin = null)
+    {
+        await Session.Driver.Storage.SetCookieAsync(
+            new SetCookieCommandParameters(cookie)
+            {
+                Partition = new StorageKeyPartitionDescriptor
+                {
+                    SourceOrigin = sourceOrigin,
+                    UserContextId = Id,
+                },
+            }).ConfigureAwait(false);
     }
 
     public async Task SetPermissionsAsync(

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -179,6 +179,10 @@ namespace PuppeteerSharp
             => DefaultContext.SetPermissionAsync(origin, permissions);
 
         /// <inheritdoc/>
+        public Task DeleteMatchingCookiesAsync(params DeleteCookiesRequest[] filters)
+            => DefaultContext.DeleteMatchingCookiesAsync(filters);
+
+        /// <inheritdoc/>
         public Task<ICDPSession> CreateCDPSessionAsync() => Target.CreateCDPSessionAsync();
 
         /// <inheritdoc/>

--- a/lib/PuppeteerSharp/Cdp/Messaging/StorageGetCookiesRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/StorageGetCookiesRequest.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class StorageGetCookiesRequest
+    {
+        public string BrowserContextId { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/StorageGetCookiesResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/StorageGetCookiesResponse.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class StorageGetCookiesResponse
+    {
+        public CookieParam[] Cookies { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/StorageSetCookiesRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/StorageSetCookiesRequest.cs
@@ -1,0 +1,9 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class StorageSetCookiesRequest
+    {
+        public string BrowserContextId { get; set; }
+
+        public CookieParam[] Cookies { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/DeleteCookiesRequest.cs
+++ b/lib/PuppeteerSharp/DeleteCookiesRequest.cs
@@ -1,0 +1,35 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Request to delete cookies matching specific filters.
+    /// </summary>
+    public class DeleteCookiesRequest
+    {
+        /// <summary>
+        /// Gets or sets the name of the cookies to remove.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL. If specified, deletes all the cookies with the given name where domain and path match
+        /// the provided URL.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the domain. If specified, deletes only cookies with the exact domain.
+        /// </summary>
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path. If specified, deletes only cookies with the exact path.
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the partition key. If specified, deletes cookies in the given partition key.
+        /// In Chrome, partitionKey matches the top-level site the partitioned cookie is available in.
+        /// </summary>
+        public string PartitionKey { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/IBrowser.cs
+++ b/lib/PuppeteerSharp/IBrowser.cs
@@ -277,6 +277,13 @@ namespace PuppeteerSharp
         Task SetPermissionAsync(string origin, params PermissionEntry[] permissions);
 
         /// <summary>
+        /// Deletes cookies matching the provided filters from the default <see cref="IBrowserContext"/>.
+        /// </summary>
+        /// <param name="filters">Filters to match cookies against.</param>
+        /// <returns>Task.</returns>
+        Task DeleteMatchingCookiesAsync(params DeleteCookiesRequest[] filters);
+
+        /// <summary>
         /// Creates a Chrome Devtools Protocol session attached to the browser.
         /// </summary>
         /// <returns>A task that returns a <see cref="ICDPSession"/>.</returns>

--- a/lib/PuppeteerSharp/IBrowserContext.cs
+++ b/lib/PuppeteerSharp/IBrowserContext.cs
@@ -47,6 +47,33 @@ namespace PuppeteerSharp
         Task ClearPermissionOverridesAsync();
 
         /// <summary>
+        /// Gets all cookies in the browser context.
+        /// </summary>
+        /// <returns>Task which resolves to an array of <see cref="CookieParam"/>.</returns>
+        Task<CookieParam[]> GetCookiesAsync();
+
+        /// <summary>
+        /// Sets cookies in the browser context.
+        /// </summary>
+        /// <param name="cookies">Cookies to set.</param>
+        /// <returns>Task.</returns>
+        Task SetCookieAsync(params CookieParam[] cookies);
+
+        /// <summary>
+        /// Removes cookies from the browser context.
+        /// </summary>
+        /// <param name="cookies">Complete <see cref="CookieParam"/> objects to be removed.</param>
+        /// <returns>Task.</returns>
+        Task DeleteCookieAsync(params CookieParam[] cookies);
+
+        /// <summary>
+        /// Deletes cookies matching the provided filters in this browser context.
+        /// </summary>
+        /// <param name="filters">Filters to match cookies against.</param>
+        /// <returns>Task.</returns>
+        Task DeleteMatchingCookiesAsync(params DeleteCookiesRequest[] filters);
+
+        /// <summary>
         /// Closes the browser context. All the targets that belong to the browser context will be closed.
         /// </summary>
         /// <returns>Task.</returns>


### PR DESCRIPTION
## Summary
- Adds `DeleteMatchingCookiesAsync` to `IBrowserContext`/`BrowserContext` and `IBrowser`/`Browser` to delete cookies by filter criteria (name, domain, path, URL, partition key)
- Adds supporting BrowserContext-level cookie infrastructure: `GetCookiesAsync`, `SetCookieAsync`, `DeleteCookieAsync`
- Implements CDP support via `Storage.getCookies`/`Storage.setCookies` commands and BiDi support via `UserContext` cookie methods

## Upstream PR
Ports [puppeteer#14175](https://github.com/puppeteer/puppeteer/pull/14175) - `feat: add Browser.deleteMatchingCookies() method`

## Changes
| File | Description |
|------|-------------|
| `DeleteCookiesRequest.cs` | New class for specifying cookie deletion filters |
| `IBrowserContext.cs` / `BrowserContext.cs` | Added `GetCookiesAsync`, `SetCookieAsync`, `DeleteCookieAsync`, `DeleteMatchingCookiesAsync` |
| `IBrowser.cs` / `Browser.cs` | Added `DeleteMatchingCookiesAsync` shortcut delegating to default context |
| `CdpBrowserContext.cs` | CDP implementation using `Storage.getCookies`/`Storage.setCookies` |
| `BidiBrowserContext.cs` | BiDi implementation via `UserContext` cookie methods |
| `UserContext.cs` | Added `GetCookiesAsync` and `SetCookieAsync` using WebDriver BiDi Storage API |
| `StorageGet/SetCookiesRequest/Response.cs` | CDP messaging classes for Storage domain |
| `BrowserContextCookiesTests.cs` | 4 tests covering deletion by name, URL, domain, and path |

## Test plan
- [x] All 4 new `BrowserContextCookiesTests` pass with Chrome/CDP
- [x] All 4 new `BrowserContextCookiesTests` pass with Firefox/BiDi
- [x] All 34 existing cookie tests still pass
- [x] All 24 existing BrowserContext tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)