### PR TITLE
New Feature: Implement Locator.WaitHandleAsync (#10650) (#2271)

### DIFF
--- a/lib/PuppeteerSharp.Tests/LocatorTests/LocatorWaitHandleTests.cs
+++ b/lib/PuppeteerSharp.Tests/LocatorTests/LocatorWaitHandleTests.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.LocatorTests
+{
+    public class LocatorWaitHandleTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("locator.spec", "Locator.prototype.waitHandle", "should work")]
+        public async Task ShouldWork()
+        {
+            await Page.SetContentAsync(@"
+                <script>
+                    setTimeout(() => {
+                        const element = document.createElement('div');
+                        element.innerText = 'test2';
+                        document.body.append(element);
+                    }, 50);
+                </script>");
+
+            var handle = await Page.Locator("div").WaitHandleAsync();
+            Assert.That(handle, Is.Not.Null);
+            await handle.DisposeAsync();
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/FilteredLocator.cs
+++ b/lib/PuppeteerSharp/Locators/FilteredLocator.cs
@@ -18,9 +18,9 @@ namespace PuppeteerSharp.Locators
             _predicate = predicate;
         }
 
-        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        internal override async Task<IJSHandle> WaitHandleCoreAsync(LocatorActionOptions options, CancellationToken cancellationToken)
         {
-            var handle = await Delegate.WaitHandleAsync(options, cancellationToken).ConfigureAwait(false);
+            var handle = await Delegate.WaitHandleCoreAsync(options, cancellationToken).ConfigureAwait(false);
 
             var elementHandle = handle as IElementHandle;
             if (elementHandle == null)

--- a/lib/PuppeteerSharp/Locators/Locator.cs
+++ b/lib/PuppeteerSharp/Locators/Locator.cs
@@ -137,6 +137,18 @@ namespace PuppeteerSharp.Locators
         }
 
         /// <summary>
+        /// Waits for the locator to get a handle from the page.
+        /// </summary>
+        /// <param name="options">Optional action options.</param>
+        /// <returns>A task that resolves to a handle for the located element.</returns>
+        public async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options = null)
+        {
+            return await RunWithRetryAsync(
+                ct => WaitHandleCoreAsync(options, ct),
+                options?.CancellationToken ?? default).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Waits for the locator to get a value from the page.
         /// Note this requires the value to be JSON-serializable.
         /// </summary>
@@ -145,9 +157,7 @@ namespace PuppeteerSharp.Locators
         /// <returns>A task that resolves to the serialized value.</returns>
         public async Task<T> WaitAsync<T>(LocatorActionOptions options = null)
         {
-            var handle = await RunWithRetryAsync(
-                ct => WaitHandleAsync(options, ct),
-                options?.CancellationToken ?? default).ConfigureAwait(false);
+            var handle = await WaitHandleAsync(options).ConfigureAwait(false);
 
             try
             {
@@ -166,9 +176,7 @@ namespace PuppeteerSharp.Locators
         /// <returns>A task that completes when the element is located.</returns>
         public async Task WaitAsync(LocatorActionOptions options = null)
         {
-            var handle = await RunWithRetryAsync(
-                ct => WaitHandleAsync(options, ct),
-                options?.CancellationToken ?? default).ConfigureAwait(false);
+            var handle = await WaitHandleAsync(options).ConfigureAwait(false);
 
             await handle.DisposeAsync().ConfigureAwait(false);
         }
@@ -313,7 +321,7 @@ namespace PuppeteerSharp.Locators
         /// <param name="options">Optional action options.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that resolves to a handle for the located element.</returns>
-        internal abstract Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken);
+        internal abstract Task<IJSHandle> WaitHandleCoreAsync(LocatorActionOptions options, CancellationToken cancellationToken);
 
         private static async Task WaitForStableBoundingBoxAsync(IElementHandle handle)
         {
@@ -347,7 +355,7 @@ namespace PuppeteerSharp.Locators
             await RunWithRetryAsync(
                 async ct =>
                 {
-                    var handle = await WaitHandleAsync(null, ct).ConfigureAwait(false);
+                    var handle = await WaitHandleCoreAsync(null, ct).ConfigureAwait(false);
                     var elementHandle = handle as IElementHandle;
 
                     if (elementHandle == null)

--- a/lib/PuppeteerSharp/Locators/MappedLocator.cs
+++ b/lib/PuppeteerSharp/Locators/MappedLocator.cs
@@ -16,9 +16,9 @@ namespace PuppeteerSharp.Locators
             _mapper = mapper;
         }
 
-        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        internal override async Task<IJSHandle> WaitHandleCoreAsync(LocatorActionOptions options, CancellationToken cancellationToken)
         {
-            var handle = await Delegate.WaitHandleAsync(options, cancellationToken).ConfigureAwait(false);
+            var handle = await Delegate.WaitHandleCoreAsync(options, cancellationToken).ConfigureAwait(false);
 
             try
             {

--- a/lib/PuppeteerSharp/Locators/NodeLocator.cs
+++ b/lib/PuppeteerSharp/Locators/NodeLocator.cs
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Locators
             return new NodeLocator(frame, selector);
         }
 
-        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        internal override async Task<IJSHandle> WaitHandleCoreAsync(LocatorActionOptions options, CancellationToken cancellationToken)
         {
             var waitOptions = new WaitForSelectorOptions
             {


### PR DESCRIPTION
## Summary
- Adds a public `WaitHandleAsync` method to the `Locator` class that returns an `IJSHandle` directly, matching upstream's `Locator.prototype.waitHandle`
- Refactors existing `WaitAsync` and `WaitAsync<T>` methods to use the new `WaitHandleAsync` internally, reducing code duplication
- Renames the internal abstract method to `WaitHandleCoreAsync` to avoid conflict with the new public method

Upstream PR: https://github.com/puppeteer/puppeteer/pull/10650
Closes #2271

## Test plan
- [x] Added `LocatorWaitHandleTests.ShouldWork` test matching the upstream test
- [x] All 3 locator tests pass (Chrome/CDP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)