### PR TITLE
Migrate to WebDriverBiDi RemoteValue type-safe subclass API

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiDeserializer.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiDeserializer.cs
@@ -43,8 +43,7 @@ internal static class BidiDeserializer
             UndefinedRemoteValue or NullRemoteValue => null,
             StringRemoteValue s => s.Value,
             BooleanRemoteValue b => (object)b.Value,
-            LongRemoteValue l => (object)l.Value,
-            DoubleRemoteValue d => (object)d.Value,
+            NumberRemoteValue n => (object)n.Value,
             ValueHoldingRemoteValue v when value.Type == RemoteValueType.BigInt =>
                 v.ValueObject != null ? Convert.ToInt64(v.ValueObject, CultureInfo.InvariantCulture) : null,
             _ => null,

--- a/lib/PuppeteerSharp/Bidi/BidiDeserializer.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiDeserializer.cs
@@ -38,14 +38,15 @@ internal static class BidiDeserializer
             return null;
         }
 
-        return value.Type switch
+        return value switch
         {
-            "undefined" => null,
-            "null" => null,
-            "string" => value.Value,
-            "number" => DeserializeNumber(value.Value),
-            "boolean" => value.Value,
-            "bigint" => value.Value != null ? Convert.ToInt64(value.Value, CultureInfo.InvariantCulture) : null,
+            UndefinedRemoteValue or NullRemoteValue => null,
+            StringRemoteValue s => s.Value,
+            BooleanRemoteValue b => (object)b.Value,
+            LongRemoteValue l => (object)l.Value,
+            DoubleRemoteValue d => (object)d.Value,
+            ValueHoldingRemoteValue v when value.Type == RemoteValueType.BigInt =>
+                v.ValueObject != null ? Convert.ToInt64(v.ValueObject, CultureInfo.InvariantCulture) : null,
             _ => null,
         };
     }
@@ -59,13 +60,13 @@ internal static class BidiDeserializer
 
         switch (value.Type)
         {
-            case "array":
-            case "set":
-                if (value.Value is IEnumerable<RemoteValue> enumerable)
+            case RemoteValueType.Array:
+            case RemoteValueType.Set:
+                if (value is CollectionRemoteValue collection)
                 {
                     var list = new List<object>();
 
-                    foreach (var item in enumerable)
+                    foreach (var item in collection.Value)
                     {
                         list.Add(item.ToPrettyPrint());
                     }
@@ -74,45 +75,32 @@ internal static class BidiDeserializer
                 }
 
                 return Array.Empty<object>();
-            case "object":
-            case "map":
+            case RemoteValueType.Object:
+            case RemoteValueType.Map:
                 // TODO
-                return value.Value;
-            case "regexp":
-            case "date":
+                return value is ValueHoldingRemoteValue vhMap ? vhMap.ValueObject : null;
+            case RemoteValueType.RegExp:
+            case RemoteValueType.Date:
                 // TODO
-                return value.Value;
-            case "promise":
+                return value is ValueHoldingRemoteValue vhDate ? vhDate.ValueObject : null;
+            case RemoteValueType.Promise:
                 return "{}";
-            case "undefined":
+            case RemoteValueType.Undefined:
                 return "undefined";
-            case "null":
+            case RemoteValueType.Null:
                 return "null";
-            case "number":
-                return DeserializeNumber(value.Value);
-            case "bigint":
-                return Convert.ToInt64(value.Value, CultureInfo.InvariantCulture);
-            case "boolean":
-                return Convert.ToBoolean(value.Value, CultureInfo.InvariantCulture);
+            case RemoteValueType.Number:
+                return value is ValueHoldingRemoteValue vhNum ? vhNum.ValueObject : null;
+            case RemoteValueType.BigInt:
+                return value is ValueHoldingRemoteValue vhBigInt
+                    ? Convert.ToInt64(vhBigInt.ValueObject, CultureInfo.InvariantCulture)
+                    : null;
+            case RemoteValueType.Boolean:
+                return value is BooleanRemoteValue b
+                    ? (object)b.Value
+                    : null;
             default:
-                return value.Value;
-        }
-    }
-
-    private static object DeserializeNumber(object value)
-    {
-        switch (value)
-        {
-            case "-0":
-                return -0;
-            case "NaN":
-                return double.NaN;
-            case "Infinity":
-                return double.PositiveInfinity;
-            case "-Infinity":
-                return double.NegativeInfinity;
-            default:
-                return value;
+                return value is ValueHoldingRemoteValue vh ? vh.ValueObject : null;
         }
     }
 }

