### PR TITLE
Add missing tests: coverage.spec.ts (#2149)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/csscoverage/empty.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/csscoverage/empty.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<style></style>
+<div>empty style tag</div>

--- a/lib/PuppeteerSharp.Tests/CoverageTests/CSSCoverageTests.cs
+++ b/lib/PuppeteerSharp.Tests/CoverageTests/CSSCoverageTests.cs
@@ -133,6 +133,16 @@ namespace PuppeteerSharp.Tests.CoverageTests
                 Is.EqualTo(TestUtils.CompressText(involved)));
         }
 
+        [Test, PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should work with empty stylesheets")]
+        public async Task ShouldWorkWithEmptyStylesheets()
+        {
+            await Page.Coverage.StartCSSCoverageAsync();
+            await Page.GoToAsync(TestConstants.ServerUrl + "/csscoverage/empty.html");
+            var coverage = await Page.Coverage.StopCSSCoverageAsync();
+            Assert.That(coverage, Has.Exactly(1).Items);
+            Assert.That(coverage[0].Text, Is.EqualTo(string.Empty));
+        }
+
         [Test, PuppeteerTest("coverage.spec", "Coverage specs CSSCoverage", "should ignore injected stylesheets")]
         public async Task ShouldIgnoreInjectedStylesheets()
         {


### PR DESCRIPTION
## Summary
- Add missing CSS coverage test: "should work with empty stylesheets"
- Add `empty.html` test fixture for CSS coverage testing
- The other 3 tests from the issue were already implemented

Closes #2149

## Test plan
- [x] All 26 coverage tests pass (25 passed, 1 pre-existing skip)
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)