### PR TITLE
Fix: SlowMo causing timeouts on busy pages (#2659)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/Connection.cs
+++ b/lib/PuppeteerSharp/Cdp/Connection.cs
@@ -248,6 +248,15 @@ namespace PuppeteerSharp.Cdp
         {
             try
             {
+                // Apply SlowMo delay before entering the serialized queue.
+                // In upstream Puppeteer (JS), the delay runs independently per message.
+                // If we delay inside the serialized queue, delays accumulate and cause
+                // timeouts on busy pages (see #2659).
+                if (e.Message.Length > 0 && Delay > 0)
+                {
+                    await Task.Delay(Delay).ConfigureAwait(false);
+                }
+
                 await _callbackQueue.Enqueue(() => ProcessMessage(e)).ConfigureAwait(false);
             }
             catch (Exception exception)
@@ -264,11 +273,6 @@ namespace PuppeteerSharp.Cdp
             {
                 var response = e.Message;
                 ConnectionResponse obj;
-
-                if (response.Length > 0 && Delay > 0)
-                {
-                    await Task.Delay(Delay).ConfigureAwait(false);
-                }
 
                 try
                 {


### PR DESCRIPTION
## Summary
- Moved the SlowMo (`Task.Delay`) from inside the serialized `_callbackQueue` (TaskQueue with SemaphoreSlim=1) to before it in `Transport_MessageReceived`
- When delays were inside the serialized queue, they accumulated: N messages × delay ms, easily exceeding the 1000ms default timeout for `_frameTreeHandled` and other internal awaits
- This matches upstream Puppeteer (JS) behavior where each message's delay runs independently since JS doesn't serialize message processing through a semaphore

Closes #2659

## Test plan
- [x] Verified fix compiles cleanly
- [x] Ran demo with SlowMo=20 navigating multiple pages — no timeouts
- [x] All 50 LauncherTests pass (0 failures)
- [x] All 57 NavigationTests pass (0 failures)
- [x] All 170 EvalTests/NetworkTests/FrameTests/RequestInterceptionTests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)