--- a/lib/PuppeteerSharp/Bidi/BidiElementHandle.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiElementHandle.cs
@@ -94,9 +94,9 @@ internal class BidiElementHandle(RemoteValue value, BidiRealm realm) : ElementHa
 
         await handle.DisposeAsync().ConfigureAwait(false);
 
-        if (value?.Type == "window" && value.Value is WindowProxyProperties windowProxy)
+        if (value?.Type == RemoteValueType.Window && value is WindowProxyRemoteValue windowProxyValue)
         {
-            var contextId = windowProxy.Context;
+            var contextId = windowProxyValue.Value.Context;
             return BidiFrame.BidiPage.Frames.FirstOrDefault(frame => frame.Id == contextId);
         }
 

--- a/lib/PuppeteerSharp/Bidi/BidiFrame.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiFrame.cs
@@ -599,15 +599,15 @@ public class BidiFrame : Frame
     internal async Task SetFilesAsync(BidiElementHandle element, string[] files)
     {
         await BrowsingContext.SetFilesAsync(
-            element.Value.ToSharedReference(),
+            element.Value.ConvertTo<NodeRemoteValue>().ToSharedReference(),
             files).ConfigureAwait(false);
     }
 
-    internal async Task<IList<RemoteValue>> LocateNodesAsync(BidiElementHandle element, BidiLocator locator)
+    internal async Task<IList<NodeRemoteValue>> LocateNodesAsync(BidiElementHandle element, BidiLocator locator)
     {
         return await BrowsingContext.LocateNodesAsync(
             locator,
-            [element.Value.ToSharedReference()]).ConfigureAwait(false);
+            [element.Value.ConvertTo<NodeRemoteValue>().ToSharedReference()]).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -995,7 +995,7 @@ public class BidiFrame : Frame
                             return BidiDeserializer.Deserialize(jsHandle.RemoteValue);
                         }
 
-                        if (arg is BidiJSHandle { RemoteValue.Type: "error" } && !string.IsNullOrEmpty(logEntryText))
+                        if (arg is BidiJSHandle { RemoteValue.Type: RemoteValueType.Error } && !string.IsNullOrEmpty(logEntryText))
                         {
                             return (object)logEntryText.Split('\n')[0];
                         }

--- a/lib/PuppeteerSharp/Bidi/BidiJSHandle.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiJSHandle.cs
@@ -75,7 +75,7 @@ internal class BidiJSHandle(RemoteValue value, BidiRealm realm) : JSHandle
             return "JSHandle:" + RemoteValue.ToPrettyPrint();
         }
 
-        return "JSHandle@" + RemoteValue.Type;
+        return "JSHandle@" + RemoteValue.Type.ToString().ToLowerInvariant();
     }
 
     /// <inheritdoc/>

--- a/lib/PuppeteerSharp/Bidi/BidiJSHandle.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiJSHandle.cs
@@ -40,13 +40,13 @@ internal class BidiJSHandle(RemoteValue value, BidiRealm realm) : JSHandle
         {
             return RemoteValue.Type switch
             {
-                "string" or "number" or "bigint" or "boolean" or "undefined" or "null" => true,
+                RemoteValueType.String or RemoteValueType.Number or RemoteValueType.BigInt or RemoteValueType.Boolean or RemoteValueType.Undefined or RemoteValueType.Null => true,
                 _ => false,
             };
         }
     }
 
-    internal string Id => RemoteValue.Handle;
+    internal string Id => (RemoteValue as IObjectReferenceRemoteValue)?.Handle;
 
     internal override Realm Realm { get; } = realm;
 
@@ -60,7 +60,7 @@ internal class BidiJSHandle(RemoteValue value, BidiRealm realm) : JSHandle
         // If it's a primitive value or doesn't have a handle, deserialize directly
         if (IsPrimitiveValue || string.IsNullOrEmpty(Id))
         {
-            return DeserializeValue<T>(RemoteValue.Value);
+            return DeserializeValue<T>(RemoteValue is ValueHoldingRemoteValue vh ? vh.ValueObject : null);
         }
 
         // Otherwise, use evaluation for objects with handles
@@ -127,7 +127,7 @@ internal class BidiJSHandle(RemoteValue value, BidiRealm realm) : JSHandle
             return (T)(object)Convert.ToDecimal(value, CultureInfo.InvariantCulture);
         }
 
