### PR TITLE
Fix: Do not allow switching tabs while screenshot is in progress (#12724)

### DIFF
--- a/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreenshotTests/PageScreenshotTests.cs
@@ -265,6 +265,28 @@ namespace PuppeteerSharp.Tests.ScreenshotTests
             await Task.WhenAll(closeTasks);
         }
 
+        [Test, PuppeteerTest("screenshot.spec", "Screenshots Page.screenshot", "should run in parallel with page.close()")]
+        public async Task ShouldRunInParallelWithPageClose()
+        {
+            await using var context = await Browser.CreateBrowserContextAsync();
+
+            var page1 = await context.NewPageAsync();
+            var page2 = await context.NewPageAsync();
+
+            var screen1 = page1.ScreenshotDataAsync();
+            var screen2 = page2.ScreenshotDataAsync();
+
+            var close1 = screen1.ContinueWith(_ => page1.CloseAsync()).Unwrap();
+            var close2 = screen2.ContinueWith(_ => page2.CloseAsync()).Unwrap();
+
+            await screen1;
+            var page3 = await Browser.NewPageAsync();
+            await page3.ScreenshotDataAsync();
+            var close3 = page3.CloseAsync();
+
+            await Task.WhenAll(close1, close2, close3);
+        }
+
         [Test, PuppeteerTest("screenshot.spec", "Screenshots Cdp", "should allow transparency")]
         public async Task ShouldAllowTransparency()
         {

--- a/lib/PuppeteerSharp/Bidi/BidiBrowserContext.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowserContext.cs
@@ -186,6 +186,9 @@ public class BidiBrowserContext : BrowserContext
     /// <inheritdoc />
     public override async Task<IPage> NewPageAsync(CreatePageOptions options = null)
     {
+        var guard = await WaitForScreenshotOperationsAsync().ConfigureAwait(false);
+        guard?.Dispose();
+
         var type = options?.Type == CreatePageType.Window
             ? WebDriverBiDi.BrowsingContext.CreateType.Window
             : WebDriverBiDi.BrowsingContext.CreateType.Tab;

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -780,6 +780,9 @@ public class BidiPage : Page
     /// <inheritdoc />
     public override async Task CloseAsync(PageCloseOptions options = null)
     {
+        var guard = await ((BrowserContext)BrowserContext).WaitForScreenshotOperationsAsync().ConfigureAwait(false);
+        guard?.Dispose();
+
         try
         {
             await BidiMainFrame.BrowsingContext.CloseAsync(options?.RunBeforeUnload).ConfigureAwait(false);

--- a/lib/PuppeteerSharp/Cdp/CdpBrowserContext.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowserContext.cs
@@ -59,7 +59,12 @@ public class CdpBrowserContext : BrowserContext
             .Where(p => p != null).ToArray();
 
     /// <inheritdoc/>
-    public override Task<IPage> NewPageAsync(CreatePageOptions options = null) => _browser.CreatePageInContextAsync(Id, options);
+    public override async Task<IPage> NewPageAsync(CreatePageOptions options = null)
+    {
+        var guard = await WaitForScreenshotOperationsAsync().ConfigureAwait(false);
+        guard?.Dispose();
+        return await _browser.CreatePageInContextAsync(Id, options).ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
     public override Task CloseAsync()

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -769,6 +769,9 @@ public class CdpPage : Page
     /// <inheritdoc/>
     public override async Task CloseAsync(PageCloseOptions options = null)
     {
+        var guard = await ((BrowserContext)BrowserContext).WaitForScreenshotOperationsAsync().ConfigureAwait(false);
+        guard?.Dispose();
+
         if (Client?.Detached ?? true)
         {
             _logger.LogWarning("Protocol error: Connection closed. Most likely the page has been closed.");

--- a/lib/PuppeteerSharp/Helpers/ScreenshotMutex.cs
+++ b/lib/PuppeteerSharp/Helpers/ScreenshotMutex.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp.Helpers
+{
+    internal sealed class ScreenshotMutex
+    {
+        private readonly Queue<TaskCompletionSource<bool>> _acquirers = new();
+        private bool _locked;
+
+        internal async Task<IDisposable> AcquireAsync(Action onRelease = null)
+        {
+            if (!_locked)
+            {
+                _locked = true;
+                return new Guard(this, onRelease);
+            }
+
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _acquirers.Enqueue(tcs);
+            await tcs.Task.ConfigureAwait(false);
+            return new Guard(this, onRelease);
+        }
+
+        private void Release()
+        {
+            if (_acquirers.Count > 0)
+            {
+                var next = _acquirers.Dequeue();
+                next.TrySetResult(true);
+            }
+            else
+            {
+                _locked = false;
+            }
+        }
+
+        private sealed class Guard : IDisposable
+        {
+            private readonly ScreenshotMutex _mutex;
+            private readonly Action _onRelease;
+            private int _disposed;
+
+            internal Guard(ScreenshotMutex mutex, Action onRelease)
+            {
+                _mutex = mutex;
+                _onRelease = onRelease;
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                _onRelease?.Invoke();
+                _mutex.Release();
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -482,8 +482,10 @@ namespace PuppeteerSharp
         public Task<string> ScreenshotBase64Async() => ScreenshotBase64Async(new ScreenshotOptions());
 
         /// <inheritdoc/>
-        public Task<string> ScreenshotBase64Async(ScreenshotOptions options)
-            => _screenshotTaskQueue.Enqueue(async () =>
+        public async Task<string> ScreenshotBase64Async(ScreenshotOptions options)
+        {
+            using var guard = await ((BrowserContext)BrowserContext).StartScreenshotAsync().ConfigureAwait(false);
+            return await _screenshotTaskQueue.Enqueue(async () =>
             {
                 if (options == null)
                 {
@@ -593,7 +595,8 @@ namespace PuppeteerSharp
 
                     return result;
                 }
-            });
+            }).ConfigureAwait(false);
+        }
 
         /// <inheritdoc/>
         public Task<byte[]> ScreenshotDataAsync() => ScreenshotDataAsync(new ScreenshotOptions());


### PR DESCRIPTION
## Summary

- Ports upstream [puppeteer#12724](https://github.com/puppeteer/puppeteer/pull/12724) to PuppeteerSharp
- Adds a context-level `ScreenshotMutex` that prevents `NewPageAsync()` and `CloseAsync()` from interfering with in-progress screenshot operations
- While screenshots are being taken in a `BrowserContext`, `NewPageAsync()` and `CloseAsync()` will automatically wait for screenshots to finish

## Changes

- **`ScreenshotMutex`** (new): FIFO async mutex with an `onRelease` callback, used to track screenshot operations at the browser context level
- **`BrowserContext`**: Added `StartScreenshotAsync()` (acquires mutex) and `WaitForScreenshotOperationsAsync()` (waits for mutex if screenshots in progress)
- **`Page.ScreenshotBase64Async`**: Acquires the context-level mutex before proceeding with the per-page screenshot queue
- **`CdpPage.CloseAsync`** / **`BidiPage.CloseAsync`**: Wait for in-progress screenshot operations before closing
- **`CdpBrowserContext.NewPageAsync`** / **`BidiBrowserContext.NewPageAsync`**: Wait for in-progress screenshot operations before creating new pages

Closes #2680

## Test plan

- [x] New test `ShouldRunInParallelWithPageClose` passes (Chrome/CDP)
- [x] All existing screenshot tests continue to pass (12/12 passed; 1 pre-existing failure on master unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)