### PR TITLE
Add missing tests: input.spec.ts (#2157)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpElementHandle.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpElementHandle.cs
@@ -149,7 +149,6 @@ public class CdpElementHandle : ElementHandle, ICdpHandle
                 var backendNodeId = node.Node.BackendNodeId;
 
                 var files = resolveFilePaths ? filePaths.Select(Path.GetFullPath).ToArray() : filePaths;
-                CheckForFileAccess(files);
                 await handle.Client.SendAsync(
                     "DOM.setFileInputFiles",
                     new DomSetFileInputFilesRequest
@@ -204,19 +203,4 @@ public class CdpElementHandle : ElementHandle, ICdpHandle
 
     /// <inheritdoc />
     public override string ToString() => Handle.ToString();
-
-    private void CheckForFileAccess(string[] files)
-    {
-        foreach (var file in files)
-        {
-            try
-            {
-                File.Open(file, FileMode.Open).Dispose();
-            }
-            catch (Exception ex)
-            {
-                throw new PuppeteerException($"{files} does not exist or is not readable", ex);
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Add two missing upstream tests from `input.spec.ts` for `FileChooser.accept`:
  - `should succeed even for non-existent files` - verifies that accepting a non-existent file does not throw
  - `should error on read of non-existent files` - verifies that reading an accepted non-existent file errors in the browser
- Remove `CheckForFileAccess` validation from `CdpElementHandle.UploadFileAsync` to match upstream Puppeteer behavior (file existence is not checked on accept; errors surface when the browser tries to read the file)

## Test plan
- [x] Both new tests pass with Chrome/CDP
- [x] All 7 existing FileChooserAcceptTests pass

Closes #2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)