-        if (typeof(T) == typeof(DateTime) && RemoteValue.Type == "date")
+        if (typeof(T) == typeof(DateTime) && RemoteValue.Type == RemoteValueType.Date)
         {
             return (T)(object)DateTime.Parse(value.ToString(), CultureInfo.InvariantCulture);
         }

--- a/lib/PuppeteerSharp/Bidi/BidiJSHandle.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiJSHandle.cs
@@ -55,12 +55,40 @@ internal class BidiJSHandle(RemoteValue value, BidiRealm realm) : JSHandle
         return new BidiJSHandle(value, realm);
     }
 
+    public override Task<IJSHandle> GetPropertyAsync(string propertyName)
+    {
+        // For handleless objects (e.g. from log events), look up the property
+        // directly from the RemoteValue dictionary to avoid a browser round-trip
+        // that would fail due to serialization issues
+        if (string.IsNullOrEmpty(Id) && RemoteValue is KeyValuePairCollectionRemoteValue kvp && kvp.Value != null)
+        {
+            foreach (var entry in kvp.Value)
+            {
+                if (entry.Key?.ToString() == propertyName)
+                {
+                    return Task.FromResult<IJSHandle>(BidiJSHandle.From(entry.Value, realm));
+                }
+            }
+
+            return base.GetPropertyAsync(propertyName);
+        }
+
+        return base.GetPropertyAsync(propertyName);
+    }
+
     public override async Task<T> JsonValueAsync<T>()
     {
         // If it's a primitive value or doesn't have a handle, deserialize directly
         if (IsPrimitiveValue || string.IsNullOrEmpty(Id))
         {
-            return DeserializeValue<T>(RemoteValue is ValueHoldingRemoteValue vh ? vh.ValueObject : null);
+            var valueObject = RemoteValue switch
+            {
+                ValueHoldingRemoteValue vh => vh.ValueObject,
+                CollectionRemoteValue crv => crv.Value,
+                KeyValuePairCollectionRemoteValue kvp => (object)kvp.Value,
+                _ => null,
+            };
+            return DeserializeValue<T>(valueObject);
         }
 
         // Otherwise, use evaluation for objects with handles

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -598,8 +598,9 @@ public class BidiPage : Page
     /// <inheritdoc />
     public override async Task SetJavaScriptEnabledAsync(bool enabled)
     {
-        var commandParameters = new WebDriverBiDi.Emulation.SetScriptingEnabledCommandParameters(enabled)
+        var commandParameters = new WebDriverBiDi.Emulation.SetScriptingEnabledCommandParameters
         {
+            IsScriptingEnabled = enabled,
             Contexts = [BidiMainFrame.BrowsingContext.Id],
         };
 
@@ -619,9 +620,8 @@ public class BidiPage : Page
     /// <inheritdoc />
     public override async Task SetCacheEnabledAsync(bool enabled = true)
     {
-        var commandParameters = new SetCacheBehaviorCommandParameters
+        var commandParameters = new SetCacheBehaviorCommandParameters(enabled ? CacheBehavior.Default : CacheBehavior.Bypass)
         {
-            CacheBehavior = enabled ? CacheBehavior.Default : CacheBehavior.Bypass,
             Contexts = [BidiMainFrame.BrowsingContext.Id],
         };
 
@@ -1107,16 +1107,12 @@ public class BidiPage : Page
             _ => null,
         };
 
-        if (remoteValue?.Type == "window")
+        if (remoteValue is WindowProxyRemoteValue windowProxyRemoteValue)
         {
-            var windowProxy = remoteValue.ValueAs<WindowProxyProperties>();
-            if (windowProxy != null)
+            var frame = Frames.OfType<BidiFrame>().FirstOrDefault(f => f.Id == windowProxyRemoteValue.Value.Context);
+            if (frame != null)
             {
-                var frame = Frames.OfType<BidiFrame>().FirstOrDefault(f => f.Id == windowProxy.Context);
-                if (frame != null)
-                {
-                    return frame;
-                }
+                return frame;
             }
         }
 

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -446,14 +446,10 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 {
                     dict[key] = null;
                 }
-                else if (remoteValue is ValueHoldingRemoteValue vhDict)
-                {
-                    dict[key] = DeserializeResult<object>(vhDict.ValueObject);
-                }
                 else
                 {
-                    // Circular reference - set to null
-                    dict[key] = null;
+                    var value = GetValueObject(remoteValue);
+                    dict[key] = value != null ? DeserializeResult<object>(value) : null;
                 }
             }
 
@@ -486,24 +482,23 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 {
                     property.SetValue(boxedInstance, null);
                 }
-                else if (remoteValue is not ValueHoldingRemoteValue vhProp)
-                {
-                    // Circular reference - set to null
-                    property.SetValue(boxedInstance, null);
-                }
                 else
                 {
-                    // Get the value from RemoteValue
-                    var value = vhProp.ValueObject;
+                    var value = GetValueObject(remoteValue);
+                    if (value == null)
+                    {
+                        property.SetValue(boxedInstance, null);
+                    }
+                    else
+                    {
+                        // Recursively deserialize the value to the property type
+                        var deserializedValue = typeof(BidiRealm)
+                            .GetMethod(nameof(DeserializeResult), BindingFlags.Instance | BindingFlags.NonPublic)
+                            ?.MakeGenericMethod(property.PropertyType)
+                            .Invoke(this, [value]);
 
-                    // Recursively deserialize the value to the property type
-                    var deserializedValue = typeof(BidiRealm)
-                        .GetMethod(nameof(DeserializeResult), BindingFlags.Instance | BindingFlags.NonPublic)
-                        ?.MakeGenericMethod(property.PropertyType)
-                        .Invoke(this, [value]);
-
-                    // Set the property value on the boxed instance
-                    property.SetValue(boxedInstance, deserializedValue);
+                        property.SetValue(boxedInstance, deserializedValue);
+                    }
                 }
             }
         }

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -393,12 +393,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 // Iterate over the input and add converted items to the list
                 foreach (var item in enumerable)
                 {
-                    var itemToSerialize = item;
-
-                    if (item is ValueHoldingRemoteValue remoteValue)
-                    {
-                        itemToSerialize = remoteValue.ValueObject;
-                    }
+                    var itemToSerialize = item is RemoteValue rv ? GetValueObject(rv) ?? item : item;
 
                     // Maybe there is a better way to do this.
                     var deserializedItem = typeof(BidiRealm)
@@ -753,6 +748,11 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 return ((IObjectReferenceRemoteValue)objectHandle.RemoteValue).ToRemoteObjectReference();
             case BidiElementHandle elementHandle:
                 ValidateHandle(elementHandle.BidiJSHandle);
+                if (string.IsNullOrEmpty(elementHandle.BidiJSHandle.Id))
+                {
+                    return elementHandle.Value.ToLocalValue();
+                }
+
                 return ((IObjectReferenceRemoteValue)elementHandle.Value).ToRemoteObjectReference();
         }
 

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -209,8 +209,13 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
         => remoteValue.Type is RemoteValueType.Symbol or RemoteValueType.Function or RemoteValueType.WeakMap or RemoteValueType.WeakSet or RemoteValueType.Error or RemoteValueType.Proxy
             or RemoteValueType.TypedArray or RemoteValueType.ArrayBuffer or RemoteValueType.Generator or RemoteValueType.Window;
 
