### PR TITLE
Add missing tests: page.spec.ts Page.select (#2172)

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/SelectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SelectTests.cs
@@ -120,5 +120,15 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.That(await Page.QuerySelectorAsync("select").EvaluateFunctionAsync<string>(
                 "select => Array.from(select.options).filter(option => option.selected)[0].value"), Is.EqualTo(""));
         }
+
+        [Test, PuppeteerTest("page.spec", "Page Page.select", "should work when re-defining top-level Event class")]
+        public async Task ShouldWorkWhenReDefiningTopLevelEventClass()
+        {
+            await Page.GoToAsync(TestConstants.ServerUrl + "/input/select.html");
+            await Page.EvaluateFunctionAsync("() => window.Event = undefined");
+            await Page.SelectAsync("select", "blue");
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onInput"), Is.EqualTo(new string[] { "blue" }));
+            Assert.That(await Page.EvaluateExpressionAsync<string[]>("result.onChange"), Is.EqualTo(new string[] { "blue" }));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Port upstream test "should work when re-defining top-level Event class" from the `Page.select` describe block in `page.spec.ts`
- This test verifies that `Page.SelectAsync` works correctly even when the top-level `Event` class is set to `undefined` on the page (see upstream issue puppeteer/puppeteer#3327)

Closes #2172

## Test plan
- [x] New test `ShouldWorkWhenReDefiningTopLevelEventClass` passes with Chrome/CDP
- [x] All 16 existing SelectTests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)