### PR TITLE
Add missing tests: page.spec.ts BrowserContext.overridePermissions (#2164)

### DIFF
--- a/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserContextTests/BrowserContextOverridePermissionsTests.cs
@@ -103,6 +103,18 @@ namespace PuppeteerSharp.Tests.BrowserContextTests
             Assert.That(await GetPermissionAsync(otherPage, "geolocation"), Is.EqualTo("granted"));
         }
 
+        [Test, PuppeteerTest("browsercontext.spec", "BrowserContext BrowserContext.overridePermissions", "should grant persistent-storage")]
+        public async Task ShouldGrantPersistentStorage()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            Assert.That(await GetPermissionAsync(Page, "persistent-storage"), Is.Not.EqualTo("granted"));
+            await Context.OverridePermissionsAsync(TestConstants.EmptyPage, new OverridePermission[]
+            {
+                OverridePermission.PersistentStorage
+            });
+            Assert.That(await GetPermissionAsync(Page, "persistent-storage"), Is.EqualTo("granted"));
+        }
+
         [Test, Ignore("Fails on Firefox")]
         public async Task AllEnumsdAreValid()
         {


### PR DESCRIPTION
## Summary
- Add missing upstream test `should grant persistent-storage` from `browsercontext.spec` `BrowserContext.overridePermissions` describe block
- Tests that `Context.OverridePermissionsAsync` correctly grants the `persistent-storage` permission

Closes #2164

## Test plan
- [x] New test `ShouldGrantPersistentStorage` passes with Chrome/CDP
- [x] All existing `BrowserContextOverridePermissionsTests` continue to pass (7 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)