-    private static object GetValueObject(RemoteValue remoteValue)
-        => remoteValue is ValueHoldingRemoteValue vh ? vh.ValueObject : null;
+    private static object GetValueObject(RemoteValue remoteValue) => remoteValue switch
+    {
+        ValueHoldingRemoteValue vh => vh.ValueObject,
+        CollectionRemoteValue crv => crv.Value,
+        KeyValuePairCollectionRemoteValue kvp => kvp.Value,
+        _ => null,
+    };
 
     private static string ToCamelCase(string name)
     {
@@ -745,10 +750,10 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                     return objectHandle.RemoteValue.ToLocalValue();
                 }
 
-                return new RemoteObjectReference(objectHandle.Id);
+                return ((IObjectReferenceRemoteValue)objectHandle.RemoteValue).ToRemoteObjectReference();
             case BidiElementHandle elementHandle:
                 ValidateHandle(elementHandle.BidiJSHandle);
-                return new RemoteObjectReference(elementHandle.BidiJSHandle.Id);
+                return ((IObjectReferenceRemoteValue)elementHandle.Value).ToRemoteObjectReference();
         }
 
         // Handle Regex as BiDi RegExp

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -745,10 +745,10 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                     return objectHandle.RemoteValue.ToLocalValue();
                 }
 
-                return objectHandle.RemoteValue.ToLocalValue();
+                return new RemoteObjectReference(objectHandle.Id);
             case BidiElementHandle elementHandle:
                 ValidateHandle(elementHandle.BidiJSHandle);
