### PR TITLE
Expose InterceptResolutionState on IRequest

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -59,19 +59,8 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
     /// <inheritdoc cref="Response"/>
     public override CdpHttpResponse Response { get; internal set; }
 
-    internal CDPSession Client
-    {
-        get => _client;
-        set => _client = value;
-    }
-
-    internal override Payload ContinueRequestOverrides => _continueRequestOverrides;
-
-    internal override ResponseData ResponseForRequest => _responseForRequest;
-
-    internal override RequestAbortErrorCode AbortErrorReason => _abortErrorReason;
-
-    private InterceptResolutionState InterceptResolutionState
+    /// <inheritdoc/>
+    public override InterceptResolutionState InterceptResolutionState
     {
         get
         {
@@ -86,7 +75,20 @@ public class CdpHttpRequest : Request<CdpHttpResponse>
         }
     }
 
-    private bool IsInterceptResolutionHandled { get; set; }
+    /// <inheritdoc/>
+    public override bool IsInterceptResolutionHandled { get; protected set; }
+
+    internal CDPSession Client
+    {
+        get => _client;
+        set => _client = value;
+    }
+
+    internal override Payload ContinueRequestOverrides => _continueRequestOverrides;
+
+    internal override ResponseData ResponseForRequest => _responseForRequest;
+
+    internal override RequestAbortErrorCode AbortErrorReason => _abortErrorReason;
 
     /// <inheritdoc/>
     public override async Task ContinueAsync(Payload overrides = null, int? priority = null)

--- a/lib/PuppeteerSharp/IRequest.cs
+++ b/lib/PuppeteerSharp/IRequest.cs
@@ -118,6 +118,16 @@ namespace PuppeteerSharp
         bool HasPostData { get; }
 
         /// <summary>
+        /// Gets whether the intercept resolution has already been handled.
+        /// </summary>
+        bool IsInterceptResolutionHandled { get; }
+
+        /// <summary>
+        /// Gets the current intercept resolution state.
+        /// </summary>
+        InterceptResolutionState InterceptResolutionState { get; }
+
+        /// <summary>
         /// Continues request with optional request overrides. To use this, request interception should be enabled with <see cref="IPage.SetRequestInterceptionAsync(bool)"/>. Exception is immediately thrown if the request interception is not enabled.
         /// If the URL is set it won't perform a redirect. The request will be silently forwarded to the new url. For example, the address bar will show the original url.
         /// </summary>

--- a/lib/PuppeteerSharp/InterceptResolutionAction.cs
+++ b/lib/PuppeteerSharp/InterceptResolutionAction.cs
@@ -25,13 +25,39 @@ using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp;
 
+/// <summary>
+/// Represents the action taken for an intercepted request.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumMemberConverter<InterceptResolutionAction>))]
-internal enum InterceptResolutionAction
+public enum InterceptResolutionAction
 {
+    /// <summary>
+    /// The request will be aborted.
+    /// </summary>
     Abort,
+
+    /// <summary>
+    /// The request will be fulfilled with a custom response.
+    /// </summary>
     Respond,
+
+    /// <summary>
+    /// The request will continue normally.
+    /// </summary>
     Continue,
+
+    /// <summary>
+    /// Request interception is disabled.
+    /// </summary>
     Disabled,
+
+    /// <summary>
+    /// No interception action has been set yet.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// The interception has already been handled.
+    /// </summary>
     AlreadyHandled,
 }

--- a/lib/PuppeteerSharp/InterceptResolutionState.cs
+++ b/lib/PuppeteerSharp/InterceptResolutionState.cs
@@ -22,9 +22,20 @@
 
 namespace PuppeteerSharp;
 
-internal class InterceptResolutionState(InterceptResolutionAction action, int? priority = null)
+/// <summary>
+/// Represents the current state of request interception resolution.
+/// </summary>
+/// <param name="action">The interception action.</param>
+/// <param name="priority">The interception priority.</param>
+public class InterceptResolutionState(InterceptResolutionAction action, int? priority = null)
 {
+    /// <summary>
+    /// Gets or sets the intercept resolution action.
+    /// </summary>
     public InterceptResolutionAction Action { get; set; } = action;
 
+    /// <summary>
+    /// Gets or sets the intercept resolution priority.
+    /// </summary>
     public int? Priority { get; set; } = priority;
 }

--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -55,6 +55,12 @@ namespace PuppeteerSharp
         /// <inheritdoc />
         public bool HasPostData { get; internal init; }
 
+        /// <inheritdoc />
+        public abstract bool IsInterceptResolutionHandled { get; protected set; }
+
+        /// <inheritdoc />
+        public abstract InterceptResolutionState InterceptResolutionState { get; }
+
         internal List<IRequest> RedirectChainList { get; init; }
 
         internal abstract Payload ContinueRequestOverrides


### PR DESCRIPTION
## Summary
- Exposes `InterceptResolutionState` and `IsInterceptResolutionHandled` as public API on `IRequest`, allowing users to check if a request has already been handled by interception
- Makes `InterceptResolutionAction` enum and `InterceptResolutionState` class public (previously internal)
- Adds XML documentation for all newly public types and members

Closes #1524

## Test plan
- [x] Build passes with 0 errors and 0 warnings
- [x] All 96 request interception tests pass (2 skipped as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)