### PR TITLE
Trim CLAUDE.md: remove API catalog, add actionable conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,23 @@
 # PuppeteerSharp Codebase Overview
 
-PuppeteerSharp is a C# library for automating Chromium-based browsers and Firefox. It provides a high-level API to control browsers via the DevTools Protocol (CDP) and WebDriver BiDi protocol. This document provides a comprehensive guide to understanding the codebase.
+PuppeteerSharp is a C# library for automating Chromium-based browsers and Firefox. It provides a high-level API to control browsers via the DevTools Protocol (CDP) and WebDriver BiDi protocol.
 
 ## Goal
 
 The goal of this project is to be a port of the popular Node.js Puppeteer library to .NET.
 Everything in PuppeteerSharp is inspired by the original Puppeteer library, but adapted to C# idioms and .NET practices.
+
+## C# Code Style
+
+When editing C# files, always place static members before non-static members (SA1204/SA1202 style rules). Never place a static method after instance methods.
+
+## Git Workflow
+
+Always verify which git branch you are on before making commits or creating PRs. Never commit to main/master. If the task requires a new branch, create it immediately and confirm with `git branch --show-current` before proceeding.
+
+## Upstream Porting Conventions
+
+When porting upstream TypeScript/Puppeteer changes to PuppeteerSharp (.NET), translate API naming conventions: camelCase → PascalCase, Promise<T> → Task<T>, interfaces prefixed with I, events use C# event patterns. Use `ReloadOptions`-style single parameter objects rather than creating redundant overloads.
 
 ## External Sources:
 These external sources are referenced or used as inspiration in the codebase. Feel free to explore them for deeper understanding.
@@ -25,8 +37,8 @@ You are allowed to run git commands to update these repositories locally.
 ```
 lib/
 ├── PuppeteerSharp/                 # Main library
-│   ├── Bidi/                       # WebDriver BiDi protocol implementation (45 files)
-│   ├── Cdp/                        # Chrome DevTools Protocol implementation (204 files)
+│   ├── Bidi/                       # WebDriver BiDi protocol implementation
+│   ├── Cdp/                        # Chrome DevTools Protocol implementation
 │   ├── Transport/                  # Communication layer (WebSocket, etc.)
 │   ├── Helpers/                    # Utility functions and extensions
 │   ├── Input/                      # Keyboard, Mouse, Touchscreen input handling
@@ -39,32 +51,13 @@ lib/
 │   ├── States/                     # Process state machine
 │   ├── Injected/                   # JavaScript to be injected into pages
 │   └── *.cs                        # Core classes (Browser, Page, Frame, etc.)
-├── PuppeteerSharp.Tests/           # 58+ test categories (~45k+ test files)
+├── PuppeteerSharp.Tests/           # Test categories
 ├── PuppeteerSharp.Nunit/           # NUnit test framework integration
 ├── PuppeteerSharp.TestServer/      # Local HTTP server for testing
 ├── PuppeteerSharp.TestServer/wwwroot/ # Test fixtures and assets
 ├── demo/                           # Demo application
 └── PuppeteerSharp.sln              # Solution file
 ```
-
-## Key Architecture Patterns
-
-### Dual Protocol Support: CDP vs BiDi
-
-PuppeteerSharp supports two browser automation protocols:
-
-1. **Chrome DevTools Protocol (CDP)**: 204 files in `Cdp/`
-   - Implemented in: `CdpBrowser`, `CdpPage`, `CdpFrame`, `CdpTarget`, etc.
-   - CDP-specific implementation classes
-   - Used for Chromium-based browsers and Firefox
-   - Classes: `CdpJSHandle`, `CdpElementHandle`, `CdpKeyboard`, `CdpMouse`, etc.
-
-2. **WebDriver BiDi Protocol**: 45 files in `Bidi/`
-   - Implemented in: `BidiBrowser`, `BidiPage`, `BidiFrame`, `BidiTarget`, etc.
-   - Newer, more standardized protocol
-   - Lower-level core implementations in `Bidi/Core/` directory
-   - Classes: `BidiJSHandle`, `BidiElementHandle`, `BidiMouse`, etc.
-   - Events: `BidiBrowsingContextEventArgs`, `UserPromptEventArgs`, `ResponseEventArgs`, etc.
 
 ### Protocol Abstraction Pattern
 
