### PR TITLE
New Feature: Implement Locator.filter (#10631)

### DIFF
--- a/lib/PuppeteerSharp.Tests/LocatorTests/LocatorFilterTests.cs
+++ b/lib/PuppeteerSharp.Tests/LocatorTests/LocatorFilterTests.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.LocatorTests
+{
+    public class LocatorFilterTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("locator.spec", "Locator.prototype.filter", "should resolve as soon as the predicate matches")]
+        public async Task ShouldResolveAsSoonAsThePredicateMatches()
+        {
+            await Page.SetContentAsync("<div id='test'>test</div>");
+            var hoverTask = Page
+                .Locator("#test")
+                .SetTimeout(5000)
+                .Filter("async (element) => element.getAttribute('clickable') === 'true'")
+                .Filter("(element) => element.getAttribute('clickable') === 'true'")
+                .HoverAsync();
+
+            await Task.Delay(2000);
+            await Page.EvaluateExpressionAsync(
+                "document.querySelector('#test')?.setAttribute('clickable', 'true')");
+
+            await hoverTask;
+        }
+
+        [Test, PuppeteerTest("locator.spec", "Locator Locator.prototype.map", "should work with expect")]
+        public async Task ShouldWorkWithFilter()
+        {
+            await Page.SetContentAsync("<div id='test'>test</div>");
+            var resultTask = Page
+                .Locator("#test")
+                .Filter("(element) => element.getAttribute('clickable') !== null")
+                .Map("(element) => element.getAttribute('clickable')")
+                .WaitAsync<string>();
+
+            await Page.EvaluateExpressionAsync(
+                "document.querySelector('#test')?.setAttribute('clickable', 'true')");
+
+            var result = await resultTask;
+            Assert.That(result, Is.EqualTo("true"));
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -118,6 +118,10 @@ namespace PuppeteerSharp
         }
 
         /// <inheritdoc/>
+        public Locators.Locator Locator(string selector)
+            => Locators.NodeLocator.Create(this, selector);
+
+        /// <inheritdoc/>
         public Task<IElementHandle> WaitForXPathAsync(string xpath, WaitForSelectorOptions options = null)
         {
             if (string.IsNullOrEmpty(xpath))

--- a/lib/PuppeteerSharp/IFrame.cs
+++ b/lib/PuppeteerSharp/IFrame.cs
@@ -387,6 +387,14 @@ namespace PuppeteerSharp
         Task<IElementHandle> WaitForSelectorAsync(string selector, WaitForSelectorOptions options = null);
 
         /// <summary>
+        /// Creates a locator for the provided selector. See <see cref="Locators.Locator"/> for
+        /// details and supported actions.
+        /// </summary>
+        /// <param name="selector">A selector to locate an element.</param>
+        /// <returns>A locator for the provided selector.</returns>
+        Locators.Locator Locator(string selector);
+
+        /// <summary>
         /// Waits for a selector to be added to the DOM.
         /// </summary>
         /// <param name="xpath">A xpath selector of an element to wait for.</param>

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -1420,6 +1420,14 @@ namespace PuppeteerSharp
         Task<IElementHandle> WaitForSelectorAsync(string selector, WaitForSelectorOptions options = null);
 
         /// <summary>
+        /// Creates a locator for the provided selector. See <see cref="Locators.Locator"/> for
+        /// details and supported actions.
+        /// </summary>
+        /// <param name="selector">A selector to locate an element.</param>
+        /// <returns>A locator for the provided selector.</returns>
+        Locators.Locator Locator(string selector);
+
+        /// <summary>
         /// Waits for a xpath selector to be added to the DOM.
         /// </summary>
         /// <param name="xpath">A xpath selector of an element to wait for.</param>

--- a/lib/PuppeteerSharp/Locators/DelegatedLocator.cs
+++ b/lib/PuppeteerSharp/Locators/DelegatedLocator.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// A locator that delegates to another locator.
+    /// </summary>
+    internal abstract class DelegatedLocator : Locator
+    {
+        private readonly Locator _delegate;
+
+        protected DelegatedLocator(Locator @delegate)
+        {
+            _delegate = @delegate;
+            CopyOptions(_delegate);
+        }
+
+        /// <summary>
+        /// Gets the delegate locator.
+        /// </summary>
+        protected Locator Delegate => _delegate;
+    }
+}

--- a/lib/PuppeteerSharp/Locators/FilteredLocator.cs
+++ b/lib/PuppeteerSharp/Locators/FilteredLocator.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// A locator that filters elements based on a JavaScript predicate.
+    /// The predicate is evaluated in the page context. If the predicate does not
+    /// match, the locator will retry until it matches or the timeout is reached.
+    /// </summary>
+    internal class FilteredLocator : DelegatedLocator
+    {
+        private readonly string _predicate;
+
+        internal FilteredLocator(Locator @base, string predicate)
+            : base(@base)
+        {
+            _predicate = predicate;
+        }
+
+        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        {
+            var handle = await Delegate.WaitHandleAsync(options, cancellationToken).ConfigureAwait(false);
+
+            var elementHandle = handle as IElementHandle;
+            if (elementHandle == null)
+            {
+                await handle.DisposeAsync().ConfigureAwait(false);
+                throw new PuppeteerException("FilteredLocator: handle is not an element.");
+            }
+
+            var frame = elementHandle.Frame;
+            await frame.WaitForFunctionAsync(
+                _predicate,
+                new WaitForFunctionOptions { Timeout = Timeout },
+                handle).ConfigureAwait(false);
+
+            return handle;
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/Locator.cs
+++ b/lib/PuppeteerSharp/Locators/Locator.cs
@@ -1,0 +1,442 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using PuppeteerSharp.Input;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// Locators describe a strategy of locating elements and performing an action on
+    /// them. If the action fails because the element is not ready for the action,
+    /// the whole operation is retried. Various preconditions for a successful action
+    /// are checked automatically.
+    /// </summary>
+    public abstract class Locator
+    {
+        /// <summary>
+        /// For observables coming from promises, a delay is needed, otherwise the retry will
+        /// never yield in a permanent failure for a promise.
+        /// </summary>
+        internal const int RetryDelay = 100;
+
+        private bool _ensureElementIsInTheViewport = true;
+        private bool _waitForEnabled = true;
+        private bool _waitForStableBoundingBox = true;
+
+        /// <summary>
+        /// Gets or sets the visibility option.
+        /// </summary>
+        protected internal VisibilityOption? Visibility { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout in milliseconds.
+        /// </summary>
+        protected internal int Timeout { get; set; } = 30_000;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ensure the element is in the viewport.
+        /// </summary>
+        protected internal bool EnsureElementIsInTheViewport
+        {
+            get => _ensureElementIsInTheViewport;
+            set => _ensureElementIsInTheViewport = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to wait for the element to be enabled.
+        /// </summary>
+        protected internal bool WaitForEnabled
+        {
+            get => _waitForEnabled;
+            set => _waitForEnabled = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to wait for a stable bounding box.
+        /// </summary>
+        protected internal bool WaitForStableBoundingBox
+        {
+            get => _waitForStableBoundingBox;
+            set => _waitForStableBoundingBox = value;
+        }
+
+        /// <summary>
+        /// Sets the timeout for the locator.
+        /// </summary>
+        /// <param name="timeout">Timeout in milliseconds.</param>
+        /// <returns>The locator instance for chaining.</returns>
+        public Locator SetTimeout(int timeout)
+        {
+            Timeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the visibility option for the locator.
+        /// </summary>
+        /// <param name="visibility">The visibility option.</param>
+        /// <returns>The locator instance for chaining.</returns>
+        public Locator SetVisibility(VisibilityOption? visibility)
+        {
+            Visibility = visibility;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether to wait for the element to be enabled before acting.
+        /// </summary>
+        /// <param name="value">Whether to wait for enabled.</param>
+        /// <returns>The locator instance for chaining.</returns>
+        public Locator SetWaitForEnabled(bool value)
+        {
+            _waitForEnabled = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether to ensure the element is scrolled into the viewport.
+        /// </summary>
+        /// <param name="value">Whether to ensure the element is in the viewport.</param>
+        /// <returns>The locator instance for chaining.</returns>
+        public Locator SetEnsureElementIsInTheViewport(bool value)
+        {
+            _ensureElementIsInTheViewport = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether to wait for a stable bounding box before acting.
+        /// </summary>
+        /// <param name="value">Whether to wait for a stable bounding box.</param>
+        /// <returns>The locator instance for chaining.</returns>
+        public Locator SetWaitForStableBoundingBox(bool value)
+        {
+            _waitForStableBoundingBox = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Creates a new locator that filters elements using the provided predicate.
+        /// If the predicate does not match, the locator will retry.
+        /// </summary>
+        /// <param name="predicate">A JavaScript function expression that takes an element and returns a boolean.</param>
+        /// <returns>A new locator that filters based on the predicate.</returns>
+        public Locator Filter(string predicate)
+        {
+            return new FilteredLocator(this, predicate);
+        }
+
+        /// <summary>
+        /// Maps the locator using the provided mapper.
+        /// </summary>
+        /// <param name="mapper">A JavaScript function expression that transforms the element.</param>
+        /// <returns>A new locator that maps the element.</returns>
+        public Locator Map(string mapper)
+        {
+            return new MappedLocator(this, mapper);
+        }
+
+        /// <summary>
+        /// Waits for the locator to get a value from the page.
+        /// Note this requires the value to be JSON-serializable.
+        /// </summary>
+        /// <typeparam name="T">The type of the return value.</typeparam>
+        /// <param name="options">Optional action options.</param>
+        /// <returns>A task that resolves to the serialized value.</returns>
+        public async Task<T> WaitAsync<T>(LocatorActionOptions options = null)
+        {
+            var handle = await RunWithRetryAsync(
+                ct => WaitHandleAsync(options, ct),
+                options?.CancellationToken ?? default).ConfigureAwait(false);
+
+            try
+            {
+                return await handle.JsonValueAsync<T>().ConfigureAwait(false);
+            }
+            finally
+            {
+                await handle.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the locator to locate an element.
+        /// </summary>
+        /// <param name="options">Optional action options.</param>
+        /// <returns>A task that completes when the element is located.</returns>
+        public async Task WaitAsync(LocatorActionOptions options = null)
+        {
+            var handle = await RunWithRetryAsync(
+                ct => WaitHandleAsync(options, ct),
+                options?.CancellationToken ?? default).ConfigureAwait(false);
+
+            await handle.DisposeAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Clicks the located element.
+        /// </summary>
+        /// <param name="options">Optional click options.</param>
+        /// <returns>A task that completes when the click is performed.</returns>
+        public Task ClickAsync(LocatorClickOptions options = null)
+        {
+            return PerformActionAsync(
+                async (handle, ct) =>
+                {
+                    var clickOptions = new ClickOptions
+                    {
+                        Button = options?.Button ?? MouseButton.Left,
+                        Count = options?.Count ?? 1,
+                        Delay = options?.Delay ?? 0,
+                        OffSet = options?.OffSet,
+                    };
+                    await handle.ClickAsync(clickOptions).ConfigureAwait(false);
+                },
+                true,
+                options?.CancellationToken ?? default);
+        }
+
+        /// <summary>
+        /// Hovers over the located element.
+        /// </summary>
+        /// <param name="options">Optional action options.</param>
+        /// <returns>A task that completes when the hover is performed.</returns>
+        public Task HoverAsync(LocatorActionOptions options = null)
+        {
+            return PerformActionAsync(
+                async (handle, ct) => await handle.HoverAsync().ConfigureAwait(false),
+                false,
+                options?.CancellationToken ?? default);
+        }
+
+        /// <summary>
+        /// Scrolls the located element.
+        /// </summary>
+        /// <param name="options">Optional scroll options.</param>
+        /// <returns>A task that completes when the scroll is performed.</returns>
+        public Task ScrollAsync(LocatorScrollOptions options = null)
+        {
+            return PerformActionAsync(
+                async (handle, ct) =>
+                {
+                    await handle.EvaluateFunctionAsync(
+                        @"(el, scrollTop, scrollLeft) => {
+                            if (scrollTop !== undefined) { el.scrollTop = scrollTop; }
+                            if (scrollLeft !== undefined) { el.scrollLeft = scrollLeft; }
+                        }",
+                        options?.ScrollTop,
+                        options?.ScrollLeft).ConfigureAwait(false);
+                },
+                false,
+                options?.CancellationToken ?? default);
+        }
+
+        /// <summary>
+        /// Fills the located element with the provided value.
+        /// </summary>
+        /// <param name="value">The value to fill.</param>
+        /// <param name="options">Optional action options.</param>
+        /// <returns>A task that completes when the fill is performed.</returns>
+        public Task FillAsync(string value, LocatorActionOptions options = null)
+        {
+            return PerformActionAsync(
+                async (handle, ct) =>
+                {
+                    var inputType = await handle.EvaluateFunctionAsync<string>(
+                        @"(el) => {
+                            if (el instanceof HTMLSelectElement) return 'select';
+                            if (el instanceof HTMLInputElement) {
+                                if (new Set(['textarea','text','url','tel','search','password','number','email']).has(el.type))
+                                    return 'typeable-input';
+                                else return 'other-input';
+                            }
+                            if (el.isContentEditable) return 'contenteditable';
+                            return 'unknown';
+                        }").ConfigureAwait(false);
+
+                    switch (inputType)
+                    {
+                        case "select":
+                            await handle.SelectAsync(value).ConfigureAwait(false);
+                            break;
+                        case "contenteditable":
+                        case "typeable-input":
+                            var textToType = await handle.EvaluateFunctionAsync<string>(
+                                @"(input, newValue) => {
+                                    const currentValue = input.isContentEditable ? input.innerText : input.value;
+                                    if (newValue.length <= currentValue.length || !newValue.startsWith(input.value)) {
+                                        if (input.isContentEditable) { input.innerText = ''; } else { input.value = ''; }
+                                        return newValue;
+                                    }
+                                    const originalValue = input.isContentEditable ? input.innerText : input.value;
+                                    if (input.isContentEditable) { input.innerText = ''; input.innerText = originalValue; }
+                                    else { input.value = ''; input.value = originalValue; }
+                                    return newValue.substring(originalValue.length);
+                                }",
+                                value).ConfigureAwait(false);
+                            await handle.TypeAsync(textToType).ConfigureAwait(false);
+                            break;
+                        case "other-input":
+                            await handle.FocusAsync().ConfigureAwait(false);
+                            await handle.EvaluateFunctionAsync(
+                                @"(input, value) => {
+                                    input.value = value;
+                                    input.dispatchEvent(new Event('input', {bubbles: true}));
+                                    input.dispatchEvent(new Event('change', {bubbles: true}));
+                                }",
+                                value).ConfigureAwait(false);
+                            break;
+                        default:
+                            throw new PuppeteerException("Element cannot be filled out.");
+                    }
+                },
+                true,
+                options?.CancellationToken ?? default);
+        }
+
+        /// <summary>
+        /// Copies options from another locator.
+        /// </summary>
+        /// <param name="other">The locator to copy options from.</param>
+        internal void CopyOptions(Locator other)
+        {
+            Timeout = other.Timeout;
+            Visibility = other.Visibility;
+            _waitForEnabled = other._waitForEnabled;
+            _ensureElementIsInTheViewport = other._ensureElementIsInTheViewport;
+            _waitForStableBoundingBox = other._waitForStableBoundingBox;
+        }
+
+        /// <summary>
+        /// Waits for the element and returns a handle.
+        /// </summary>
+        /// <param name="options">Optional action options.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task that resolves to a handle for the located element.</returns>
+        internal abstract Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken);
+
+        private static async Task WaitForStableBoundingBoxAsync(IElementHandle handle)
+        {
+            var result = await handle.EvaluateFunctionAsync<bool>(
+                @"(element) => {
+                    return new Promise(resolve => {
+                        window.requestAnimationFrame(() => {
+                            const rect1 = element.getBoundingClientRect();
+                            window.requestAnimationFrame(() => {
+                                const rect2 = element.getBoundingClientRect();
+                                resolve(
+                                    rect1.x === rect2.x && rect1.y === rect2.y &&
+                                    rect1.width === rect2.width && rect1.height === rect2.height
+                                );
+                            });
+                        });
+                    });
+                }").ConfigureAwait(false);
+
+            if (!result)
+            {
+                throw new PuppeteerException("Bounding box is not stable.");
+            }
+        }
+
+        private async Task PerformActionAsync(
+            Func<IElementHandle, CancellationToken, Task> action,
+            bool waitForEnabled,
+            CancellationToken cancellationToken)
+        {
+            await RunWithRetryAsync(
+                async ct =>
+                {
+                    var handle = await WaitHandleAsync(null, ct).ConfigureAwait(false);
+                    var elementHandle = handle as IElementHandle;
+
+                    if (elementHandle == null)
+                    {
+                        await handle.DisposeAsync().ConfigureAwait(false);
+                        throw new PuppeteerException("Locator did not resolve to an element.");
+                    }
+
+                    try
+                    {
+                        if (EnsureElementIsInTheViewport)
+                        {
+                            var isInViewport = await elementHandle.IsIntersectingViewportAsync().ConfigureAwait(false);
+                            if (!isInViewport)
+                            {
+                                await elementHandle.ScrollIntoViewAsync().ConfigureAwait(false);
+                            }
+                        }
+
+                        if (WaitForStableBoundingBox)
+                        {
+                            await WaitForStableBoundingBoxAsync(elementHandle).ConfigureAwait(false);
+                        }
+
+                        if (waitForEnabled && WaitForEnabled)
+                        {
+                            await WaitForEnabledAsync(elementHandle).ConfigureAwait(false);
+                        }
+
+                        await action(elementHandle, ct).ConfigureAwait(false);
+                        return handle;
+                    }
+                    catch
+                    {
+                        await handle.DisposeAsync().ConfigureAwait(false);
+                        throw;
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<IJSHandle> RunWithRetryAsync(
+            Func<CancellationToken, Task<IJSHandle>> operation,
+            CancellationToken cancellationToken)
+        {
+            using var timeoutCts = Timeout > 0
+                ? new CancellationTokenSource(Timeout)
+                : new CancellationTokenSource();
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                timeoutCts.Token, cancellationToken);
+
+            var linkedToken = linkedCts.Token;
+
+            while (true)
+            {
+                try
+                {
+                    return await operation(linkedToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"Timed out after waiting {Timeout}ms");
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception) when (!linkedToken.IsCancellationRequested)
+                {
+                    await Task.Delay(RetryDelay, linkedToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task WaitForEnabledAsync(IElementHandle handle)
+        {
+            var isEnabled = await handle.EvaluateFunctionAsync<bool>(
+                @"(element) => {
+                    if ('disabled' in element && typeof element.disabled === 'boolean') {
+                        return !element.disabled;
+                    }
+                    return true;
+                }").ConfigureAwait(false);
+
+            if (!isEnabled)
+            {
+                throw new PuppeteerException("Element is disabled.");
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/LocatorActionOptions.cs
+++ b/lib/PuppeteerSharp/Locators/LocatorActionOptions.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// Options for locator actions.
+    /// </summary>
+    public class LocatorActionOptions
+    {
+        /// <summary>
+        /// Gets or sets the cancellation token to cancel the action.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = default;
+    }
+}

--- a/lib/PuppeteerSharp/Locators/LocatorClickOptions.cs
+++ b/lib/PuppeteerSharp/Locators/LocatorClickOptions.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using PuppeteerSharp.Input;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// Options for locator click actions.
+    /// </summary>
+    public class LocatorClickOptions
+    {
+        /// <summary>
+        /// Gets or sets the cancellation token to cancel the action.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = default;
+
+        /// <summary>
+        /// Gets or sets the mouse button to use for clicking.
+        /// </summary>
+        public MouseButton Button { get; set; } = MouseButton.Left;
+
+        /// <summary>
+        /// Gets or sets the number of clicks.
+        /// </summary>
+        public int Count { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the time to wait between mousedown and mouseup in milliseconds.
+        /// </summary>
+        public int Delay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the click relative to the top-left corner of the element's padding box.
+        /// </summary>
+        public Offset? OffSet { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/LocatorScrollOptions.cs
+++ b/lib/PuppeteerSharp/Locators/LocatorScrollOptions.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// Options for locator scroll actions.
+    /// </summary>
+    public class LocatorScrollOptions
+    {
+        /// <summary>
+        /// Gets or sets the cancellation token to cancel the action.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = default;
+
+        /// <summary>
+        /// Gets or sets the vertical scroll position.
+        /// </summary>
+        public decimal? ScrollTop { get; set; }
+
+        /// <summary>
+        /// Gets or sets the horizontal scroll position.
+        /// </summary>
+        public decimal? ScrollLeft { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/MappedLocator.cs
+++ b/lib/PuppeteerSharp/Locators/MappedLocator.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// A locator that maps the located element using a JavaScript function.
+    /// </summary>
+    internal class MappedLocator : DelegatedLocator
+    {
+        private readonly string _mapper;
+
+        internal MappedLocator(Locator @base, string mapper)
+            : base(@base)
+        {
+            _mapper = mapper;
+        }
+
+        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        {
+            var handle = await Delegate.WaitHandleAsync(options, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                return await handle.EvaluateFunctionHandleAsync(_mapper).ConfigureAwait(false);
+            }
+            finally
+            {
+                await handle.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/NodeLocator.cs
+++ b/lib/PuppeteerSharp/Locators/NodeLocator.cs
@@ -1,0 +1,65 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// A locator that finds elements using a CSS selector.
+    /// </summary>
+    internal class NodeLocator : Locator
+    {
+        private readonly IPage _page;
+        private readonly IFrame _frame;
+        private readonly string _selector;
+
+        private NodeLocator(IPage page, string selector)
+        {
+            _page = page;
+            _selector = selector;
+            Timeout = page.DefaultTimeout;
+        }
+
+        private NodeLocator(IFrame frame, string selector)
+        {
+            _frame = frame;
+            _selector = selector;
+        }
+
+        internal static Locator Create(IPage page, string selector)
+        {
+            return new NodeLocator(page, selector);
+        }
+
+        internal static Locator Create(IFrame frame, string selector)
+        {
+            return new NodeLocator(frame, selector);
+        }
+
+        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        {
+            var waitOptions = new WaitForSelectorOptions
+            {
+                Timeout = Timeout,
+                Visible = Visibility == VisibilityOption.Visible ? true : Visibility == VisibilityOption.Hidden ? false : null,
+            };
+
+            IElementHandle handle;
+
+            if (_page != null)
+            {
+                handle = await _page.WaitForSelectorAsync(_selector, waitOptions).ConfigureAwait(false);
+            }
+            else
+            {
+                handle = await _frame.WaitForSelectorAsync(_selector, waitOptions).ConfigureAwait(false);
+            }
+
+            if (handle == null)
+            {
+                throw new PuppeteerException($"Could not find element matching selector: {_selector}");
+            }
+
+            return handle;
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/VisibilityOption.cs
+++ b/lib/PuppeteerSharp/Locators/VisibilityOption.cs
@@ -1,0 +1,18 @@
+namespace PuppeteerSharp.Locators
+{
+    /// <summary>
+    /// Visibility option for locator operations.
+    /// </summary>
+    public enum VisibilityOption
+    {
+        /// <summary>
+        /// Wait for the element to be hidden.
+        /// </summary>
+        Hidden,
+
+        /// <summary>
+        /// Wait for the element to be visible.
+        /// </summary>
+        Visible,
+    }
+}

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -681,6 +681,10 @@ namespace PuppeteerSharp
             => MainFrame.WaitForSelectorAsync(selector, options ?? new WaitForSelectorOptions());
 
         /// <inheritdoc/>
+        public Locators.Locator Locator(string selector)
+            => Locators.NodeLocator.Create(this, selector);
+
+        /// <inheritdoc/>
 #pragma warning disable CS0618 // WaitForXPathAsync is obsolete
         public Task<IElementHandle> WaitForXPathAsync(string xpath, WaitForSelectorOptions options = null)
             => MainFrame.WaitForXPathAsync(xpath, options ?? new WaitForSelectorOptions());


### PR DESCRIPTION
## Summary
- Implements the Locator system from upstream Puppeteer, focused on the `filter()` method from [upstream PR #10631](https://github.com/puppeteer/puppeteer/pull/10631)
- Adds `Locator` base class with retry logic, timeout management, and action methods (click, hover, scroll, fill, wait)
- Adds `FilteredLocator` for filtering located elements using JavaScript predicates
- Adds `MappedLocator` for transforming located elements using JavaScript functions
- Adds `NodeLocator` for creating locators from CSS selectors via `Page.Locator()` and `Frame.Locator()`

## Changes
- New `Locators/` directory with `Locator`, `DelegatedLocator`, `NodeLocator`, `FilteredLocator`, `MappedLocator`, and option classes
- `IPage`/`Page` and `IFrame`/`Frame` now expose a `Locator(string selector)` method
- New `LocatorTests/LocatorFilterTests.cs` with tests for filter and map+filter combinations

## Test plan
- [x] `ShouldResolveAsSoonAsThePredicateMatches` - verifies chained `.Filter()` with async/sync predicates
- [x] `ShouldWorkWithFilter` - verifies `.Filter()` + `.Map()` + `.WaitAsync<T>()` pipeline
- [x] Existing ClickTests pass without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)