### PR TITLE
New Feature: Expose CDPSession.Detached property (#13615) (#2890)

### DIFF
--- a/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
+++ b/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
@@ -140,5 +140,24 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
         [Test, PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should expose the underlying connection")]
         public async Task ShouldExposeTheUnderlyingConnection()
             => Assert.That(await Page.CreateCDPSessionAsync(), Is.Not.Null);
+
+        [Test, PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should keep the underlying connection after being detached")]
+        public async Task ShouldKeepTheUnderlyingConnectionAfterBeingDetached()
+        {
+            var client = await Page.CreateCDPSessionAsync();
+            var cdpSession = client as CDPSession;
+            var connection = cdpSession?.Connection;
+            await client.DetachAsync();
+            Assert.That(cdpSession?.Connection, Is.EqualTo(connection));
+        }
+
+        [Test, PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should expose detached state")]
+        public async Task ShouldExposeDetachedState()
+        {
+            var client = await Page.CreateCDPSessionAsync();
+            Assert.That(client.Detached, Is.False);
+            await client.DetachAsync();
+            Assert.That(client.Detached, Is.True);
+        }
     }
 }

--- a/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/MockCDPSession.cs
+++ b/lib/PuppeteerSharp.Tests/DeviceRequestPromptTests/MockCDPSession.cs
@@ -47,6 +47,7 @@ public class MockCDPSession : ICDPSession
 #pragma warning disable CS0067
 
     public string CloseReason { get; }
+    public bool Detached { get; }
     public bool IsClosed { get; }
     public ILoggerFactory LoggerFactory { get; }
     public string Id { get; } = "1";

--- a/lib/PuppeteerSharp/Bidi/BidiCdpSession.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiCdpSession.cs
@@ -59,6 +59,9 @@ public class BidiCdpSession(BidiFrame bidiFrame, ILoggerFactory loggerFactory) :
     /// <inheritdoc />
     public string CloseReason { get; private set; }
 
+    /// <inheritdoc />
+    public bool Detached { get; private set; }
+
     internal static IEnumerable<BidiCdpSession> Sessions => _sessions.Values;
 
     internal BidiFrame Frame { get; set; } = bidiFrame;

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -34,6 +34,9 @@ namespace PuppeteerSharp
         public string CloseReason { get; protected set; }
 
         /// <inheritdoc/>
+        public abstract bool Detached { get; }
+
+        /// <inheritdoc/>
         public ILoggerFactory LoggerFactory => Connection.LoggerFactory;
 
         internal Connection Connection { get; set; }

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -769,7 +769,7 @@ public class CdpPage : Page
     /// <inheritdoc/>
     public override async Task CloseAsync(PageCloseOptions options = null)
     {
-        if (Client?.Connection?.IsClosed ?? true)
+        if (Client?.Detached ?? true)
         {
             _logger.LogWarning("Protocol error: Connection closed. Most likely the page has been closed.");
             return;

--- a/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
@@ -92,7 +92,7 @@ public class CdpWebWorker : WebWorker
         switch (_targetType)
         {
             case TargetType.ServiceWorker:
-                if (CdpCDPSession.Connection != null)
+                if (!CdpCDPSession.Detached)
                 {
                     await CdpCDPSession.Connection.SendAsync(
                         "Target.closeTarget",
@@ -111,7 +111,7 @@ public class CdpWebWorker : WebWorker
 
                 break;
             case TargetType.SharedWorker:
-                if (CdpCDPSession.Connection != null)
+                if (!CdpCDPSession.Detached)
                 {
                     await CdpCDPSession.Connection.SendAsync(
                         "Target.closeTarget",

--- a/lib/PuppeteerSharp/ICDPSession.cs
+++ b/lib/PuppeteerSharp/ICDPSession.cs
@@ -66,6 +66,11 @@ namespace PuppeteerSharp
         string CloseReason { get; }
 
         /// <summary>
+        /// True if the session has been detached, false otherwise.
+        /// </summary>
+        bool Detached { get; }
+
+        /// <summary>
         /// Detaches session from target. Once detached, session won't emit any events and can't be used to send messages.
         /// </summary>
         /// <returns>A Task that when awaited detaches from the session target.</returns>


### PR DESCRIPTION
## Summary

- Adds a public `Detached` property to `ICDPSession`, `CDPSession`, `CdpCDPSession`, and `BidiCdpSession` that indicates whether the session has been detached from its target
- In the CDP implementation, `Detached` returns `true` when either the underlying connection is closed or the session has been explicitly detached
- The connection reference is now preserved after detach (no longer set to `null` in `Close()`) matching upstream behavior
- `DetachAsync()` and `SendAsync()` now check the `Detached` property instead of checking for `null` connection
- `CdpWebWorker` updated to use `Detached` instead of checking `Connection != null`
- Added `Detached` to `MockCDPSession` test helper

## Upstream Reference

Ports [puppeteer#13615](https://github.com/puppeteer/puppeteer/issues/13615) - "feat: expose CDPSession.detached"

Commit: `33e3e83d3c47e1fcedbbec186ae3ab98ae7cf025` by Alexey Pelykh

## Test plan

- [x] Added test: `ShouldKeepTheUnderlyingConnectionAfterBeingDetached` - verifies connection reference is preserved after detach
- [x] Added test: `ShouldExposeDetachedState` - verifies `Detached` is `false` before detach and `true` after
- [x] All 11 CDPSession tests pass (10 existing + 2 new; 1 pre-existing flaky test `ShouldSendEvents` occasionally catches extra favicon requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)