### PR TITLE
Add missing tests: page.spec.ts Page.waitForNetworkIdle (#2168)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/abort-request.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/abort-request.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<button id="abort"></button>
+
+<script>
+  const button = document.getElementById('abort');
+  button.addEventListener('click', getJson)
+  async function getJson() {
+    const abort = new AbortController();
+    const result = fetch("/simple.json", {
+      signal: abort.signal
+    });
+    abort.abort();
+  }
+</script>

--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNetworkIdleTests.cs
@@ -91,6 +91,27 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(t2, Is.GreaterThan(t1));
         }
 
+        [Test, PuppeteerTest("page.spec", "Page Page.waitForNetworkIdle", "should work with aborted requests")]
+        public async Task ShouldWorkWithAbortedRequests()
+        {
+            await Page.GoToAsync(TestConstants.ServerUrl + "/abort-request.html");
+
+            await using var element = await Page.QuerySelectorAsync("#abort");
+            await element.ClickAsync();
+
+            var error = false;
+            try
+            {
+                await Page.WaitForNetworkIdleAsync();
+            }
+            catch
+            {
+                error = true;
+            }
+
+            Assert.That(error, Is.False);
+        }
+
         [Test, PuppeteerTest("page.spec", "Page Page.waitForNetworkIdle", "should work with no timeout")]
         public async Task ShouldWorkWithNoTimeout()
         {

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -508,10 +508,14 @@ public class CdpPage : Page
 
             networkManager.Request -= RequestEventListener;
             networkManager.Response -= ResponseEventListener;
+            networkManager.RequestFinished -= RequestEventListener;
+            networkManager.RequestFailed -= RequestEventListener;
         }
 
         networkManager.Request += RequestEventListener;
         networkManager.Response += ResponseEventListener;
+        networkManager.RequestFinished += RequestEventListener;
+        networkManager.RequestFailed += RequestEventListener;
 
         Evaluate();
 


### PR DESCRIPTION
## Summary
- Add upstream test `ShouldWorkWithAbortedRequests` for `Page.waitForNetworkIdle` that verifies `WaitForNetworkIdleAsync` works correctly when fetch requests are aborted client-side via `AbortController`.
- Fix `CdpPage.WaitForNetworkIdleAsync` to also subscribe to `RequestFailed` and `RequestFinished` events from the NetworkManager, matching the upstream Puppeteer behavior which tracks all three terminal request states (Response, RequestFailed, RequestFinished).
- Add `abort-request.html` test fixture (matching upstream asset).

Closes #2168

## Test plan
- [x] New test `ShouldWorkWithAbortedRequests` passes with Chrome/CDP
- [x] All existing `WaitForNetworkIdle` tests still pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)