### PR TITLE
Fix: Increase frame tree sync timeout to prevent premature connection close (#2965)

### DIFF
--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -284,7 +284,7 @@ namespace PuppeteerSharp.Cdp
             {
                 try
                 {
-                    await _frameTreeHandled.Task.WithTimeout().ConfigureAwait(false);
+                    await _frameTreeHandled.Task.WithTimeout(Puppeteer.DefaultTimeout).ConfigureAwait(false);
                     switch (e.MessageID)
                     {
                         case "Page.frameAttached":


### PR DESCRIPTION
## Summary
- Fixed "Navigating frame was detached: Timeout of 1000 ms exceeded" error that occurs on slow/busy machines during frame tree initialization
- The `_frameTreeHandled` synchronization barrier in `FrameManager` was using `TaskHelper.DefaultTimeout` (1000ms), which is too short for slow environments and unrelated to the user-configurable `Page.DefaultTimeout`
- Changed to use `Puppeteer.DefaultTimeout` (30s), matching upstream Puppeteer's behavior more closely (upstream uses no timeout at all)

Closes #2965

## Test plan
- [x] Library builds successfully
- [x] All 28 frame tests pass (`FrameTests`)
- [x] All 54 navigation tests pass (`NavigationTests`, 3 pre-existing SSL failures unrelated to change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)