### PR TITLE
feat: add support for DevTools Issues

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -1368,6 +1368,21 @@
     "comment": "Flaky on Mac"
   },
   {
+    "testIdPattern": "[page.spec] Page Page.Events.Issue *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "BiDi does not support issue events"
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.Events.error should throw when page crashes",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/PageTests/PageEventsIssueTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageEventsIssueTests.cs
@@ -1,0 +1,70 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.PageTests;
+
+public class PageEventsIssueTests : PuppeteerPageBaseTest
+{
+    [Test, PuppeteerTest("page.spec", "Page Page.Events.Issue", "should emit issue event when CSP violation occurs")]
+    public async Task ShouldEmitIssueEventWhenCspViolationOccurs()
+    {
+        await Page.GoToAsync(TestConstants.ServerUrl + "/csp.html");
+
+        var issueTask = new TaskCompletionSource<Issue>();
+        Page.Issue += (_, e) => issueTask.TrySetResult(e.Issue);
+
+        await Page.AddScriptTagAsync(new AddTagOptions { Content = "console.log(\"CSP test\")" });
+
+        var issue = await issueTask.Task;
+        Assert.That(issue, Is.Not.Null);
+        Assert.That(issue.Code, Is.EqualTo("ContentSecurityPolicyIssue"));
+    }
+
+    [Test, PuppeteerTest("page.spec", "Page Page.Events.Issue", "should emit issue event from cross-origin iframe")]
+    public async Task ShouldEmitIssueEventFromCrossOriginIframe()
+    {
+        await Page.GoToAsync(TestConstants.EmptyPage);
+
+        var cspIssueTask = new TaskCompletionSource<Issue>();
+        Page.Issue += (_, e) =>
+        {
+            if (e.Issue.Code == "ContentSecurityPolicyIssue")
+            {
+                cspIssueTask.TrySetResult(e.Issue);
+            }
+        };
+
+        var crossOriginUrl = TestConstants.CrossProcessUrl + "/csp.html";
+        await Page.SetContentAsync($"<iframe src=\"{crossOriginUrl}\"></iframe>");
+
+        var frame = await Page.WaitForFrameAsync(crossOriginUrl);
+        Assert.That(frame, Is.Not.Null);
+
+        await frame.AddScriptTagAsync(new AddTagOptions { Content = "console.log(\"CSP test in iframe\")" });
+
+        var issue = await cspIssueTask.Task;
+        Assert.That(issue, Is.Not.Null);
+        Assert.That(issue.Code, Is.EqualTo("ContentSecurityPolicyIssue"));
+    }
+}
+
+public class PageEventsIssueDisabledTests : PuppeteerPageBaseTest
+{
+    public PageEventsIssueDisabledTests()
+    {
+        DefaultOptions = TestConstants.DefaultBrowserOptions();
+        DefaultOptions.IssuesEnabled = false;
+    }
+
+    [Test, PuppeteerTest("page.spec", "Page Page.Events.Issue when issues are disabled", "should be able to connect and disable issues")]
+    public async Task ShouldBeAbleToConnectAndDisableIssues()
+    {
+        var issueEmitted = false;
+        Page.Issue += (_, _) => issueEmitted = true;
+
+        await Page.GoToAsync(TestConstants.ServerUrl + "/csp.html");
+
+        Assert.That(issueEmitted, Is.False);
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
@@ -46,6 +46,7 @@ public class BidiBrowser : Browser
     private readonly BidiBrowserTarget _target;
     private readonly string _webSocketEndpoint;
     private readonly bool _networkEnabled;
+    private readonly bool _issuesEnabled;
     private bool _isClosed;
 
     private BidiBrowser(Core.Browser browserCore, IBrowserOptions options, ILoggerFactory loggerFactory, string webSocketEndpoint)
@@ -53,6 +54,7 @@ public class BidiBrowser : Browser
         _target = new BidiBrowserTarget(this);
         _options = options;
         _networkEnabled = options.NetworkEnabled;
+        _issuesEnabled = options.IssuesEnabled;
         BrowserCore = browserCore;
         _webSocketEndpoint = webSocketEndpoint;
         _logger = loggerFactory.CreateLogger<BidiBrowser>();
@@ -380,6 +382,8 @@ public class BidiBrowser : Browser
     }
 
     internal override bool IsNetworkEnabled() => _networkEnabled;
+
+    internal override bool IsIssuesEnabled() => _issuesEnabled;
 
     private static WindowState MapFromClientWindowState(WebDriverBiDi.Browser.ClientWindowState state) => state switch
     {

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -256,6 +256,8 @@ namespace PuppeteerSharp
 
         internal virtual bool IsNetworkEnabled() => true;
 
+        internal virtual bool IsIssuesEnabled() => true;
+
         internal IEnumerable<string> GetCustomQueryHandlerNames()
             => CustomQuerySelectorRegistry.Default.GetCustomQueryHandlerNames();
 

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -37,6 +37,7 @@ public class CdpBrowser : Browser
     private readonly ILogger<Browser> _logger;
     private readonly bool _handleDevToolsAsPage;
     private readonly bool _networkEnabled;
+    private readonly bool _issuesEnabled;
     private Task _closeTask;
 
     internal CdpBrowser(
@@ -49,7 +50,8 @@ public class CdpBrowser : Browser
         Func<Target, bool> targetFilter = null,
         Func<Target, bool> isPageTargetFunc = null,
         bool handleDevToolsAsPage = false,
-        bool networkEnabled = true)
+        bool networkEnabled = true,
+        bool issuesEnabled = true)
     {
         BrowserType = browser;
         DefaultViewport = defaultViewport;
@@ -58,6 +60,7 @@ public class CdpBrowser : Browser
         Connection = connection;
         _handleDevToolsAsPage = handleDevToolsAsPage;
         _networkEnabled = networkEnabled;
+        _issuesEnabled = issuesEnabled;
         var targetFilterCallback = targetFilter ?? (_ => true);
         _logger = Connection.LoggerFactory.CreateLogger<Browser>();
         IsPageTargetFunc =
@@ -228,7 +231,8 @@ public class CdpBrowser : Browser
         Func<Target, bool> isPageTargetCallback = null,
         Action<IBrowser> initAction = null,
         bool handleDevToolsAsPage = false,
-        bool networkEnabled = true)
+        bool networkEnabled = true,
+        bool issuesEnabled = true)
     {
         var browser = new CdpBrowser(
             browserToCreate,
@@ -240,7 +244,8 @@ public class CdpBrowser : Browser
             targetFilter,
             isPageTargetCallback,
             handleDevToolsAsPage,
-            networkEnabled);
+            networkEnabled,
+            issuesEnabled);
 
         try
         {
@@ -263,6 +268,8 @@ public class CdpBrowser : Browser
     }
 
     internal override bool IsNetworkEnabled() => _networkEnabled;
+
+    internal override bool IsIssuesEnabled() => _issuesEnabled;
 
     internal async Task<IPage> CreatePageInContextAsync(string contextId, CreatePageOptions options = null)
     {

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -73,7 +73,7 @@ public class CdpPage : Page
 
         _emulationManager = new CdpEmulationManager(client);
         _logger = Client.Connection.LoggerFactory.CreateLogger<Page>();
-        FrameManager = new FrameManager(client, this, TimeoutSettings, target.Browser.IsNetworkEnabled());
+        FrameManager = new FrameManager(client, this, TimeoutSettings, target.Browser.IsNetworkEnabled(), target.Browser.IsIssuesEnabled());
         Accessibility = new Accessibility(client, () => MainFrame?.Id, () => (FrameManager.MainFrame as Frame)?.MainRealm);
 
         // Use browser context's connection, as current Bluetooth emulation in Chromium is

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -26,13 +26,14 @@ namespace PuppeteerSharp.Cdp
         private readonly HashSet<Binding> _bindings = new();
         private TaskCompletionSource<bool> _frameTreeHandled = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        internal FrameManager(CDPSession client, Page page, TimeoutSettings timeoutSettings, bool networkEnabled = true)
+        internal FrameManager(CDPSession client, Page page, TimeoutSettings timeoutSettings, bool networkEnabled = true, bool issuesEnabled = true)
         {
             Client = client;
             Page = page;
             _logger = Client.Connection.LoggerFactory.CreateLogger<FrameManager>();
             NetworkManager = new NetworkManager(this, client.Connection.LoggerFactory, networkEnabled);
             TimeoutSettings = timeoutSettings;
+            IssuesEnabled = issuesEnabled;
 
             Client.MessageReceived += Client_MessageReceived;
             Client.Disconnected += (sender, e) => _ = OnClientDisconnectAsync();
@@ -57,6 +58,8 @@ namespace PuppeteerSharp.Cdp
         internal Page Page { get; }
 
         internal TimeoutSettings TimeoutSettings { get; }
+
+        internal bool IssuesEnabled { get; }
 
         internal FrameTree FrameTree { get; } = new();
 
@@ -211,10 +214,19 @@ namespace PuppeteerSharp.Cdp
                 _frameTreeHandled.TrySetResult(true);
                 await HandleFrameTreeAsync(client, getFrameTreeTask.Result.FrameTree).ConfigureAwait(false);
 
-                await Task.WhenAll(
+                var tasks = new List<Task>
+                {
                     client.SendAsync("Page.setLifecycleEventsEnabled", new PageSetLifecycleEventsEnabledRequest { Enabled = true }),
                     client.SendAsync("Runtime.enable"),
-                    networkInitTask).ConfigureAwait(false);
+                    networkInitTask,
+                };
+
+                if (IssuesEnabled)
+                {
+                    tasks.Add(client.SendAsync("Audits.enable"));
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
 
                 if (frame != null)
                 {
@@ -325,6 +337,9 @@ namespace PuppeteerSharp.Cdp
                         case "Page.lifecycleEvent":
                             OnLifeCycleEvent(e.MessageData.ToObject<LifecycleEventResponse>());
                             break;
+                        case "Audits.issueAdded":
+                            OnIssueAdded(e.MessageData.ToObject<AuditsIssueAddedResponse>());
+                            break;
                     }
                 }
                 catch (Exception ex)
@@ -360,6 +375,22 @@ namespace PuppeteerSharp.Cdp
                 frame.OnLifecycleEvent(e.LoaderId, e.Name);
                 LifecycleEvent?.Invoke(this, new FrameEventArgs(frame));
             }
+        }
+
+        private void OnIssueAdded(AuditsIssueAddedResponse e)
+        {
+            if (e?.Issue == null)
+            {
+                return;
+            }
+
+            var issue = new Issue
+            {
+                Code = e.Issue.Code,
+                Details = e.Issue.Details,
+            };
+
+            Page.OnIssue(new IssueEventArgs(issue));
         }
 
         private void OnExecutionContextsCleared(CDPSession session)

--- a/lib/PuppeteerSharp/Cdp/Messaging/AuditsInspectorIssue.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/AuditsInspectorIssue.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class AuditsInspectorIssue
+    {
+        public string Code { get; set; }
+
+        public JsonElement Details { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/AuditsIssueAddedResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/AuditsIssueAddedResponse.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class AuditsIssueAddedResponse
+    {
+        public AuditsInspectorIssue Issue { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -45,6 +45,11 @@ namespace PuppeteerSharp
         public bool NetworkEnabled { get; set; } = true;
 
         /// <summary>
+        /// Experimental setting to disable monitoring issue events by default.
+        /// </summary>
+        public bool IssuesEnabled { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the default Viewport.
         /// </summary>
         /// <value>The default Viewport.</value>

--- a/lib/PuppeteerSharp/IBrowserOptions.cs
+++ b/lib/PuppeteerSharp/IBrowserOptions.cs
@@ -18,6 +18,11 @@ namespace PuppeteerSharp
         bool NetworkEnabled { get; set; }
 
         /// <summary>
+        /// Experimental setting to disable monitoring issue events by default.
+        /// </summary>
+        bool IssuesEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets the default Viewport.
         /// </summary>
         /// <value>The default Viewport.</value>

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -94,6 +94,11 @@ namespace PuppeteerSharp
         event EventHandler<MetricEventArgs> Metrics;
 
         /// <summary>
+        /// Raised when a DevTools issue is reported.
+        /// </summary>
+        event EventHandler<IssueEventArgs> Issue;
+
+        /// <summary>
         /// Raised when an uncaught exception happens within the page.
         /// </summary>
         event EventHandler<PageErrorEventArgs> PageError;

--- a/lib/PuppeteerSharp/Issue.cs
+++ b/lib/PuppeteerSharp/Issue.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Represents a DevTools issue.
+    /// </summary>
+    public class Issue
+    {
+        /// <summary>
+        /// Gets the issue code.
+        /// </summary>
+        public string Code { get; init; }
+
+        /// <summary>
+        /// Gets the issue details.
+        /// </summary>
+        public JsonElement Details { get; init; }
+    }
+}

--- a/lib/PuppeteerSharp/IssueEventArgs.cs
+++ b/lib/PuppeteerSharp/IssueEventArgs.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// <see cref="IPage.Issue"/> event arguments.
+    /// </summary>
+    public class IssueEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IssueEventArgs"/> class.
+        /// </summary>
+        /// <param name="issue">The issue that was reported.</param>
+        public IssueEventArgs(Issue issue) => Issue = issue;
+
+        /// <summary>
+        /// Gets the reported issue.
+        /// </summary>
+        public Issue Issue { get; }
+    }
+}

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -162,6 +162,11 @@ namespace PuppeteerSharp
         public bool NetworkEnabled { get; set; } = true;
 
         /// <summary>
+        /// Experimental setting to disable monitoring issue events by default.
+        /// </summary>
+        public bool IssuesEnabled { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the default Viewport.
         /// </summary>
         /// <value>The default Viewport.</value>

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -187,7 +187,8 @@ namespace PuppeteerSharp
                                 options.TargetFilter,
                                 options.IsPageTarget,
                                 handleDevToolsAsPage: options.HandleDevToolsAsPage,
-                                networkEnabled: options.NetworkEnabled)
+                                networkEnabled: options.NetworkEnabled,
+                                issuesEnabled: options.IssuesEnabled)
                             .ConfigureAwait(false);
                     }
 
@@ -440,7 +441,8 @@ namespace PuppeteerSharp
                         options.IsPageTarget,
                         options.InitAction,
                         options.HandleDevToolsAsPage,
-                        options.NetworkEnabled)
+                        options.NetworkEnabled,
+                        options.IssuesEnabled)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -93,6 +93,9 @@ namespace PuppeteerSharp
         public event EventHandler<RequestEventArgs> RequestServedFromCache;
 
         /// <inheritdoc/>