@@ -74,306 +67,7 @@ The library uses a base class pattern with protocol-specific implementations:
 - **Abstract Base Classes**: `Browser`, `Page`, `Frame`, `Request<TResponse>`, `Response<TRequest>`
 - **Protocol Implementations**: `CdpBrowser`/`BidiBrowser`, `CdpPage`/`BidiPage`, etc.
 
-This design allows code to work with either protocol transparently through interfaces.
-
-## Core Components
-
-### 1. Entry Point: Puppeteer Static Class
-- **File**: `/PuppeteerSharp/Puppeteer.cs`
-- **Key Methods**:
-  - `LaunchAsync(LaunchOptions)`: Launch a browser instance
-  - `ConnectAsync(ConnectOptions)`: Connect to existing browser
-  - `GetDefaultArgs()`: Get default browser launch arguments
-  - Static properties: `Devices`, `NetworkConditions`, `ExtraJsonSerializerContext`
-
-### 2. Browser Management
-
-#### `Launcher` Class
-- Determines which browser to launch (Chrome, Chromium, Firefox)
-- Resolves executable path
-- Creates appropriate launcher (`ChromeLauncher` or `FirefoxLauncher`)
-- Handles process lifecycle
-
-#### `IBrowser` Interface & `Browser` Abstract Class
-- **Key Properties**:
-  - `WebSocketEndpoint`: Connection URL
-  - `BrowserType`: Chrome, Chromium, or Firefox
-  - `DefaultContext`: Default browser context
-  - `DefaultWaitForTimeout`: Global timeout setting
-- **Key Methods**:
-  - `NewPageAsync()`: Create new page
-  - `CreateBrowserContextAsync()`: Create isolated context
-  - `Targets()`: Get all targets (pages, workers, etc.)
-  - `PagesAsync()`: Get all pages across contexts
-  - `GetVersionAsync()`: Browser version
-  - `Disconnect()`: Disconnect from browser
-
-### 3. Page Model
-
-#### `IPage` Interface & `Page` Abstract Class
-- **Key Properties**:
-  - `MainFrame`: Primary frame
-  - `Frames`: All frames in page
-  - `Url`: Current URL
-  - `Workers`: Web workers
-  - `Keyboard`, `Mouse`, `Touchscreen`: Input devices
-- **Key Events**: (40+ events)
-  - `Close`, `Load`, `DOMContentLoaded`
-  - `Console`, `Dialog`, `Error`, `PageError`
-  - `Request`, `Response`, `RequestFailed`, `RequestFinished`
-  - `FrameAttached`, `FrameDetached`, `FrameNavigated`
-- **Key Methods**:
-  - `GoToAsync()`: Navigate to URL
-  - `ScreenshotAsync()`: Capture page screenshot
-  - `PdfAsync()`: Generate PDF
-  - `EvaluateAsync()`: Execute JavaScript
-  - `WaitForNavigationAsync()`: Wait for navigation
-  - `WaitForSelectorAsync()`: Wait for element
-  - `InterceptRequestAsync()`: Intercept network requests
-
-### 4. Frame Model
-
-#### `IFrame` Interface & `Frame` Abstract Class
-- Represents an `<iframe>` or main document
-- Lifecycle events: attached → navigated → detached
-- Similar evaluation and waiting methods as Page
-- **Key Methods**:
-  - `ChildFrames`: Get nested frames
-  - `ParentFrame`: Get parent frame
-  - `EvaluateAsync()`, `EvaluateFunctionAsync()`: Execute code
-  - `WaitForSelectorAsync()`: Wait for elements
-  - `QuerySelectorAsync()`, `QuerySelectorAllAsync()`: Find elements
-
-### 5. Element Handling
-
-#### Handle Hierarchy
-- `IJSHandle` (Interface): Represents object in browser
-- `JSHandle` (Abstract): Base implementation
-- `CdpJSHandle` / `BidiJSHandle`: Protocol-specific implementations
-- `IElementHandle` (Interface): Represents DOM element
-- `ElementHandle` (Abstract): Element-specific operations
-- `CdpElementHandle` / `BidiElementHandle`: Protocol-specific implementations
-
-#### `ElementHandle` Capabilities
-- **Selection**: `QuerySelectorAsync()`, `QuerySelectorAllAsync()`, `EvaluateAsync()`
-- **Interaction**: `ClickAsync()`, `TypeAsync()`, `PressAsync()`
-- **Properties**: `BoundingBoxAsync()`, `BoxModelAsync()`, `ScreenshotAsync()`
-- **Forms**: `UploadFileAsync()`, `SelectAsync()`
-- **Drag & Drop**: `DragAsync()`, `DragAndDropAsync()`
-
-### 6. Network Management
-
-#### Request/Response Model
-- **Request**:
-  - Abstract base: `Request<TResponse>`
-  - Implementations: `CdpHttpRequest`, `BidiHttpRequest`
-  - Properties: URL, headers, method, post data, resource type
-  - Methods: `ContinueAsync()`, `AbortAsync()`, `RespondAsync()`
-
-- **Response**:
-  - Abstract base: `Response<TRequest>`
-  - Implementations: `CdpHttpResponse`, `BidiHttpResponse`
-  - Methods: `TextAsync()`, `JsonAsync()`, `BufferAsync()`
-  - Properties: Status code, headers, URL
-
-#### Interception
-- `InterceptRequestAsync()`: Register request handler
-- Request properties and methods for control
-- Redirect chain tracking
-- Initiator information
-
-### 7. Communication Layer
-
-#### Transport (`Transport/` directory)
-- `IConnectionTransport`: Abstract transport interface
-- `WebSocketTransport`: WebSocket implementation
-- `MessageReceivedEventArgs`: Message event data
-- Handles binary message sending/receiving
-
-#### Connection (`Cdp/Connection.cs`)
-- `Connection` class: Manages CDP communication
-- Session management via `CdpCDPSession`
-- Message routing and callback handling
-- Error handling and protocol timeout
-
-#### CDPSession (`ICDPSession` interface)
-- Low-level protocol session
-- `SendAsync()`: Send CDP commands
-- Event subscriptions for CDP events
-- Methods for direct protocol access
-
-### 8. Execution Context & Script Evaluation
-
-#### Realm (Base Class)
-- Abstract: `Realm` (core evaluation base)
-- Manages execution contexts and script evaluation
-- Task manager for tracking ongoing operations
-
-#### IsolatedWorld
-- CDP-specific execution context implementation
-- Binding management for JavaScript callbacks
-- Context lifecycle handling
-- Frame and Worker association
-
-#### ExecutionContext
-- Represents a JavaScript execution environment
-- Methods for evaluation and handle adoption
-- Binding utilities for calling .NET from JS
-
-### 9. Input Handling
-
-#### Keyboard (`Input/`)
-- `IKeyboard` interface
-- `Keyboard` base class
-- `CdpKeyboard`, `BidiKeyboard` implementations
-- **Methods**: `PressAsync()`, `TypeAsync()`, `DownAsync()`, `UpAsync()`
-- Key definitions and special key handling
-
-#### Mouse (`Input/`)
-- `IMouse` interface
-- `Mouse` base class
-- `CdpMouse`, `BidiMouse` implementations
-- **Methods**: `MoveAsync()`, `ClickAsync()`, `DragAsync()`, `WheelAsync()`
-- Button types: Left, Right, Middle
-- Mouse state tracking
-
-#### Touchscreen (`Input/`)
-- `ITouchscreen` interface
-- `Touchscreen` base class
-- `CdpTouchscreen` implementation
-- **Methods**: `TapAsync()`, `TouchAsync()`
-
-### 10. Dialog Handling
-
-#### Dialog Classes
-- Abstract `Dialog` base class
-- `CdpDialog` (CDP implementation)
-- `BidiDialog` (BiDi implementation)
-- **Types**: alert, confirm, prompt, beforeunload
-- **Methods**: `Accept(string text)`, `Dismiss()`
-- Properties: `DialogType`, `Message`, `DefaultValue`
-
-### 11. File Handling
-
-#### FileChooser
-- Handles file input selection
-- `AcceptAsync()`: Select files for upload
-- `CancelAsync()`: Cancel file selection
-- Triggers on file input element interaction
-
-#### DeviceRequestPrompt
-- Handles device permission requests
-- Device info: name, model, type
-- Accept/reject operations
-
-### 12. Target Management
-
-#### ITarget Interface
-- Represents browser entity (page, iframe, worker, etc.)
-- Types: Page, WebWorker, Other
-- **Methods**: `PageAsync()`, `WorkerAsync()`, `AsPageAsync()`, `CreateCDPSessionAsync()`
-- URL, type, parent/child relationships
-
-#### Target Manager
-- `ITargetManager` interface
-- `ChromeTargetManager`: Chrome-specific target tracking
-- `FirefoxTargetManager`: Firefox-specific target tracking
-- Target lifecycle: discovered → created → destroyed
-
-### 13. Error Handling
-
-#### Exception Hierarchy
-- `PuppeteerException`: Base exception for all Puppeteer errors
-- `ProcessException`: Browser process issues
-- `TargetClosedException`: Target closed during operation
-- `TargetCrashedException`: Target crashed
-- `MessageException`: Protocol message errors
-- `SelectorException`: Selector parsing errors
-- `BufferException`: Buffer operation errors
-- `EvaluationFailedException`: Script evaluation errors
-- `WaitTaskTimeoutException`: Wait operation timeout
-
-### 14. Feature-Specific Modules
-
-#### PageAccessibility (`PageAccessibility/`)
-- `IAccessibility` interface
-- Accessibility tree snapshot
-- AXNode serialization
-- `SerializedAXNode`: Serialized accessibility data
-- Supports ARIA attributes
-
-#### PageCoverage (`PageCoverage/`)
-- `ICoverage` interface
-- JavaScript coverage tracking
-- CSS coverage tracking
-- Coverage entry with ranges
-- Function-level coverage support
-
-#### Media (`Media/`)
-- Viewport options, margins, clips
-- Screen orientation
-- Print media emulation
-- Screenshot options (type, quality, clip)
-- Print-to-PDF options
-
-#### Mobile (`Mobile/`)
-- Device descriptors (iPhone, iPad, etc.)
-- Pre-configured device profiles
-- Emulation settings: viewport, user agent, device scale factor
-- Touch support configuration
-
-### 15. Query Handlers (`QueryHandlers/`)
-- `CssQueryHandler`: CSS selector support
-- `XPathQueryHandler`: XPath expression support
-- `TextQueryHandler`: Text content matching
-- `PierceQueryHandler`: Shadow DOM piercing
-- `CustomQueryHandler`: User-defined handlers
-- Support for combined/nested selectors
-
-### 16. Browser Data Management
-
-#### BrowserData (`BrowserData/`)
-- Browser version tracking
-- Release channel information
-- Build ID management
-- Installed browser cache
-- Chrome and Firefox specifics
-- Version resolution and downloading
-
-### 17. Process State Management (`States/`)
-- State machine for browser process lifecycle
-- States: Initial → ProcessStarting → Started → Exiting → Exited → Disposed → Killing
-- `State` base class
-- `StateManager`: State transition handling
-- Proper cleanup and resource management
-
 ## Testing Infrastructure
