### PR TITLE
Fix: Apply timeout to waiting for navigation response (#2564)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -152,7 +152,16 @@ public class CdpFrame : Frame
 
         await raceTask.ConfigureAwait(false);
 
-        return await watcher.NavigationResponseAsync().ConfigureAwait(false);
+        var navigationResponseTask = watcher.NavigationResponseAsync();
+        var completedTask = await Task.WhenAny(
+            watcher.TerminationTask,
+            navigationResponseTask).ConfigureAwait(false);
+
+        await completedTask.ConfigureAwait(false);
+
+        return completedTask == navigationResponseTask
+            ? navigationResponseTask.Result
+            : null;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- Race `NavigationResponseAsync()` against `TerminationTask` in `CdpFrame.WaitForNavigationAsync` so timeouts apply to the entire operation, not just the initial lifecycle event wait
- Fixes potential hang when the navigation response never arrives
- Port of upstream puppeteer/puppeteer#12142

## Test plan
- [x] `dotnet build` passes with 0 errors
- [x] 54/57 navigation tests pass (3 pre-existing SSL failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)