-                return elementHandle.Value.ToLocalValue();
+                return new RemoteObjectReference(elementHandle.BidiJSHandle.Id);
         }
 
         // Handle Regex as BiDi RegExp

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -311,6 +311,10 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
             // The command result is null because the connection closed
             throw new TargetClosedException($"Protocol error ({ex.Message})", "Browser disconnected");
         }
+        catch (WebDriverBiDi.WebDriverBiDiConnectionException ex)
+        {
+            throw new TargetClosedException($"Protocol error ({ex.Message})", "Browser disconnected");
+        }
 
         if (result.ResultType == EvaluateResultType.Exception)
         {

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -553,15 +553,18 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                     // Non-serializable types (symbol, function, etc.) are treated as null
                     result[key] = null;
                 }
-                else if (remoteValue is not ValueHoldingRemoteValue vhObj)
-                {
-                    // If RemoteValue has no value and is not null/undefined or non-serializable, it's a circular reference
-                    hasCircularRef = true;
-                    result[key] = null;
-                }
                 else
                 {
-                    result[key] = DeserializeToObjectInternal(vhObj.ValueObject, ref hasCircularRef);
+                    var val = GetValueObject(remoteValue);
+                    if (val == null)
+                    {
+                        hasCircularRef = true;
+                        result[key] = null;
+                    }
+                    else
+                    {
+                        result[key] = DeserializeToObjectInternal(val, ref hasCircularRef);
+                    }
                 }
             }
 
@@ -587,14 +590,14 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 return null;
             }
 
-            // If RemoteValue has no value and is not null/undefined or non-serializable, it's a circular reference
-            if (remoteVal is not ValueHoldingRemoteValue vhNested)
+            var nestedVal = GetValueObject(remoteVal);
+            if (nestedVal == null)
             {
                 hasCircularRef = true;
                 return null;
             }
 
-            return DeserializeToObjectInternal(vhNested.ValueObject, ref hasCircularRef);
+            return DeserializeToObjectInternal(nestedVal, ref hasCircularRef);
         }
 
         // Handle IEnumerable for arrays (but not strings)
@@ -618,15 +621,18 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                         // Non-serializable types (symbol, function, etc.) are treated as null
                         list.Add(null);
                     }
-                    else if (rv is not ValueHoldingRemoteValue vhItem)
-                    {
-                        // If RemoteValue has no value and is not null/undefined or non-serializable, it's a circular reference
-                        hasCircularRef = true;
-                        list.Add(null);
-                    }
                     else
                     {
-                        list.Add(DeserializeToObjectInternal(vhItem.ValueObject, ref hasCircularRef));
+                        var rvVal = GetValueObject(rv);
+                        if (rvVal == null)
+                        {
+                            hasCircularRef = true;
+                            list.Add(null);
+                        }
+                        else
+                        {
+                            list.Add(DeserializeToObjectInternal(rvVal, ref hasCircularRef));
+                        }
                     }
                 }
                 else

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -119,13 +119,13 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
         => CreateHandleAsync(await EvaluateAsync(false, false, script, args).ConfigureAwait(false));
 
     internal override async Task<T> EvaluateExpressionAsync<T>(string script)
-        => DeserializeResult<T>((await EvaluateAsync(true, true, script).ConfigureAwait(false)).Result.Value);
+        => DeserializeResult<T>(GetValueObject((await EvaluateAsync(true, true, script).ConfigureAwait(false)).Result));
 
     internal override async Task EvaluateExpressionAsync(string script)
         => await EvaluateAsync(true, true, script).ConfigureAwait(false);
 
     internal override async Task<T> EvaluateFunctionAsync<T>(string script, params object[] args)
