### PR TITLE
Fix: Do not use loaderId for lifecycle events

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -79,8 +79,6 @@ public class CdpFrame : Frame
     /// <inheritdoc/>
     public override async Task<IResponse> GoToAsync(string url, NavigationOptions options)
     {
-        var ensureNewDocumentNavigation = false;
-
         if (options == null)
         {
             throw new ArgumentNullException(nameof(options));
@@ -106,7 +104,8 @@ public class CdpFrame : Frame
 
             task = await Task.WhenAny(
                     watcher.TerminationTask,
-                    ensureNewDocumentNavigation ? watcher.NewDocumentNavigationTask : watcher.SameDocumentNavigationTask)
+                    watcher.NewDocumentNavigationTask,
+                    watcher.SameDocumentNavigationTask)
                 .ConfigureAwait(false);
 
             await task.ConfigureAwait(false);
@@ -127,8 +126,6 @@ public class CdpFrame : Frame
                 ReferrerPolicy = ReferrerPolicyToProtocol(referrerPolicy),
                 FrameId = Id,
             }).ConfigureAwait(false);
-
-            ensureNewDocumentNavigation = !string.IsNullOrEmpty(response.LoaderId);
 
             if (!string.IsNullOrEmpty(response.ErrorText) &&
                 response.ErrorText != "net::ERR_HTTP_RESPONSE_CODE_FAILURE")

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -420,8 +420,8 @@ namespace PuppeteerSharp.Cdp
 
                 var eventArgs = new FrameEventArgs(frame);
                 FrameNavigatedWithinDocument?.Invoke(this, eventArgs);
-                frame.OnFrameNavigated(new FrameNavigatedEventArgs(frame, NavigationType.Navigation));
-                FrameNavigated?.Invoke(this, new FrameNavigatedEventArgs(frame, NavigationType.Navigation));
+                frame.OnFrameNavigated(new FrameNavigatedEventArgs(frame, NavigationType.Navigation, navigatedWithinDocument: true));
+                FrameNavigated?.Invoke(this, new FrameNavigatedEventArgs(frame, NavigationType.Navigation, navigatedWithinDocument: true));
             }
         }
 

--- a/lib/PuppeteerSharp/FrameNavigatedEventArgs.cs
+++ b/lib/PuppeteerSharp/FrameNavigatedEventArgs.cs
@@ -12,10 +12,12 @@ public record FrameNavigatedEventArgs
     /// </summary>
     /// <param name="frame">Frame.</param>
     /// <param name="type">Navigation type.</param>
-    internal FrameNavigatedEventArgs(IFrame frame, NavigationType type)
+    /// <param name="navigatedWithinDocument">Whether this is a within-document navigation.</param>
+    internal FrameNavigatedEventArgs(IFrame frame, NavigationType type, bool navigatedWithinDocument = false)
     {
         Frame = frame;
         Type = type;
+        NavigatedWithinDocument = navigatedWithinDocument;
     }
 
     /// <summary>
@@ -28,4 +30,9 @@ public record FrameNavigatedEventArgs
     /// Navigation type.
     /// </summary>
     public NavigationType Type { get; }
+
+    /// <summary>
+    /// Whether this is a within-document navigation (e.g., via History API).
+    /// </summary>
+    internal bool NavigatedWithinDocument { get; }
 }


### PR DESCRIPTION
## Summary
- Ports upstream Puppeteer fix [puppeteer/puppeteer#8395](https://github.com/puppeteer/puppeteer/commit/c96c915b535dcf414038677bd3d3ed6b980a4901) which works around the upstream Chromium bug [crbug.com/1325782](https://crbug.com/1325782)
- Replaces `loaderId`-based navigation detection in `LifecycleWatcher` with a `_newDocumentNavigation` flag set when `FrameNavigated` fires for cross-document navigations
- Removes `ensureNewDocumentNavigation` from `CdpFrame.GoToAsync`, now always waits for both new document and same document navigation tasks
- Adds `NavigatedWithinDocument` property to `FrameNavigatedEventArgs` to correctly distinguish within-document navigations (e.g., History API) from cross-document navigations

Closes #1969

## Test plan
- [x] All 57 navigation tests pass
- [x] All 24 frame tests pass
- [x] All 9 wait-for-navigation tests pass
- [x] All 5 prerender tests pass
- [x] `ShouldWorkWhenReloadCausesHistoryAPIInBeforeunload` test (which exercises the beforeunload + history.replaceState scenario) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)