### PR TITLE
Fix: Implement fallback to Chrome for Testing dashboard download URLs (#11951)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -68,6 +68,17 @@ namespace PuppeteerSharp.BrowserData
             }
         }
 
+        internal static string GetFolder(Platform platform)
+            => platform switch
+            {
+                Platform.Linux or Platform.LinuxArm64 => "linux64",
+                Platform.MacOSArm64 => "mac-arm64",
+                Platform.MacOS => "mac-x64",
+                Platform.Win32 => "win32",
+                Platform.Win64 => "win64",
+                _ => throw new PuppeteerException($"Unknown platform: {platform}"),
+            };
+
         private static string[] GetChromeWindowsLocations(ChromeReleaseChannel channel)
         {
             var suffix = channel switch
@@ -135,16 +146,5 @@ namespace PuppeteerSharp.BrowserData
                 GetFolder(platform),
                 $"chrome-{GetFolder(platform)}.zip"
             ];
-
-        private static string GetFolder(Platform platform)
-            => platform switch
-            {
-                Platform.Linux or Platform.LinuxArm64 => "linux64",
-                Platform.MacOSArm64 => "mac-arm64",
-                Platform.MacOS => "mac-x64",
-                Platform.Win32 => "win32",
-                Platform.Win64 => "win64",
-                _ => throw new PuppeteerException($"Unknown platform: {platform}"),
-            };
     }
 }

--- a/lib/PuppeteerSharp/BrowserData/ChromeDashboardVersionResult.cs
+++ b/lib/PuppeteerSharp/BrowserData/ChromeDashboardVersionResult.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace PuppeteerSharp.BrowserData
+{
+    internal class ChromeDashboardVersionResult
+    {
+        public Dictionary<string, ChromeDashboardDownloadEntry[]> Downloads { get; set; }
+
+        internal class ChromeDashboardDownloadEntry
+        {
+            public string Platform { get; set; }
+
+            public string Url { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- When the primary Chrome download URL fails, the `BrowserFetcher` now falls back to querying the [Chrome for Testing dashboard](https://googlechromelabs.github.io/chrome-for-testing/) to resolve an alternative download URL
- The fallback applies to `Chrome` and `ChromeHeadlessShell` browsers only (not Firefox or Chromium)
- The fallback is skipped when a custom `BaseUrl` is configured, to respect user-defined download sources

## Changes
- **`BrowserFetcher.cs`**: Added `TryResolveFallbackDownloadUrlAsync` method that queries `https://googlechromelabs.github.io/chrome-for-testing/{buildId}.json` and finds the matching platform URL. Wrapped the download call in a try-catch that attempts the fallback on failure.
- **`BrowserData/Chrome.cs`**: Made `GetFolder` method `internal` so it can be reused by `BrowserFetcher` for platform-to-dashboard-key mapping.
- **`BrowserData/ChromeDashboardVersionResult.cs`**: New model class for deserializing the Chrome for Testing dashboard JSON response.

## Upstream Reference
Ported from [puppeteer/puppeteer#11951](https://github.com/puppeteer/puppeteer/pull/11951).

## Test plan
- [x] All existing `ChromeDataTests` pass
- [x] Build succeeds with zero warnings/errors
- [ ] Manual verification: temporarily corrupt a Chrome download URL to confirm fallback kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)