-        => DeserializeResult<T>((await EvaluateAsync(true, false, script, args).ConfigureAwait(false)).Result.Value);
+        => DeserializeResult<T>(GetValueObject((await EvaluateAsync(true, false, script, args).ConfigureAwait(false)).Result));
 
     internal override async Task EvaluateFunctionAsync(string script, params object[] args)
     {
@@ -135,7 +135,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
     internal IJSHandle CreateHandle(RemoteValue remoteValue)
     {
         if (
-            remoteValue.Type is "node" or "window" &&
+            remoteValue.Type is RemoteValueType.Node or RemoteValueType.Window &&
             this is BidiFrameRealm)
         {
             return BidiElementHandle.From(remoteValue, this);
@@ -190,7 +190,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
     /// These types have HasValue=false but are valid values, not circular references.
     /// </summary>
     private static bool IsNullOrUndefinedType(RemoteValue remoteValue)
-        => remoteValue.Type is "null" or "undefined";
+        => remoteValue.Type is RemoteValueType.Null or RemoteValueType.Undefined;
 
     /// <summary>
     /// Checks if a RemoteValue represents a non-serializable JavaScript type that should be deserialized
@@ -198,7 +198,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
     /// Matches upstream Puppeteer's Deserializer behavior where promises return {}.
     /// </summary>
     private static bool IsEmptyObjectType(RemoteValue remoteValue)
-        => remoteValue.Type is "promise";
+        => remoteValue.Type is RemoteValueType.Promise;
 
     /// <summary>
     /// Checks if a RemoteValue represents a non-serializable JavaScript type that should be treated as null/undefined.
@@ -206,8 +206,11 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
     /// should return null rather than being treated as circular references.
     /// </summary>
     private static bool IsNonSerializableType(RemoteValue remoteValue)
-        => remoteValue.Type is "symbol" or "function" or "weakmap" or "weakset" or "error" or "proxy"
-            or "typedarray" or "arraybuffer" or "generator" or "window";
+        => remoteValue.Type is RemoteValueType.Symbol or RemoteValueType.Function or RemoteValueType.WeakMap or RemoteValueType.WeakSet or RemoteValueType.Error or RemoteValueType.Proxy
+            or RemoteValueType.TypedArray or RemoteValueType.ArrayBuffer or RemoteValueType.Generator or RemoteValueType.Window;
+
+    private static object GetValueObject(RemoteValue remoteValue)
+        => remoteValue is ValueHoldingRemoteValue vh ? vh.ValueObject : null;
 
     private static string ToCamelCase(string name)
     {
@@ -224,7 +227,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
         var result = evaluateResult.Result;
 
         if (
-            result.Type is "node" or "window" &&
+            result.Type is RemoteValueType.Node or RemoteValueType.Window &&
             this is BidiFrameRealm)
         {
             return BidiElementHandle.From(result, this);
@@ -387,9 +390,9 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 {
                     var itemToSerialize = item;
 
-                    if (item is RemoteValue remoteValue)
+                    if (item is ValueHoldingRemoteValue remoteValue)
                     {
-                        itemToSerialize = remoteValue.Value;
+                        itemToSerialize = remoteValue.ValueObject;
                     }
 
                     // Maybe there is a better way to do this.
@@ -443,9 +446,9 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 {
                     dict[key] = null;
                 }
-                else if (remoteValue.HasValue)
+                else if (remoteValue is ValueHoldingRemoteValue vhDict)
                 {
-                    dict[key] = DeserializeResult<object>(remoteValue.Value);
+                    dict[key] = DeserializeResult<object>(vhDict.ValueObject);
                 }
                 else
                 {
@@ -483,7 +486,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 {
                     property.SetValue(boxedInstance, null);
                 }
-                else if (!remoteValue.HasValue)
+                else if (remoteValue is not ValueHoldingRemoteValue vhProp)
                 {
                     // Circular reference - set to null
                     property.SetValue(boxedInstance, null);
@@ -491,7 +494,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 else
                 {
                     // Get the value from RemoteValue
-                    var value = remoteValue.Value;
+                    var value = vhProp.ValueObject;
 
                     // Recursively deserialize the value to the property type
                     var deserializedValue = typeof(BidiRealm)
@@ -555,7 +558,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                     // Non-serializable types (symbol, function, etc.) are treated as null
                     result[key] = null;
                 }
-                else if (!remoteValue.HasValue)
+                else if (remoteValue is not ValueHoldingRemoteValue vhObj)
                 {
                     // If RemoteValue has no value and is not null/undefined or non-serializable, it's a circular reference
                     hasCircularRef = true;
@@ -563,7 +566,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 }
                 else
                 {
-                    result[key] = DeserializeToObjectInternal(remoteValue.Value, ref hasCircularRef);
+                    result[key] = DeserializeToObjectInternal(vhObj.ValueObject, ref hasCircularRef);
                 }
             }
 
@@ -590,13 +593,13 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
             }
 
             // If RemoteValue has no value and is not null/undefined or non-serializable, it's a circular reference
-            if (!remoteVal.HasValue)
+            if (remoteVal is not ValueHoldingRemoteValue vhNested)
             {
                 hasCircularRef = true;
                 return null;
             }
 
-            return DeserializeToObjectInternal(remoteVal.Value, ref hasCircularRef);
+            return DeserializeToObjectInternal(vhNested.ValueObject, ref hasCircularRef);
         }
 
         // Handle IEnumerable for arrays (but not strings)
@@ -620,7 +623,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                         // Non-serializable types (symbol, function, etc.) are treated as null
                         list.Add(null);
                     }
-                    else if (!rv.HasValue)
+                    else if (rv is not ValueHoldingRemoteValue vhItem)
                     {
                         // If RemoteValue has no value and is not null/undefined or non-serializable, it's a circular reference
                         hasCircularRef = true;
@@ -628,7 +631,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                     }
                     else
                     {
-                        list.Add(DeserializeToObjectInternal(rv.Value, ref hasCircularRef));
+                        list.Add(DeserializeToObjectInternal(vhItem.ValueObject, ref hasCircularRef));
                     }
                 }
                 else
@@ -667,7 +670,7 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
         return value;
     }
 
-    private async Task<ArgumentValue> FormatArgumentAsync(object arg)
+    private async Task<LocalValue> FormatArgumentAsync(object arg)
     {
         if (arg is TaskCompletionSource<object> tcs)
         {
@@ -725,13 +728,13 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
             case IDictionary dictionary:
                 return await SerializeDictionaryAsync(dictionary).ConfigureAwait(false);
             case IEnumerable enumerable:
-                var list = new List<ArgumentValue>();
+                var list = new List<LocalValue>();
                 foreach (var item in enumerable)
                 {
                     list.Add(await FormatArgumentAsync(item).ConfigureAwait(false));
                 }
 
-                return LocalValue.Array(list.Select(el => el as LocalValue).ToList());
+                return LocalValue.Array(list);
             case BidiJSHandle objectHandle:
                 ValidateHandle(objectHandle);
 
@@ -739,13 +742,13 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
                 // serialize its value directly instead of using it as a remote reference
                 if (string.IsNullOrEmpty(objectHandle.Id))
                 {
-                    return SerializeRemoteValue(objectHandle.RemoteValue);
+                    return objectHandle.RemoteValue.ToLocalValue();
                 }
 
-                return objectHandle.RemoteValue.ToRemoteReference();
+                return objectHandle.RemoteValue.ToLocalValue();
             case BidiElementHandle elementHandle:
                 ValidateHandle(elementHandle.BidiJSHandle);
-                return elementHandle.Value.ToRemoteReference();
+                return elementHandle.Value.ToLocalValue();
         }
 
         // Handle Regex as BiDi RegExp
@@ -868,64 +871,6 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
             _ when value.GetType().IsClass || IsAnonymousType(value.GetType()) => SerializePlainObject(value, seen),
             _ => LocalValue.Null,
         };
-    }
-
-    private LocalValue SerializeRemoteValue(RemoteValue remoteValue)
-    {
-        return remoteValue.Type switch
-        {
-            "undefined" => LocalValue.Undefined,
-            "null" => LocalValue.Null,
-            "string" => LocalValue.String((string)remoteValue.Value),
-            "number" => remoteValue.Value switch
-            {
-                long l => LocalValue.Number(l),
-                double d when double.IsPositiveInfinity(d) => LocalValue.Infinity,
-                double d when double.IsNegativeInfinity(d) => LocalValue.NegativeInfinity,
-                double d when double.IsNaN(d) => LocalValue.NaN,
-                double d => LocalValue.Number(d),
-                _ => LocalValue.Number(Convert.ToDouble(remoteValue.Value, CultureInfo.InvariantCulture)),
-            },
-            "boolean" => LocalValue.Boolean((bool)remoteValue.Value),
-            "bigint" => LocalValue.BigInt(BigInteger.Parse((string)remoteValue.Value, CultureInfo.InvariantCulture)),
-            "array" => SerializeRemoteValueArray(remoteValue.Value),
-            "object" => SerializeRemoteValueObject(remoteValue.Value),
-            _ => throw new PuppeteerException($"Cannot serialize RemoteValue of type '{remoteValue.Type}' without a handle"),
-        };
-    }
-
-    private LocalValue SerializeRemoteValueArray(object value)
-    {
-        var items = new List<LocalValue>();
-        if (value is IEnumerable<RemoteValue> remoteValues)
-        {
-            foreach (var item in remoteValues)
-            {
-                items.Add(SerializeRemoteValue(item));
-            }
-        }
-
-        return LocalValue.Array(items);
-    }
-
-    private LocalValue SerializeRemoteValueObject(object value)
-    {
-        var dict = new Dictionary<string, LocalValue>();
-        if (value is RemoteValueDictionary remoteDict)
-        {
-            foreach (var kvp in remoteDict)
-            {
-                var key = kvp.Key switch
-                {
-                    string s => s,
-                    _ => kvp.Key.ToString(),
-                };
-                var val = SerializeRemoteValue(kvp.Value);
-                dict[key] = val;
-            }
-        }
-
-        return LocalValue.Object(dict);
     }
 }
 

