### PR TITLE
New Feature: Add Locator.Race static method (#2228)

### DIFF
--- a/lib/PuppeteerSharp.Tests/LocatorTests/LocatorRaceTests.cs
+++ b/lib/PuppeteerSharp.Tests/LocatorTests/LocatorRaceTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Locators;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.LocatorTests
+{
+    public class LocatorRaceTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("locator.spec", "Locator.race", "races multiple locators")]
+        public async Task RacesMultipleLocators()
+        {
+            await Page.SetViewportAsync(new ViewPortOptions { Width = 500, Height = 500 });
+            await Page.SetContentAsync("<button onclick=\"window.count++;\">test</button>");
+            await Page.EvaluateExpressionAsync("window.count = 0");
+
+            await Locator.Race(
+                Page.Locator("button"),
+                Page.Locator("button")).ClickAsync();
+
+            var count = await Page.EvaluateExpressionAsync<int>("globalThis.count");
+            Assert.That(count, Is.EqualTo(1));
+        }
+
+        [Test, PuppeteerTest("locator.spec", "Locator.race", "can be aborted")]
+        public async Task CanBeAborted()
+        {
+            await Page.SetViewportAsync(new ViewPortOptions { Width = 500, Height = 500 });
+            await Page.SetContentAsync(
+                "<button style=\"display: none;\" onclick=\"this.innerText = 'clicked';\">test</button>");
+
+            using var cts = new CancellationTokenSource();
+            var resultTask = Locator.Race(
+                    Page.Locator("button"),
+                    Page.Locator("button"))
+                .SetTimeout(5000)
+                .ClickAsync(new LocatorClickOptions { CancellationToken = cts.Token });
+
+            await Task.Delay(2000);
+            cts.Cancel();
+
+            var exception = Assert.CatchAsync(async () => await resultTask);
+            Assert.That(exception, Is.InstanceOf<OperationCanceledException>());
+        }
+
+        [Test, PuppeteerTest("locator.spec", "Locator.race", "should time out when all locators do not match")]
+        public async Task ShouldTimeOutWhenAllLocatorsDoNotMatch()
+        {
+            await Page.SetContentAsync("<button>test</button>");
+
+            var exception = Assert.ThrowsAsync<TimeoutException>(async () =>
+            {
+                await Locator.Race(
+                        Page.Locator("not-found"),
+                        Page.Locator("not-found"))
+                    .SetTimeout(5000)
+                    .ClickAsync();
+            });
+
+            Assert.That(exception.Message, Does.Contain("Timed out after waiting 5000ms"));
+        }
+
+        [Test, PuppeteerTest("locator.spec", "Locator.race", "should not time out when one of the locators matches")]
+        public async Task ShouldNotTimeOutWhenOneOfTheLocatorsMatches()
+        {
+            await Page.SetContentAsync("<button>test</button>");
+
+            await Locator.Race(
+                Page.Locator("not-found"),
+                Page.Locator("button")).ClickAsync();
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Locators/Locator.cs
+++ b/lib/PuppeteerSharp/Locators/Locator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using PuppeteerSharp.Input;
@@ -58,6 +59,16 @@ namespace PuppeteerSharp.Locators
         {
             get => _waitForStableBoundingBox;
             set => _waitForStableBoundingBox = value;
+        }
+
+        /// <summary>
+        /// Creates a new locator that races multiple locators, returning the first one to resolve.
+        /// </summary>
+        /// <param name="locators">The locators to race.</param>
+        /// <returns>A new locator that resolves to the first matching locator's result.</returns>
+        public static Locator Race(params Locator[] locators)
+        {
+            return new RaceLocator(locators);
         }
 
         /// <summary>

--- a/lib/PuppeteerSharp/Locators/RaceLocator.cs
+++ b/lib/PuppeteerSharp/Locators/RaceLocator.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp.Locators
+{
+    internal class RaceLocator : Locator
+    {
+        private readonly IReadOnlyList<Locator> _locators;
+
+        internal RaceLocator(IReadOnlyList<Locator> locators)
+        {
+            _locators = locators;
+        }
+
+        internal override async Task<IJSHandle> WaitHandleCoreAsync(
+            LocatorActionOptions options,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tcs = new TaskCompletionSource<IJSHandle>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var remaining = _locators.Count;
+            Exception lastException = null;
+
+            using var reg = cancellationToken.Register(() =>
+                tcs.TrySetCanceled(cancellationToken));
+
+            var tasks = _locators.Select(locator => Task.Run(async () =>
+            {
+                try
+                {
+                    var handle = await locator.WaitHandleCoreAsync(options, cancellationToken).ConfigureAwait(false);
+                    if (!tcs.TrySetResult(handle))
+                    {
+                        // Another locator won; dispose this handle.
+                        await handle.DisposeAsync().ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (Interlocked.Decrement(ref remaining) == 0)
+                    {
+                        tcs.TrySetException(lastException);
+                    }
+                }
+            })).ToArray();
+
+            return await tcs.Task.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Locator.Race(params Locator[] locators)` static method that races multiple locators, returning the first one to resolve
- Add `RaceLocator` class that uses `TaskCompletionSource` to race child locators concurrently, disposing loser handles
- Port 4 upstream test cases from `locator.spec.ts` (`Locator.race` describe block)

Closes #2228

Upstream refs: puppeteer PRs #10337, #10363, #10567

## Test plan
- [x] "races multiple locators" - two locators race, only one click fires
- [x] "can be aborted" - cancellation token aborts the race
- [x] "should time out when all locators do not match" - timeout when nothing matches
- [x] "should not time out when one of the locators matches" - one match succeeds despite other failing
- [x] All 13 locator tests pass (9 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)