-
-### Test Organization (58+ categories)
-
-Test directory structure demonstrates comprehensive coverage:
-
-- **AccessibilityTests/**: Accessibility tree and AXNode testing
-- **BrowserContextTests/**: Context isolation and management
-- **BrowserTests/**: Browser lifecycle, context creation
-- **ClickTests/**: Element click operations
-- **CookiesTests/**: Cookie management
-- **CoverageTests/**: Code coverage tracking
-- **DeviceRequestPromptTests/**: Device permissions
-- **DialogTests/**: Alert, confirm, prompt dialogs
-- **DragAndDropTests/**: Drag and drop operations
-- **ElementHandleTests/**: Element interaction
-- **EmulationTests/**: Device and network emulation
-- **EvaluationTests/**: JavaScript evaluation
-- **FrameTests/**: Frame lifecycle and operations
-- **InputTests/**: Keyboard, mouse, touchscreen
-- **NetworkTests/**: Request/response interception
-- **PageTests/**: Page lifecycle, navigation, properties
-- **PrerenderTests/**: Prerendering capabilities
-- **RequestInterceptionTests/**: Request modification
-- **ScreenshotTests/**: Screenshot and PDF generation
-- **TracingTests/**: Performance tracing
-- Plus many more...
 
 ### Test Infrastructure
 
@@ -390,13 +84,6 @@ Test directory structure demonstrates comprehensive coverage:
 **IMPORTANT: Test Expectations Files Rules:**
 - `TestExpectations.upstream.json`: This file should NEVER be edited unless syncing with the upstream Puppeteer project. It contains expectations that match the upstream Puppeteer test expectations.
 - `TestExpectations.local.json`: Use this file for local overrides and PuppeteerSharp-specific test expectations. Add entries here to skip or mark tests that fail due to .NET-specific issues or features not yet implemented. Never add entries to this file that are meant to match upstream expectations and never add entries without explicit confirmation.
-
-#### Test Server (`PuppeteerSharp.TestServer/`)
-- ASP.NET Core server for hosting test pages
-- wwwroot directory with test fixtures
-- Asset serving for test scenarios
-
-## Development Best Practices
 
 ### Building and Running Tests
 
@@ -423,44 +110,9 @@ You can switch between CDP and Bidi by changing the PuppeteerTestAttribute.IsCdp
 You can switch between Chrome and Firefox by changing the PuppeteerTestAttribute.IsChrome property.
 If you are fixing one single test, then you must run the entire test suite to confirm that you didn't break other tests.
 
-## Utilities and Helpers
+## Testing & Debugging
 
-### Helper Classes (`Helpers/`)
-- `AsyncFileHelper`: File I/O operations
-- `AsyncMessageQueue`: Message queue for async processing
-- `ConcurrentSet<T>`: Thread-safe set
-- `DeferredTaskQueue`: Deferred task execution
-- `EnumHelper`: Enum utilities
-- `MultiMap<K, V>`: Multi-value dictionary
-- `RemoteObjectHelper`: Remote object handling
-- `TaskHelper`: Task utility functions
-- `TaskQueue`: Sequential task execution
-- `StringExtensions`: String utilities
-- `TempDirectory`: Temporary file management
-- `ProtocolStreamReader`: Binary stream reading
-
-### JSON Helpers (`Helpers/Json/`)
-- Custom JSON converters
-- JSHandle serialization/deserialization
-- Protocol message serialization
-- Supports System.Text.Json
-
-## Key Design Patterns
-
-### 1. Abstract Factory Pattern
-- Protocol-specific implementations behind abstract base classes
-- Browser, Page, Frame, etc. have Cdp and Bidi variants
-- Factories create appropriate implementation based on protocol
-
-### 2. Template Method Pattern
-- Base Page/Frame classes define algorithm structure
-- Abstract methods for protocol-specific steps
-- Subclasses implement protocol details
-
-### 3. Task-Based Concurrency
-- Async/await throughout
-- TaskQueue for sequential operation ordering
-- TaskManager for tracking concurrent operations
+When investigating flaky tests, always look for root causes (race conditions, non-deterministic ordering like ConcurrentDictionary enumeration, frame ordering assumptions) rather than skipping the test or adding it to expected failures.
 
 ## Continuous improvement
 


### PR DESCRIPTION
## Summary
- Removed ~370 lines of detailed API documentation (class listings, method signatures, event catalogs, helper enumerations, design pattern descriptions) that Claude can read directly from source files
- Added four new sections with rules that actually change Claude's behavior:
  - **C# Code Style**: SA1202/SA1204 static member ordering rules
  - **Git Workflow**: Always verify branch before committing
  - **Upstream Porting Conventions**: Naming translation rules (camelCase→PascalCase, Promise→Task, etc.) and preference for single parameter objects over overloads
  - **Testing & Debugging**: Always fix root causes of flaky tests, never skip them

## Motivation
The API catalog consumed significant context window tokens without influencing behavior — Claude reads source files directly when it needs class/method details. The new sections encode lessons learned from recurring friction points across many sessions.

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm no essential instructions were lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)