### PR TITLE
Fix: Execution contexts might be created before previous is destroyed (#12666)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -327,7 +327,7 @@ namespace PuppeteerSharp.Cdp
                 {
                     world = frame.MainWorld;
                 }
-                else if (contextPayload.Name == UtilityWorldName && !frame.PuppeteerWorld.HasContext)
+                else if (contextPayload.Name == UtilityWorldName)
                 {
                     // In case of multiple sessions to the same target, there's a race between
                     // connections so we might end up creating multiple isolated worlds.

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -178,14 +178,16 @@ namespace PuppeteerSharp
             TaskManager.TerminateAll(new PuppeteerException("waitForFunction failed: frame got detached."));
         }
 
-        internal Task<ExecutionContext> GetExecutionContextAsync()
+        internal async Task<ExecutionContext> GetExecutionContextAsync()
         {
             if (_detached)
             {
                 throw new PuppeteerException($"Execution Context is not available in detached frame \"{Frame.Url}\" (are you trying to evaluate?)");
             }
 
-            return _contextResolveTaskWrapper.Task;
+            return await _contextResolveTaskWrapper.Task
+                .WithTimeout(TimeoutSettings.Timeout)
+                .ConfigureAwait(false);
         }
 
         internal override async Task<IJSHandle> EvaluateExpressionHandleAsync(string script)

--- a/lib/PuppeteerSharp/Locators/FunctionLocator.cs
+++ b/lib/PuppeteerSharp/Locators/FunctionLocator.cs
@@ -35,7 +35,7 @@ namespace PuppeteerSharp.Locators
             return new FunctionLocator(frame, func);
         }
 
-        internal override async Task<IJSHandle> WaitHandleAsync(LocatorActionOptions options, CancellationToken cancellationToken)
+        internal override async Task<IJSHandle> WaitHandleCoreAsync(LocatorActionOptions options, CancellationToken cancellationToken)
         {
             var waitOptions = new WaitForFunctionOptions
             {


### PR DESCRIPTION
## Summary
- Remove the `HasContext` check in `FrameManager` when assigning the utility world context, allowing a new execution context to replace the previous one even if it hasn't been destroyed yet. This fixes issues where frame swaps could cause the new context to be omitted by PuppeteerSharp.
- Add a timeout to `IsolatedWorld.GetExecutionContextAsync()` so it doesn't wait indefinitely if a context is never set.
- Fix `FunctionLocator` to override `WaitHandleCoreAsync` instead of `WaitHandleAsync` to match the base class abstract method (pre-existing build error).

## Test plan
- [x] ExecutionContext tests pass (4/4)
- [x] Evaluation tests pass (47/48, 1 skipped)
- [x] Frame tests pass (24/24)
- [x] WaitForFunction tests pass (17/17)

Implements changes from https://github.com/puppeteer/puppeteer/pull/12666
closes #2686

🤖 Generated with [Claude Code](https://claude.com/claude-code)