### PR TITLE
Fix: propagate CDP error in interception (#13607) (#2883)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -304,10 +304,7 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         catch (PuppeteerException ex)
         {
             IsInterceptResolutionHandled = false;
-
-            // In certain cases, protocol will return error if the request was already canceled
-            // or the page was closed. We should tolerate these errors
-            _logger.LogError(ex.ToString());
+            HandleError(ex);
         }
     }
 
@@ -326,10 +323,8 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         }
         catch (PuppeteerException ex)
         {
-            // In certain cases, protocol will return error if the request was already canceled
-            // or the page was closed. We should tolerate these errors
-            _logger.LogError(ex.ToString());
             IsInterceptResolutionHandled = false;
+            HandleError(ex);
         }
     }
 
@@ -389,10 +384,23 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         }
         catch (PuppeteerException ex)
         {
-            // In certain cases, protocol will return error if the request was already canceled
-            // or the page was closed. We should tolerate these errors
-            _logger.LogError(ex.ToString());
             IsInterceptResolutionHandled = false;
+            HandleError(ex);
         }
+    }
+
+    private void HandleError(PuppeteerException ex)
+    {
+        if (ex.Message.Contains("Invalid header") ||
+            ex.Message.Contains("Unsafe header") ||
+            ex.Message.Contains("Expected \"header\"") ||
+            ex.Message.Contains("invalid argument"))
+        {
+            throw ex;
+        }
+
+        // In certain cases, protocol will return error if the request was already canceled
+        // or the page was closed. We should tolerate these errors.
+        _logger.LogError(ex.ToString());
     }
 }


### PR DESCRIPTION
## Summary
- Add `HandleError` method to `CdpHttpRequest` that checks CDP error messages for header validation errors (`Invalid header`, `Unsafe header`, `Expected "header"`, `invalid argument`) and re-throws them instead of silently swallowing
- Other protocol errors (canceled requests, closed pages) continue to be tolerated and logged
- Add tests for `Request.continue` and `Request.respond` with invalid header values

Ports upstream Puppeteer fix: https://github.com/puppeteer/puppeteer/issues/13607

Closes #2883

## Test plan
- [x] New test `RequestContinueTests.ShouldFailIfTheHeaderValueIsInvalid` passes
- [x] New test `RequestRespondTests.ShouldFailIfTheHeaderValueIsInvalid` passes
- [x] All 79 existing request interception tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)