### PR TITLE
Fix: Stop calling BringToFront when taking page screenshots

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -525,11 +525,6 @@ namespace PuppeteerSharp
                 var stack = new DisposableTasksStack();
                 await using (stack.ConfigureAwait(false))
                 {
-                    if (!ScreenshotBurstModeOn)
-                    {
-                        await BringToFrontAsync().ConfigureAwait(false);
-                    }
-
                     // FromSurface is not supported on Firefox.
                     // It seems that Puppeteer solved this just by ignoring screenshot tests in firefox.
                     if (Browser.BrowserType == SupportedBrowser.Firefox)


### PR DESCRIPTION
## Summary
- Removes the `BringToFrontAsync()` call from the `ScreenshotAsync` method in `Page.cs`
- Ports upstream fix [puppeteer/puppeteer#13336](https://github.com/puppeteer/puppeteer/pull/13336) which stops bringing the page to front before taking screenshots
- This was causing issues for users who needed to take screenshots of background tabs

## Upstream Change
The upstream commit `6da2cb49049` removed the `await this.bringToFront()` call from `Page.screenshot()` in `packages/puppeteer-core/src/api/Page.ts`. This .NET port removes the equivalent `await BringToFrontAsync().ConfigureAwait(false)` call (along with the `ScreenshotBurstModeOn` guard around it, since that was only protecting the `BringToFront` call).

## Test plan
- [x] Ran all ScreenshotTests — 21 passed, 6 skipped, 1 pre-existing failure (retina display pixel match, also fails on master)

Closes #2873

🤖 Generated with [Claude Code](https://claude.com/claude-code)