### PR TITLE
Fix: Correct content-length header for multi-byte response bodies (#12702)

### DIFF
--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
@@ -148,6 +148,40 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
             Assert.That(error.Message, Does.Match("Invalid header|Expected \"header\"|invalid argument"));
         }
 
+        [Test, PuppeteerTest("requestinterception.spec", "Request.respond", "should report correct content-length header with string")]
+        public async Task ShouldReportCorrectContentLengthHeaderWithString()
+        {
+            await Page.SetRequestInterceptionAsync(true);
+            Page.Request += async (_, e) =>
+            {
+                await e.Request.RespondAsync(new ResponseData
+                {
+                    Status = HttpStatusCode.OK,
+                    Body = "Correct length \U0001F4CF?",
+                });
+            };
+            var response = await Page.GoToAsync(TestConstants.EmptyPage);
+            var headers = response.Headers;
+            Assert.That(headers["content-length"], Is.EqualTo("20"));
+        }
+
+        [Test, PuppeteerTest("requestinterception.spec", "Request.respond", "should report correct content-length header with binary body")]
+        public async Task ShouldReportCorrectContentLengthHeaderWithBinaryBody()
+        {
+            await Page.SetRequestInterceptionAsync(true);
+            Page.Request += async (_, e) =>
+            {
+                await e.Request.RespondAsync(new ResponseData
+                {
+                    Status = HttpStatusCode.OK,
+                    BodyData = System.Text.Encoding.UTF8.GetBytes("Correct length \U0001F4CF?"),
+                });
+            };
+            var response = await Page.GoToAsync(TestConstants.EmptyPage);
+            var headers = response.Headers;
+            Assert.That(headers["content-length"], Is.EqualTo("20"));
+        }
+
         [Test, PuppeteerTest("requestinterception.spec", "Request.respond", "should stringify intercepted request response headers")]
         public async Task ShouldStringifyInterceptedRequestResponseHeaders()
         {

--- a/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
@@ -487,7 +487,7 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
             }
 
             // Add content-length if not present and we have body data
-            if (!hasContentLength && response.BodyData != null)
+            if (!hasContentLength && response.BodyData is { Length: > 0 })
             {
                 responseHeaders.Add(new Header("content-length", response.BodyData.Length.ToString(CultureInfo.InvariantCulture)));
             }

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -355,11 +355,11 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
                     responseHeaders.Add(new Header { Name = keyValuePair.Key, Value = keyValuePair.Value.ToString() });
                 }
             }
+        }
 
-            if (!response.Headers.ContainsKey("content-length") && response.BodyData != null)
-            {
-                responseHeaders.Add(new Header { Name = "content-length", Value = response.BodyData.Length.ToString(CultureInfo.CurrentCulture) });
-            }
+        if (response.BodyData is { Length: > 0 } && (response.Headers == null || !response.Headers.ContainsKey("content-length")))
+        {
+            responseHeaders.Add(new Header { Name = "content-length", Value = response.BodyData.Length.ToString(CultureInfo.InvariantCulture) });
         }
 
         if (response.ContentType != null)


### PR DESCRIPTION
Implements changes from https://github.com/puppeteer/puppeteer/pull/12702

Closes #2681