### PR TITLE
Fix: Make sure bindings work after page restored from bfcache

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -252,7 +252,7 @@ public class CdpPage : Page
                 $"Failed to remove page binding with name {name}: window['{name}'] does not exists!");
         }
 
-        await Client.SendAsync("Runtime.removeBinding", new RuntimeRemoveBindingRequest { Name = name, })
+        await Client.SendAsync("Runtime.removeBinding", new RuntimeRemoveBindingRequest { Name = BindingUtils.CdpBindingPrefix + name, })
             .ConfigureAwait(false);
 
         await RemoveScriptToEvaluateOnNewDocumentAsync(exposedFun).ConfigureAwait(false);
@@ -871,7 +871,7 @@ public class CdpPage : Page
         }
 
         var expression = BindingUtils.PageBindingInitString("exposedFun", name);
-        await PrimaryTargetClient.SendAsync("Runtime.addBinding", new RuntimeAddBindingRequest { Name = name })
+        await PrimaryTargetClient.SendAsync("Runtime.addBinding", new RuntimeAddBindingRequest { Name = BindingUtils.CdpBindingPrefix + name })
             .ConfigureAwait(false);
         var functionInfo = await PrimaryTargetClient
             .SendAsync<PageAddScriptToEvaluateOnNewDocumentResponse>(

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -97,7 +97,7 @@ namespace PuppeteerSharp
                         "Runtime.addBinding",
                         new RuntimeAddBindingRequest
                         {
-                            Name = name,
+                            Name = BindingUtils.CdpBindingPrefix + name,
                             ExecutionContextName = !string.IsNullOrEmpty(context.ContextName) ? context.ContextName : null,
                             ExecutionContextId = string.IsNullOrEmpty(context.ContextName) ? context.ContextId : null,
                         }).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- Adds a CDP binding prefix (`puppeteer_`) to all `Runtime.addBinding` and `Runtime.removeBinding` calls, matching upstream Puppeteer's approach
- Updates the JavaScript `addPageBinding` function to use the prefix when calling the CDP binding, avoiding name collisions when pages are restored from the back-forward cache
- Removes the `Symbol.toStringTag` check in favor of checking `globalThis[name]` to detect already-wrapped bindings
- Adds a test verifying that `ExposeFunctionAsync` works correctly after navigating back to a BFCached page

## Upstream PR

https://github.com/puppeteer/puppeteer/pull/12663

Closes #2682

## Changes

| File | Change |
|------|--------|
| `BindingUtils.cs` | Added `CdpBindingPrefix` constant; updated JS `addPageBinding` to accept `prefix` param and use `globalThis[prefix + name]()` |
| `IsolatedWorld.cs` | Prepend `CdpBindingPrefix` to binding name in `Runtime.addBinding` call |
| `CdpPage.cs` | Prepend `CdpBindingPrefix` to binding name in `Runtime.addBinding` and `Runtime.removeBinding` calls |
| `BFCacheTests.cs` | Added test for calling exposed functions after bfcache restoration |

## Test plan

- [x] BFCache tests pass (3/3)
- [x] ExposeFunctionTests pass (13/13)
- [x] PageEvaluateTests pass
- [x] ARIA selector tests pass (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)