### PR TITLE
New Feature: Add Browser.InstallExtensionAsync and Browser.UninstallExtensionAsync (#13810) (#2920)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -117,5 +117,12 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["FAIL"]
+  },
+  {
+    "comment": "PuppeteerSharp does not support pipe mode, which is required for Extensions.loadUnpacked CDP command",
+    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"]
   }
 ]

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -1916,6 +1916,13 @@
   {
     "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
     "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox is currently only able to install signed extensions."
+  },
+  {
+    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
+    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL"],
     "comment": "Extensions are not supported in shell mode."

--- a/lib/PuppeteerSharp.Tests/Assets/simple-extension/manifest.json
+++ b/lib/PuppeteerSharp.Tests/Assets/simple-extension/manifest.json
@@ -1,4 +1,5 @@
 {
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkdj/foSvjYv+9rAjepZIQ3ghb4630EA+xEuUal77xb/NVKcHEamKHEsDKMLTSsmA0qv8biWEqSiZ5JQIdO7KagYCkFOFjHlyPkHgMCmLo14x6sqzQh1XGlALIWiLJXEA3/Z2Kde+dt0iQEbn0B9PBLo+2yghwxlS+YeP3k9YVEpvtq6Yj8v4JUqVT+8rF0A9GIHUvga30wFUpi2W1Fpiqpu+3DbOUn4LXDSgyK8q9h4H21rnAa9Y0tGkxf2Tl7Hy+Q2JuibUa6GrRKojY0TRaFv5H0Y33CtnvIbYFct/6ZpvJCTT1HmDm5yUR1aUY5PGGVREmj5PMbmPK4EwybYckQIDAQAB",
   "name": "Simple extension",
   "version": "0.1",
   "background": {

--- a/lib/PuppeteerSharp.Tests/WebExtensionTests/WebExtensionTests.cs
+++ b/lib/PuppeteerSharp.Tests/WebExtensionTests/WebExtensionTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.WebExtensionTests
+{
+    public class WebExtensionTests : PuppeteerBaseTest
+    {
+        private static readonly string _extensionPath = Path.Combine(AppContext.BaseDirectory, "Assets", "simple-extension");
+        private const string ExpectedId = "mbljndkcfjhaffohbnmoedabegpolpmd";
+
+        [Test, PuppeteerTest("webExtension.spec", "webExtension", "can install and uninstall an extension")]
+        public async Task CanInstallAndUninstallAnExtension()
+        {
+            var options = TestConstants.DefaultBrowserOptions();
+
+            if (TestConstants.IsChrome)
+            {
+                options.IgnoredDefaultArgs = new[] { "--disable-extensions" };
+                options.Args = new[] { "--enable-unsafe-extension-debugging" }
+                    .Concat(options.Args ?? Array.Empty<string>())
+                    .ToArray();
+            }
+
+            await using var browser = await Puppeteer.LaunchAsync(
+                options,
+                TestConstants.LoggerFactory);
+
+            // Install an extension. Since the `key` field is present in the
+            // manifest, this should always have the same ID.
+            Assert.That(await browser.InstallExtensionAsync(_extensionPath), Is.EqualTo(ExpectedId));
+
+            // Check we can uninstall the extension.
+            await browser.UninstallExtensionAsync(ExpectedId);
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
@@ -192,6 +192,22 @@ public class BidiBrowser : Browser
     public override Task RemoveScreenAsync(string screenId)
         => throw new NotSupportedException("RemoveScreen is not supported in WebDriver BiDi.");
 
+    /// <inheritdoc/>
+    public override async Task<string> InstallExtensionAsync(string path)
+    {
+        var result = await Driver.WebExtension.InstallAsync(
+            new WebDriverBiDi.WebExtension.InstallCommandParameters(
+                new WebDriverBiDi.WebExtension.ExtensionPath(path))).ConfigureAwait(false);
+        return result.ExtensionId;
+    }
+
+    /// <inheritdoc/>
+    public override async Task UninstallExtensionAsync(string id)
+    {
+        await Driver.WebExtension.UninstallAsync(
+            new WebDriverBiDi.WebExtension.UninstallCommandParameters(id)).ConfigureAwait(false);
+    }
+
     /// <inheritdoc />
     public override ITarget[] Targets()
         =>

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -94,6 +94,12 @@ namespace PuppeteerSharp
         public abstract Task RemoveScreenAsync(string screenId);
 
         /// <inheritdoc/>
+        public abstract Task<string> InstallExtensionAsync(string path);
+
+        /// <inheritdoc/>
+        public abstract Task UninstallExtensionAsync(string id);
+
+        /// <inheritdoc/>
         public async Task<IPage[]> PagesAsync()
             => (await Task.WhenAll(
                 BrowserContexts().Select(t => t.PagesAsync())).ConfigureAwait(false))

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -192,6 +192,21 @@ public class CdpBrowser : Browser
         await Connection.SendAsync("Emulation.removeScreen", new EmulationRemoveScreenRequest { ScreenId = screenId }).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
+    public override async Task<string> InstallExtensionAsync(string path)
+    {
+        var response = await Connection.SendAsync<ExtensionsLoadUnpackedResponse>(
+            "Extensions.loadUnpacked",
+            new ExtensionsLoadUnpackedRequest { Path = path }).ConfigureAwait(false);
+        return response.Id;
+    }
+
+    /// <inheritdoc/>
+    public override async Task UninstallExtensionAsync(string id)
+    {
+        await Connection.SendAsync("Extensions.uninstall", new ExtensionsUninstallRequest { Id = id }).ConfigureAwait(false);
+    }
+
     internal static async Task<CdpBrowser> CreateAsync(
         SupportedBrowser browserToCreate,
         Connection connection,

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsLoadUnpackedRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsLoadUnpackedRequest.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class ExtensionsLoadUnpackedRequest
+    {
+        public string Path { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsLoadUnpackedResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsLoadUnpackedResponse.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class ExtensionsLoadUnpackedResponse
+    {
+        public string Id { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsUninstallRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsUninstallRequest.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class ExtensionsUninstallRequest
+    {
+        public string Id { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/IBrowser.cs
+++ b/lib/PuppeteerSharp/IBrowser.cs
@@ -284,6 +284,24 @@ namespace PuppeteerSharp
         Task DeleteMatchingCookiesAsync(params DeleteCookiesRequest[] filters);
 
         /// <summary>
+        /// Installs an unpacked extension and returns the extension ID.
+        /// In Chrome, this is only available if the browser was created using pipe mode
+        /// and the <c>--enable-unsafe-extension-debugging</c> flag is set.
+        /// </summary>
+        /// <param name="path">The path to the unpacked extension directory.</param>
+        /// <returns>A task that resolves to the extension ID.</returns>
+        Task<string> InstallExtensionAsync(string path);
+
+        /// <summary>
+        /// Uninstalls a previously installed extension by its ID.
+        /// In Chrome, this is only available if the browser was created using pipe mode
+        /// and the <c>--enable-unsafe-extension-debugging</c> flag is set.
+        /// </summary>
+        /// <param name="id">The extension ID to uninstall.</param>
+        /// <returns>A task that completes when the extension is uninstalled.</returns>
+        Task UninstallExtensionAsync(string id);
+
+        /// <summary>
         /// Creates a Chrome Devtools Protocol session attached to the browser.
         /// </summary>
         /// <returns>A task that returns a <see cref="ICDPSession"/>.</returns>


### PR DESCRIPTION
## Summary
- Add `InstallExtensionAsync(path)` and `UninstallExtensionAsync(id)` methods to `IBrowser`, `Browser`, `CdpBrowser`, and `BidiBrowser`
- CDP implementation uses `Extensions.loadUnpacked` and `Extensions.uninstall` protocol commands
- BiDi implementation uses `WebDriverBiDi.WebExtension.InstallAsync` and `UninstallAsync`
- Add `key` field to test extension manifest for deterministic extension IDs
- Add `webExtension.spec` test with proper test expectations

## Upstream PR
- [puppeteer/puppeteer#13810](https://github.com/puppeteer/puppeteer/pull/13810) by @oliverdunk

## Notes
- CDP `Extensions.loadUnpacked` requires pipe mode which PuppeteerSharp doesn't support, so the Chrome CDP test is expected to fail (added local expectation)
- Firefox can only install signed extensions, so the Firefox test is expected to fail (upstream expectation)

## Test plan
- [x] Build succeeds with 0 errors
- [x] Existing extension tests pass (2 tests)
- [x] New WebExtension test correctly skipped for Chrome CDP (expected FAIL)
- [x] No test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)