### PR TITLE
Add missing tests: requestinterception.spec.ts (#2144)

### DIFF
--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
@@ -231,7 +231,18 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
 
             Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(response.Headers["foo"], Is.EqualTo("bar"));
-            Assert.That(response.Headers["arr"], Is.EqualTo("1\n2"));
+
+            // The separator used to handle headers with multiple values is browser
+            // specific. Chrome uses newline, Firefox uses comma-separated values.
+            if (!TestConstants.IsChrome)
+            {
+                Assert.That(response.Headers["arr"], Is.EqualTo("1, 2"));
+            }
+            else
+            {
+                Assert.That(response.Headers["arr"], Is.EqualTo("1\n2"));
+            }
+
             Assert.That(firstCookie?.Value, Is.EqualTo("1"));
             Assert.That(secondCookie?.Value, Is.EqualTo("2"));
         }


### PR DESCRIPTION
## Summary
- Port upstream test `Request.respond: should allow mocking multiple headers with same key` to PuppeteerSharp
- Replaced the previously ignored `ShouldAllowMultipleInterceptedRequestResponseHeaders` test with the properly attributed upstream version
- The other two tests from the issue (`Request.continue: should fail if the header value is invalid` and `Request.respond: should fail if the header value is invalid`) were already implemented

## Test plan
- [x] Build passes
- [x] New test `ShouldAllowMockingMultipleHeadersWithSameKey` passes with Chrome/CDP
- [x] All existing `RequestRespondTests` continue to pass
- [x] All existing `RequestContinueTests` continue to pass

Closes #2144