### PR TITLE
Add missing tests: keyboard.spec.ts (#2163)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpKeyboard.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpKeyboard.cs
@@ -62,6 +62,7 @@ public class CdpKeyboard : Keyboard
             AutoRepeat = autoRepeat,
             Location = description.Location,
             IsKeypad = description.Location == 3,
+            Commands = options?.Commands,
         });
     }
 

--- a/lib/PuppeteerSharp/Cdp/Messaging/InputDispatchKeyEventRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/InputDispatchKeyEventRequest.cs
@@ -21,5 +21,7 @@ namespace PuppeteerSharp.Cdp.Messaging
         public int Location { get; set; }
 
         public bool IsKeypad { get; set; }
+
+        public string[] Commands { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Input/DownOptions.cs
+++ b/lib/PuppeteerSharp/Input/DownOptions.cs
@@ -9,5 +9,11 @@ namespace PuppeteerSharp.Input
         /// If specified, generates an input event with this text.
         /// </summary>
         public string Text { get; set; }
+
+        /// <summary>
+        /// If specified, the commands of keyboard shortcuts.
+        /// See <see href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/commands/editor_command_names.h">Chromium Source Code</see> for valid command names.
+        /// </summary>
+        public string[] Commands { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Add `Commands` property to `DownOptions` to support keyboard shortcut commands (SelectAll, Copy, Paste) passed to CDP `Input.dispatchKeyEvent`
- Wire `Commands` through `CdpKeyboard.DownAsync` and `InputDispatchKeyEventRequest`
- Add missing test `ShouldTriggerCommandsOfKeyboardShortcuts` from upstream `keyboard.spec.ts`

The other test mentioned in the issue (`should press the meta key`) was already implemented as `ShouldPressTheMetaKey`.

Closes #2163

## Test plan
- [x] New test `ShouldTriggerCommandsOfKeyboardShortcuts` passes with Chrome/CDP
- [x] All 17 existing keyboard tests continue to pass (1 skipped as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)