### PR TITLE
New Feature: Implement Locator.Map tests

### DIFF
--- a/lib/PuppeteerSharp.Tests/LocatorTests/LocatorFilterTests.cs
+++ b/lib/PuppeteerSharp.Tests/LocatorTests/LocatorFilterTests.cs
@@ -24,21 +24,5 @@ namespace PuppeteerSharp.Tests.LocatorTests
             await hoverTask;
         }
 
-        [Test, PuppeteerTest("locator.spec", "Locator Locator.prototype.map", "should work with expect")]
-        public async Task ShouldWorkWithFilter()
-        {
-            await Page.SetContentAsync("<div id='test'>test</div>");
-            var resultTask = Page
-                .Locator("#test")
-                .Filter("(element) => element.getAttribute('clickable') !== null")
-                .Map("(element) => element.getAttribute('clickable')")
-                .WaitAsync<string>();
-
-            await Page.EvaluateExpressionAsync(
-                "document.querySelector('#test')?.setAttribute('clickable', 'true')");
-
-            var result = await resultTask;
-            Assert.That(result, Is.EqualTo("true"));
-        }
     }
 }

--- a/lib/PuppeteerSharp.Tests/LocatorTests/LocatorMapTests.cs
+++ b/lib/PuppeteerSharp.Tests/LocatorTests/LocatorMapTests.cs
@@ -1,0 +1,74 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.LocatorTests
+{
+    public class LocatorMapTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("locator.spec", "Locator.prototype.map", "should work")]
+        public async Task ShouldWork()
+        {
+            await Page.SetContentAsync("<div>test</div>");
+            var result = await Page
+                .Locator("div")
+                .Map("(element) => element.getAttribute('clickable')")
+                .WaitAsync<string>();
+
+            Assert.That(result, Is.Null);
+
+            await Page.EvaluateExpressionAsync(
+                "document.querySelector('div')?.setAttribute('clickable', 'true')");
+
+            var result2 = await Page
+                .Locator("div")
+                .Map("(element) => element.getAttribute('clickable')")
+                .WaitAsync<string>();
+
+            Assert.That(result2, Is.EqualTo("true"));
+        }
+
+        [Test, PuppeteerTest("locator.spec", "Locator.prototype.map", "should work with throws")]
+        public async Task ShouldWorkWithThrows()
+        {
+            await Page.SetContentAsync("<div>test</div>");
+            var resultTask = Page
+                .Locator("div")
+                .SetTimeout(5000)
+                .Map(@"(element) => {
+                    const clickable = element.getAttribute('clickable');
+                    if (!clickable) {
+                        throw new Error('Missing `clickable` as an attribute');
+                    }
+                    return clickable;
+                }")
+                .WaitAsync<string>();
+
+            await Task.Delay(2000);
+            await Page.EvaluateExpressionAsync(
+                "document.querySelector('div')?.setAttribute('clickable', 'true')");
+
+            var result = await resultTask;
+            Assert.That(result, Is.EqualTo("true"));
+        }
+
+        [Test, PuppeteerTest("locator.spec", "Locator.prototype.map", "should work with expect")]
+        public async Task ShouldWorkWithExpect()
+        {
+            await Page.SetContentAsync("<div>test</div>");
+            var resultTask = Page
+                .Locator("div")
+                .SetTimeout(5000)
+                .Filter("(element) => element.getAttribute('clickable') !== null")
+                .Map("(element) => element.getAttribute('clickable')")
+                .WaitAsync<string>();
+
+            await Task.Delay(2000);
+            await Page.EvaluateExpressionAsync(
+                "document.querySelector('div')?.setAttribute('clickable', 'true')");
+
+            var result = await resultTask;
+            Assert.That(result, Is.EqualTo("true"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds test coverage for `Locator.Map()` functionality, ported from upstream Puppeteer PR [#10630](https://github.com/puppeteer/puppeteer/pull/10630)
- The `Map` method, `MappedLocator`, and `DelegatedLocator` implementations already existed in the codebase
- Creates new `LocatorMapTests.cs` with 3 tests: basic map, map with throws (retry behavior), and map combined with filter
- Moves misplaced map test from `LocatorFilterTests.cs` to the proper test file

## Test plan
- [x] All 3 new `LocatorMapTests` pass with Chrome/CDP
- [x] Existing `LocatorFilterTests` still pass
- [x] Full locator test suite passes (4/4 tests)

Closes #2269

🤖 Generated with [Claude Code](https://claude.com/claude-code)