### PR TITLE
Fix: Prevent erroneous new main frame

### DIFF
--- a/lib/PuppeteerSharp/Cdp/FrameTree.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameTree.cs
@@ -82,7 +82,7 @@ namespace PuppeteerSharp.Cdp
                 var childIds = _childIds.GetOrAdd(frame.ParentId, static _ => new());
                 childIds.Add(frame.Id);
             }
-            else
+            else if (MainFrame == null)
             {
                 MainFrame = frame;
             }


### PR DESCRIPTION
## Summary
- Ported upstream fix from [puppeteer/puppeteer#10549](https://github.com/puppeteer/puppeteer/pull/10549)
- Ensures the main frame in `FrameTree` can only be set once, preventing a spurious `Page.frameNavigated` event from Chrome from replacing the actual main frame
- Single-line change: `else` → `else if (MainFrame == null)` in `FrameTree.AddFrame()`

## Changes
- **`lib/PuppeteerSharp/Cdp/FrameTree.cs`**: Added null check before assigning `MainFrame` in `AddFrame()`, so once a main frame is established, subsequent frames without a parent ID cannot overwrite it

## Context
Chrome sometimes emits a random `Page.frameNavigated` event with a frame ID different from the actual main frame. Since this event has no parent ID, it was being incorrectly set as the main frame. This fix ensures the main frame is only assigned if it hasn't been set already.

## Test plan
- [x] Frame tests pass (24/24)
- [x] Navigation tests pass (57/57)
- [x] Project builds without errors

Closes #2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)