### PR TITLE
Add missing tests: queryhandler.spec.ts in ElementHandles (#2155)

### DIFF
--- a/lib/PuppeteerSharp.Tests/QueryHandlerTests/XPathSelectorTests/XPathSelectorInElementHandlesTests.cs
+++ b/lib/PuppeteerSharp.Tests/QueryHandlerTests/XPathSelectorTests/XPathSelectorInElementHandlesTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.QueryHandlerTests.XPathSelectorTests
+{
+    public class XPathSelectorInElementHandlesTests : PuppeteerPageBaseTest
+    {
+        public XPathSelectorInElementHandlesTests() : base()
+        {
+        }
+
+        [Test, PuppeteerTest("queryhandler.spec", "Query handler tests XPath selectors in ElementHandles", "should query existing element")]
+        public async Task ShouldQueryExistingElement()
+        {
+            await Page.SetContentAsync("<div class=\"a\">a<span></span></div>");
+            var elementHandle = await Page.QuerySelectorAsync("div");
+            Assert.That(await elementHandle.QuerySelectorAsync("xpath/span"), Is.Not.Null);
+            Assert.That(await elementHandle.QuerySelectorAllAsync("xpath/span"), Has.Exactly(1).Items);
+        }
+
+        [Test, PuppeteerTest("queryhandler.spec", "Query handler tests XPath selectors in ElementHandles", "should return null for non-existing element")]
+        public async Task ShouldReturnNullForNonExistingElement()
+        {
+            await Page.SetContentAsync("<div class=\"a\">a</div>");
+            var elementHandle = await Page.QuerySelectorAsync("div");
+            Assert.That(await elementHandle.QuerySelectorAsync("xpath/span"), Is.Null);
+            Assert.That(await elementHandle.QuerySelectorAllAsync("xpath/span"), Is.Empty);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add two missing XPath selector tests for `ElementHandle` query operations from upstream `queryhandler.spec.ts`
- Tests cover `should query existing element` and `should return null for non-existing element` under the "XPath selectors in ElementHandles" describe block
- The corresponding Text selector "in ElementHandles" tests already existed; only the XPath variants were missing

Closes #2155

## Test plan
- [x] New tests build successfully
- [x] Both tests pass with Chrome/CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)