### PR TITLE
Add missing tests: injected.spec.ts (#2179)

### DIFF
--- a/lib/PuppeteerSharp.Tests/WontImplementTests.cs
+++ b/lib/PuppeteerSharp.Tests/WontImplementTests.cs
@@ -48,6 +48,9 @@ namespace PuppeteerSharp.Tests
         [PuppeteerTest("DeviceRequestPrompt.test.ts", "DeviceRequestPrompt.waitForDevice", "should listen and shortcut when there are no watchdogs")]
         [PuppeteerTest("evaluation.spec", "Evaluation specs Page.evaluate", "should work with function shorthands and nested arrow functions")]
         [PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.toElement", "should work")]
+        // These test JavaScript-internal utilities (PuppeteerUtil, createFunction) injected into the isolated realm via LazyArg - no C# equivalent
+        [PuppeteerTest("injected.spec", "PuppeteerUtil tests", "should work")]
+        [PuppeteerTest("injected.spec", "createFunction tests", "should work")]
         public void TheseTestWontBeImplemented()
         {
         }


### PR DESCRIPTION
## Summary
- Added `injected.spec.ts` tests (`PuppeteerUtil tests: should work` and `createFunction tests: should work`) to `WontImplementTests.cs`
- These tests verify JavaScript-internal utilities (`PuppeteerUtil` object and `createFunction`) injected into the browser's isolated realm via `LazyArg`, which have no C# equivalent in PuppeteerSharp

Closes #2179

🤖 Generated with [Claude Code](https://claude.com/claude-code)