### PR TITLE
New Feature: Add WaitForFonts option to PdfOptions (#12675)

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -1101,9 +1101,11 @@ public class BidiPage : Page
         var marginBottom = ConvertPrintParameterToCentimeters(options.MarginOptions.Bottom);
         var marginRight = ConvertPrintParameterToCentimeters(options.MarginOptions.Right);
 
-        // Wait for fonts to be ready
-        await BidiMainFrame.IsolatedRealm.EvaluateExpressionAsync("document.fonts.ready")
-            .WithTimeout(TimeoutSettings.Timeout).ConfigureAwait(false);
+        if (options.WaitForFonts)
+        {
+            await BidiMainFrame.IsolatedRealm.EvaluateExpressionAsync("document.fonts.ready")
+                .WithTimeout(TimeoutSettings.Timeout).ConfigureAwait(false);
+        }
 
         var pageRanges = new List<object>();
         if (!string.IsNullOrEmpty(options.PageRanges))

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -946,8 +946,11 @@ public class CdpPage : Page
             await _emulationManager.SetTransparentBackgroundColorAsync().ConfigureAwait(false);
         }
 
-        await FrameManager.MainFrame.IsolatedRealm.EvaluateExpressionAsync("() => documents.fonts.ready")
-            .WithTimeout(TimeoutSettings.Timeout).ConfigureAwait(false);
+        if (options.WaitForFonts)
+        {
+            await FrameManager.MainFrame.IsolatedRealm.EvaluateExpressionAsync("document.fonts.ready")
+                .WithTimeout(TimeoutSettings.Timeout).ConfigureAwait(false);
+        }
 
         var result = await PrimaryTargetClient.SendAsync<PagePrintToPDFResponse>(
             "Page.printToPDF",

--- a/lib/PuppeteerSharp/PdfOptions.cs
+++ b/lib/PuppeteerSharp/PdfOptions.cs
@@ -107,5 +107,13 @@ namespace PuppeteerSharp
         /// Currently only works in old Headless (headless = true).
         /// </remarks>
         public bool Outline { get; set; } = false;
+
+        /// <summary>
+        /// If <c>true</c>, waits for <c>document.fonts.ready</c> to resolve. This might require
+        /// activating the page using <see cref="IPage.BringToFrontAsync"/> if the page is in the
+        /// background.
+        /// </summary>
+        /// <remarks>Defaults to <c>true</c>.</remarks>
+        public bool WaitForFonts { get; set; } = true;
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `WaitForFonts` property to `PdfOptions` (defaults to `true`) that controls whether PDF generation waits for `document.fonts.ready` to resolve before printing
- Wraps the existing `fonts.ready` call in both `CdpPage` and `BidiPage` with the new option check
- Fixes a typo in `CdpPage` where the expression was `"() => documents.fonts.ready"` (arrow function wrapper + plural `documents`) instead of `"document.fonts.ready"`

Implements upstream PR: https://github.com/puppeteer/puppeteer/pull/12675
Closes #2678

## Test plan
- [x] All 7 existing PDF tests pass with Chrome/CDP
- [x] Build succeeds with no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)