### PR TITLE
Fix: Disable IsolateSandboxedIframes trial to prevent flakiness (#12381)

### DIFF
--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -48,6 +48,7 @@ namespace PuppeteerSharp
                 "IPH_ReadingModePageActionLabel",
                 "ReadAnythingOmniboxChip",
                 "ProcessPerSiteUpToMainFrameThreshold",
+                "IsolateSandboxedIframes",
             };
 
             disabledFeatures.AddRange(userDisabledFeatures);


### PR DESCRIPTION
## Summary
- Adds `IsolateSandboxedIframes` to the list of disabled Chrome features in `ChromeLauncher.cs`
- This prevents flaky test behavior caused by the Chrome field trial for sandboxed iframe isolation
- Upstream PR: https://github.com/puppeteer/puppeteer/pull/12381

## Changes
The upstream PR disables the `IsolateSandboxedIframes` Chrome feature flag to prevent flakiness in tests related to iframes (specifically `ElementHandle.clickablePoint` for iframes). This was caused by Chrome's field trial config for isolating sandboxed iframes affecting element positioning calculations.

In PuppeteerSharp, since we don't have the `turnOnExperimentalFeaturesForTesting` concept (both `ProcessPerSiteUpToMainFrameThreshold` and `IsolateSandboxedIframes` are always disabled), the change simply adds the feature to the existing disabled features list.

## Test plan
- [x] Main library builds successfully
- [ ] Verify `ElementHandle.clickablePoint should work for iframes` test is no longer flaky

Closes #2626

🤖 Generated with [Claude Code](https://claude.com/claude-code)