+        public event EventHandler<IssueEventArgs> Issue;
+
+        /// <inheritdoc/>
         public event EventHandler<PageErrorEventArgs> PageError;
 
         /// <inheritdoc/>
@@ -897,6 +900,8 @@ namespace PuppeteerSharp
 
         /// <inheritdoc />
         public abstract Task SetBypassServiceWorkerAsync(bool bypass);
+
+        internal void OnIssue(IssueEventArgs e) => Issue?.Invoke(this, e);
 
         internal void OnPopup(IPage popupPage) => Popup?.Invoke(this, new PopupEventArgs { PopupPage = popupPage });
 


### PR DESCRIPTION
## Summary

Implements changes from https://github.com/puppeteer/puppeteer/pull/14845 which adds support for DevTools issue events.

- Add `Issue` class with `Code` and `Details` properties representing a DevTools issue
- Add `IssueEventArgs` event arguments class
- Add `IssuesEnabled` option (default: `true`) to `LaunchOptions`, `ConnectOptions`, and `IBrowserOptions` to allow disabling issue monitoring
- Add `Issue` event to `IPage` interface and `Page` abstract class
- Add `IsIssuesEnabled()` to `Browser` base class, `CdpBrowser`, and `BidiBrowser`
- Enable `Audits.enable` CDP command in `FrameManager.InitializeAsync` when issues are enabled
- Handle `Audits.issueAdded` CDP events in `FrameManager` and emit `Page.Issue` events
- Add CDP messaging types: `AuditsIssueAddedResponse`, `AuditsInspectorIssue`
- Add tests for CSP violation issues and cross-origin iframe issue detection
- Add BiDi skip entry for Issue tests in upstream test expectations (BiDi does not support issue events)

## Test plan

- [x] `ShouldEmitIssueEventWhenCspViolationOccurs` - passes
- [x] `ShouldEmitIssueEventFromCrossOriginIframe` - passes  
- [x] `ShouldBeAbleToConnectAndDisableIssues` - passes
- [x] All 3 tests pass with `BROWSER=CHROME PROTOCOL=cdp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)