### PR TITLE
Add missing tests: frame.spec.ts (#2152)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/frames/lazy-frame.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/frames/lazy-frame.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<iframe width="100%" height="300" src="about:blank"></iframe>
+<div style="height: 800vh"></div>
+<iframe width="100%" height="300" src='./frame.html' loading="lazy"></iframe>

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameClientTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameClientTests.cs
@@ -1,0 +1,14 @@
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.FrameTests
+{
+    public class FrameClientTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("frame.spec", "Frame specs Frame.client", "should return the client instance")]
+        public void ShouldReturnTheClientInstance()
+        {
+            Assert.That(((Frame)Page.MainFrame).Client, Is.InstanceOf<ICDPSession>());
+        }
+    }
+}

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameEvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameEvaluateTests.cs
@@ -16,5 +16,17 @@ namespace PuppeteerSharp.Tests.FrameTests
                 () => frame.EvaluateExpressionAsync("5 * 8"));
             Assert.That(exception.Message, Does.Contain("Execution Context is not available in detached frame"));
         }
+
+        [Test, PuppeteerTest("frame.spec", "Frame specs Frame.evaluate", "allows readonly array to be an argument")]
+        public async Task AllowsReadonlyArrayToBeAnArgument()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var mainFrame = Page.MainFrame;
+
+            // This test checks if Frame.evaluate allows an array to be an argument.
+            // See https://github.com/puppeteer/puppeteer/issues/6953.
+            var readonlyArray = new[] { "a", "b", "c" };
+            await mainFrame.EvaluateFunctionAsync("arr => arr", (object)readonlyArray);
+        }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
@@ -167,6 +167,17 @@ namespace PuppeteerSharp.Tests.FrameTests
             Assert.That(frame2, Is.Not.SameAs(frame1));
         }
 
+        [Test, PuppeteerTest("frame.spec", "Frame specs Frame Management", "should support lazy frames")]
+        public async Task ShouldSupportLazyFrames()
+        {
+            await Page.SetViewportAsync(new ViewPortOptions { Width = 1000, Height = 1000 });
+            await Page.GoToAsync(TestConstants.ServerUrl + "/frames/lazy-frame.html");
+
+            Assert.That(
+                Page.Frames.Select(frame => ((Frame)frame).HasStartedLoading).ToArray(),
+                Is.EqualTo(new[] { true, true, false }));
+        }
+
         [Test, PuppeteerTest("frame.spec", "Frame specs Frame Management", "should support framesets")]
         public async Task ShouldSupportFramesets()
         {

--- a/lib/PuppeteerSharp.Tests/FrameTests/FramePageTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FramePageTests.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.FrameTests
+{
+    public class FramePageTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("frame.spec", "Frame specs Frame.page", "should retrieve the page from a frame")]
+        public async Task ShouldRetrieveThePageFromAFrame()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var mainFrame = Page.MainFrame;
+            Assert.That(mainFrame.Page, Is.EqualTo(Page));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Port 4 missing tests from upstream `frame.spec.ts`: "allows readonly array to be an argument", "should retrieve the page from a frame", "should support lazy frames", and "should return the client instance"
- Add `lazy-frame.html` test fixture for the lazy frames test
- New test files: `FramePageTests.cs`, `FrameClientTests.cs`

Closes #2152

## Test plan
- [x] All 4 new tests pass with Chrome/CDP
- [x] Full FrameTests suite (28 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)