### PR TITLE
Add missing tests: target.spec.ts (#2158)

### DIFF
--- a/lib/PuppeteerSharp.Tests/TargetTests/BrowserWaitForTargetTests.cs
+++ b/lib/PuppeteerSharp.Tests/TargetTests/BrowserWaitForTargetTests.cs
@@ -29,5 +29,21 @@ namespace PuppeteerSharp.Tests.TargetTests
             => Assert.ThrowsAsync<TimeoutException>(async () => await Browser.WaitForTargetAsync(
                 (target) => target.Url == TestConstants.EmptyPage,
                 new() { Timeout = 1 }));
+
+        [Test, PuppeteerTest("target.spec", "Target", "should be able to use async waitForTarget")]
+        public async Task ShouldBeAbleToUseAsyncWaitForTarget()
+        {
+            var targetTask = Context.WaitForTargetAsync(
+                target => target.Url == TestConstants.CrossProcessHttpPrefix + "/empty.html",
+                new() { Timeout = 3000 });
+            await Page.EvaluateFunctionAsync(
+                "url => window.open(url)",
+                TestConstants.CrossProcessHttpPrefix + "/empty.html");
+            var target = await targetTask;
+            var otherPage = await target.PageAsync();
+            Assert.That(otherPage.Url, Is.EqualTo(TestConstants.CrossProcessHttpPrefix + "/empty.html"));
+            Assert.That(Page, Is.Not.SameAs(otherPage));
+            await otherPage.CloseAsync();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add missing test `should be able to use async waitForTarget` from upstream `target.spec.ts`
- The test verifies that `WaitForTargetAsync` correctly detects a new page opened via `window.open` with a cross-process URL

Closes #2158

## Test plan
- [x] New test passes with Chrome/CDP
- [x] All 18 existing target tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)