### PR TITLE
Fix: Don't wait for activation if the connection is disconnected

### DIFF
--- a/lib/PuppeteerSharp.Tests/LauncherTests/BrowserDisconnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/BrowserDisconnectTests.cs
@@ -49,7 +49,14 @@ namespace PuppeteerSharp.Tests.LauncherTests
             var watchdog = page.WaitForSelectorAsync("div", new WaitForSelectorOptions { Timeout = 60000 });
             remote.Disconnect();
             var exception = Assert.ThrowsAsync<WaitTaskTimeoutException>(() => watchdog);
-            Assert.That(exception!.Message, Does.Contain("Session closed"));
+            Assert.That(
+                new[]
+                {
+                    "frame got detached",
+                    "Frame detached",
+                    "Session closed",
+                    "Session already ended",
+                }.Any(value => exception!.Message.Contains(value)), Is.True);
         }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -525,6 +525,13 @@ namespace PuppeteerSharp.Cdp
                     return;
                 }
 
+                if (Client.Connection.IsClosed)
+                {
+                    // On connection disconnected remove all frames
+                    RemoveFramesRecursively(mainFrame);
+                    return;
+                }
+
                 foreach (var child in mainFrame.ChildFrames)
                 {
                     RemoveFramesRecursively(child as Frame);


### PR DESCRIPTION
## Summary

- When the browser connection is already disconnected, `FrameManager.OnClientDisconnectAsync` now immediately removes all frames recursively instead of waiting for the 200ms swap timeout. This prevents `waitForSelector` and similar operations from hanging when the browser disconnects before the activation swap can occur.
- Updated the `ShouldRejectWaitForSelectorWhenBrowserCloses` test to accept multiple possible error messages, matching upstream changes.

**Upstream PR:** https://github.com/puppeteer/puppeteer/commit/6b20ac10b1cc6a54a87eb2f6437727d204acd1c3

## Changes

### `FrameManager.cs`
Added an early return check in `OnClientDisconnectAsync()`: if `Client.Connection.IsClosed` is true, all frames are removed immediately without waiting for the swap timeout.

### `BrowserDisconnectTests.cs`
Updated `ShouldRejectWaitForSelectorWhenBrowserCloses` to accept multiple error messages ("frame got detached", "Frame detached", "Session closed", "Session already ended") since the error message can vary depending on timing.

## Test plan

- [x] `BrowserDisconnectTests` pass with Chrome/CDP
- [x] Full `LauncherTests` suite passes (40 passed, 7 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)