--- a/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
@@ -295,7 +295,7 @@ internal class BrowsingContext : IDisposable
         await Session.Driver.Input.SetFilesAsync(parameters).ConfigureAwait(false);
     }
 
-    internal async Task<IList<RemoteValue>> LocateNodesAsync(Locator locator, SharedReference[] startNodes = null)
+    internal async Task<IList<NodeRemoteValue>> LocateNodesAsync(Locator locator, SharedReference[] startNodes = null)
     {
         var parameters = new LocateNodesCommandParameters(Id, locator);
         if (startNodes?.Length > 0)

--- a/lib/PuppeteerSharp/Bidi/Core/CallFunctionParameters.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/CallFunctionParameters.cs
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Bidi.Core;
 
 internal class CallFunctionParameters
 {
-    public List<ArgumentValue> Arguments { get; set; } = new();
+    public List<LocalValue> Arguments { get; set; } = new();
 
     public ResultOwnership? ResultOwnership { get; set; }
 

--- a/lib/PuppeteerSharp/Bidi/Core/Session.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/Session.cs
@@ -101,9 +101,7 @@ internal class Session(BiDiDriver driver, NewCommandResult info) : IDisposable
 
     public async Task SubscribeAsync(string[] events, string[] contexts = null)
     {
-        var args = new SubscribeCommandParameters();
-        args.Events.AddRange(events);
-        args.Contexts.AddRange(contexts ?? []);
+        var args = new SubscribeCommandParameters(events, contexts);
         await Driver.Session.SubscribeAsync(args).ConfigureAwait(false);
     }
 

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <ProjectReference Include="../../../../webdriverbidi-net/webdriverbidi-net/src/WebDriverBiDi/WebDriverBiDi.csproj" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
+    <PackageReference Include="WebDriverBiDi" Version="0.0.49" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <ProjectReference Include="../../../../webdriverbidi-net/webdriverbidi-net/src/WebDriverBiDi/WebDriverBiDi.csproj" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
+    <PackageReference Include="WebDriverBiDi" Version="0.0.48" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="WebDriverBiDi" Version="0.0.48" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
+    <ProjectReference Include="../../../../webdriverbidi-net/webdriverbidi-net/src/WebDriverBiDi/WebDriverBiDi.csproj" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="WebDriverBiDi" Version="0.0.45" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
+    <ProjectReference Include="../../../../webdriverbidi-net/webdriverbidi-net/src/WebDriverBiDi/WebDriverBiDi.csproj" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />


### PR DESCRIPTION
## Summary
- Adapts PuppeteerSharp to the new WebDriverBiDi.NET RemoteValue redesign ([webdriverbidi-net/webdriverbidi-net#55](https://github.com/webdriverbidi-net/webdriverbidi-net/pull/55))
- `RemoteValueType` is now an enum replacing string-based comparisons across all BiDi files
- `RemoteValue.Value`/`.HasValue`/`.Handle` moved to typed subclasses (`ValueHoldingRemoteValue`, `IObjectReferenceRemoteValue`)
- `ArgumentValue` → `LocalValue`, `ValueAs<T>()` → `ConvertTo<T>()`/pattern matching
- Replaced manual `SerializeRemoteValue` (60+ lines) with native `RemoteValue.ToLocalValue()`
- Updated `SetScriptingEnabledCommandParameters`, `SetCacheBehaviorCommandParameters`, and `SubscribeCommandParameters` constructors

## Notes
- Currently uses a local project reference to the WebDriverBiDi PR branch for testing. Will switch to NuGet package reference once the WebDriverBiDi release is published.
- Firefox BiDi tests: 843 passed, 37 failed (pre-existing), 294 skipped

## Test plan
- [x] Build succeeds with 0 errors
- [x] Firefox BiDi test suite passes (37 failures are pre-existing, not related to this change)
- [ ] Switch to NuGet package reference when WebDriverBiDi release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)