### PR TITLE
Fix: Turn on PdfOopif for PDF viewer (#2629)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/pdf-viewer.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/pdf-viewer.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+
+<iframe src="sample.pdf"></iframe>

--- a/lib/PuppeteerSharp.TestServer/wwwroot/sample.pdf
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/sample.pdf
@@ -1,0 +1,12 @@
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer<</Size 4/Root 1 0 R>>
+startxref
+206
+%%EOF

--- a/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
+++ b/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
@@ -470,6 +470,39 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             }
         }
 
+        [Test, PuppeteerTest("oopif.spec", "OOPIF", "should exposeFunction on a page with a PDF viewer")]
+        public async Task ShouldExposeFunctionOnAPageWithAPdfViewer()
+        {
+            await Page.GoToAsync(
+                TestConstants.ServerUrl + "/pdf-viewer.html",
+                new NavigationOptions { WaitUntil = new[] { WaitUntilNavigation.Networkidle2 } });
+
+            await Page.ExposeFunctionAsync("test", () =>
+            {
+                System.Diagnostics.Debug.WriteLine("test");
+            });
+        }
+
+        [Test, PuppeteerTest("oopif.spec", "OOPIF", "should evaluate on a page with a PDF viewer")]
+        public async Task ShouldEvaluateOnAPageWithAPdfViewer()
+        {
+            await Page.GoToAsync(
+                TestConstants.ServerUrl + "/pdf-viewer.html",
+                new NavigationOptions { WaitUntil = new[] { WaitUntilNavigation.Networkidle2 } });
+
+            var results = await Task.WhenAll(
+                Page.Frames.Select(async frame =>
+                    await frame.EvaluateFunctionAsync<string>("() => window.location.pathname")));
+
+            Assert.That(results, Is.EqualTo(new[]
+            {
+                "/pdf-viewer.html",
+                "/sample.pdf",
+                "/index.html",
+                "/sample.pdf",
+            }));
+        }
+
         [Test, PuppeteerTest("oopif.spec", "waitForFrame", "should resolve immediately if the frame already exists")]
         public async Task ShouldResolveImmediatelyIfTheFrameAlreadyExists()
         {

--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -58,6 +58,14 @@ namespace PuppeteerSharp
                 args = RemoveMatchingFlags(options.Args, "--enable-features");
             }
 
+            // Merge default enabled features with user-provided ones, if any.
+            var enabledFeatures = new List<string>
+            {
+                "PdfOopif",
+            };
+
+            enabledFeatures.AddRange(userEnabledFeatures);
+
             var chromiumArguments = new List<string>(
             [
                 "--allow-pre-commit-input",
@@ -90,7 +98,7 @@ namespace PuppeteerSharp
             ])
             {
                 $"--disable-features={string.Join(",", disabledFeatures)}",
-                $"--enable-features={string.Join(",", userEnabledFeatures)}",
+                $"--enable-features={string.Join(",", enabledFeatures)}",
             };
 
             if (!string.IsNullOrEmpty(options.UserDataDir))


### PR DESCRIPTION
## Summary
- Enable `PdfOopif` Chrome feature flag in the launcher to support PDF viewer in out-of-process iframes
- Add `pdf-viewer.html` and `sample.pdf` test assets
- Add two new OOPIF tests: `ShouldExposeFunctionOnAPageWithAPdfViewer` and `ShouldEvaluateOnAPageWithAPdfViewer`

## Upstream Reference
Port of [puppeteer/puppeteer#12370](https://github.com/puppeteer/puppeteer/pull/12370).

Chrome's PDF viewer replaces inner iframes with extension web views, which are not supported by Puppeteer. Enabling `PdfOopif` makes Chrome use out-of-process iframes for PDF viewing instead, which Puppeteer already supports.

## Changes
| File | Change |
|------|--------|
| `ChromeLauncher.cs` | Added `PdfOopif` to default enabled Chrome features |
| `OOPIFTests.cs` | Added two new PDF viewer tests |
| `wwwroot/pdf-viewer.html` | New test asset - HTML page embedding a PDF iframe |
| `wwwroot/sample.pdf` | New test asset - minimal PDF file |

## Test plan
- [x] Both new tests pass with Chrome/CDP
- [x] All 27 OOPIF tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)