### PR TITLE
Implement upstream PR #14824: adds extension realms API

### DIFF
--- a/lib/PuppeteerSharp.Tests/RealmsTests/RealmsTests.cs
+++ b/lib/PuppeteerSharp.Tests/RealmsTests/RealmsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/lib/PuppeteerSharp.Tests/RealmsTests/RealmsTests.cs
+++ b/lib/PuppeteerSharp.Tests/RealmsTests/RealmsTests.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.Tests.RealmsTests
             Pipe = true,
         };
 
-        [Test, PuppeteerTest("cdp/realms.spec", "extension realms", "should include content script realms")]
+        [Test, PuppeteerTest("realms.spec", "extension realms", "should include content script realms")]
         public async Task ShouldIncludeContentScriptRealms()
         {
             await using var browserWithExtension = await Puppeteer.LaunchAsync(
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.RealmsTests
             Assert.That(realms.Count, Is.GreaterThanOrEqualTo(1));
         }
 
-        [Test, PuppeteerTest("cdp/realms.spec", "extension realms", "realm should return extension that created it")]
+        [Test, PuppeteerTest("realms.spec", "extension realms", "realm should return extension that created it")]
         public async Task RealmShouldReturnExtensionThatCreatedIt()
         {
             await using var browserWithExtension = await Puppeteer.LaunchAsync(
@@ -65,7 +65,7 @@ namespace PuppeteerSharp.Tests.RealmsTests
             Assert.That(extension.Id, Is.EqualTo(extId));
         }
 
-        [Test, PuppeteerTest("cdp/realms.spec", "extension realms", "should evaluate in content script realms")]
+        [Test, PuppeteerTest("realms.spec", "extension realms", "should evaluate in content script realms")]
         public async Task ShouldEvaluateInContentScriptRealms()
         {
             await using var browserWithExtension = await Puppeteer.LaunchAsync(

--- a/lib/PuppeteerSharp.Tests/RealmsTests/RealmsTests.cs
+++ b/lib/PuppeteerSharp.Tests/RealmsTests/RealmsTests.cs
@@ -1,0 +1,102 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.RealmsTests
+{
+    public class RealmsTests : PuppeteerBaseTest
+    {
+        private static readonly string _extensionPath = Path.Combine(AppContext.BaseDirectory, "Assets", "simple-extension");
+
+        private static LaunchOptions BrowserWithExtensionOptions() => new()
+        {
+            Headless = false,
+            EnableExtensions = true,
+            Pipe = true,
+        };
+
+        [Test, PuppeteerTest("cdp/realms.spec", "extension realms", "should include content script realms")]
+        public async Task ShouldIncludeContentScriptRealms()
+        {
+            await using var browserWithExtension = await Puppeteer.LaunchAsync(
+                BrowserWithExtensionOptions(),
+                TestConstants.LoggerFactory);
+
+            var page = await browserWithExtension.NewPageAsync();
+            var extId = await browserWithExtension.InstallExtensionAsync(_extensionPath);
+            await browserWithExtension.WaitForTargetAsync(t => t.Url.Contains(extId));
+
+            await page.GoToAsync(TestConstants.EmptyPage);
+
+            var realms = page.ExtensionRealms();
+            Assert.That(realms.Count, Is.GreaterThanOrEqualTo(1));
+        }
+
+        [Test, PuppeteerTest("cdp/realms.spec", "extension realms", "realm should return extension that created it")]
+        public async Task RealmShouldReturnExtensionThatCreatedIt()
+        {
+            await using var browserWithExtension = await Puppeteer.LaunchAsync(
+                BrowserWithExtensionOptions(),
+                TestConstants.LoggerFactory);
+
+            var page = await browserWithExtension.NewPageAsync();
+            var extId = await browserWithExtension.InstallExtensionAsync(_extensionPath);
+            await browserWithExtension.WaitForTargetAsync(t => t.Url.Contains(extId));
+
+            await page.GoToAsync(TestConstants.EmptyPage);
+            var realms = page.ExtensionRealms();
+
+            Realm realm = null;
+            foreach (var r in realms)
+            {
+                var ext = await r.ExtensionAsync();
+                if (ext != null && ext.Id == extId)
+                {
+                    realm = r;
+                    break;
+                }
+            }
+
+            Assert.That(realm, Is.Not.Null);
+            var extension = await realm.ExtensionAsync();
+            Assert.That(extension, Is.Not.Null);
+            Assert.That(extension.Id, Is.EqualTo(extId));
+        }
+
+        [Test, PuppeteerTest("cdp/realms.spec", "extension realms", "should evaluate in content script realms")]
+        public async Task ShouldEvaluateInContentScriptRealms()
+        {
+            await using var browserWithExtension = await Puppeteer.LaunchAsync(
+                BrowserWithExtensionOptions(),
+                TestConstants.LoggerFactory);
+
+            var page = await browserWithExtension.NewPageAsync();
+            var extId = await browserWithExtension.InstallExtensionAsync(_extensionPath);
+            await browserWithExtension.WaitForTargetAsync(t => t.Url.Contains(extId));
+
+            await page.GoToAsync(TestConstants.EmptyPage);
+            var realms = page.ExtensionRealms();
+
+            Realm contentScriptRealm = null;
+            foreach (var r in realms)
+            {
+                var ext = await r.ExtensionAsync();
+                if (ext != null && ext.Id == extId)
+                {
+                    contentScriptRealm = r;
+                    break;
+                }
+            }
+
+            Assert.That(contentScriptRealm, Is.Not.Null);
+
+            var isContentScript = await contentScriptRealm.EvaluateFunctionAsync<bool>("() => globalThis.thisIsTheContentScript");
+            Assert.That(isContentScript, Is.True);
+
+            var isContentScriptInMain = await page.EvaluateFunctionAsync<object>("() => globalThis.thisIsTheContentScript");
+            Assert.That(isContentScriptInMain, Is.Null);
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -200,6 +201,10 @@ public class BidiBrowser : Browser
         await Driver.WebExtension.UninstallAsync(
             new WebDriverBiDi.WebExtension.UninstallCommandParameters(id)).ConfigureAwait(false);
     }
+
+    /// <inheritdoc/>
+    public override Task<IReadOnlyDictionary<string, Extension>> GetExtensionsAsync()
+        => throw new NotSupportedException("GetExtensions is not supported in WebDriver BiDi.");
 
     /// <inheritdoc />
     public override ITarget[] Targets()

--- a/lib/PuppeteerSharp/Bidi/BidiFrame.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiFrame.cs
@@ -557,6 +557,10 @@ public class BidiFrame : Frame
         return BidiElementHandle.From(node, (BidiRealm)parentFrame.MainRealm) as ElementHandle;
     }
 
+    /// <inheritdoc />
+    public override IReadOnlyList<Realm> ExtensionRealms()
+        => throw new NotSupportedException("ExtensionRealms is not supported in WebDriver BiDi.");
+
     internal static BidiFrame From(BidiPage parentPage, BidiFrame parentFrame, BrowsingContext browsingContext)
     {
         parentFrame = new BidiFrame(parentPage, parentFrame, browsingContext);
@@ -609,10 +613,6 @@ public class BidiFrame : Frame
             locator,
             [element.Value.ConvertTo<NodeRemoteValue>().ToSharedReference()]).ConfigureAwait(false);
     }
-
-    /// <inheritdoc />
-    public override IReadOnlyList<Realm> ExtensionRealms()
-        => throw new NotSupportedException("ExtensionRealms is not supported in WebDriver BiDi.");
 
     /// <inheritdoc />
     protected internal override DeviceRequestPromptManager GetDeviceRequestPromptManager() => throw new System.NotImplementedException();

--- a/lib/PuppeteerSharp/Bidi/BidiFrame.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiFrame.cs
@@ -611,6 +611,10 @@ public class BidiFrame : Frame
     }
 
     /// <inheritdoc />
+    public override IReadOnlyList<Realm> ExtensionRealms()
+        => throw new NotSupportedException("ExtensionRealms is not supported in WebDriver BiDi.");
+
+    /// <inheritdoc />
     protected internal override DeviceRequestPromptManager GetDeviceRequestPromptManager() => throw new System.NotImplementedException();
 
     private static ConsoleType ConvertConsoleMessageLevel(string method)

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -881,6 +881,10 @@ public class BidiPage : Page
     public override Task SetBypassServiceWorkerAsync(bool bypass) => throw new NotImplementedException();
 
     /// <inheritdoc />
+    public override IReadOnlyList<Realm> ExtensionRealms()
+        => throw new NotSupportedException("ExtensionRealms is not supported in WebDriver BiDi.");
+
+    /// <inheritdoc />
     public override async Task<NewDocumentScriptEvaluation> EvaluateExpressionOnNewDocumentAsync(string expression)
     {
         // Wrap the expression in a function so it can be used as a preload script

--- a/lib/PuppeteerSharp/Bidi/BidiRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiRealm.cs
@@ -45,7 +45,14 @@ internal class BidiRealm(Core.Realm realm, TimeoutSettings timeoutSettings) : Re
 
     public JSHandle InternalPuppeteerUtilHandle { get; set; }
 
+    /// <inheritdoc/>
+    public override string Origin => throw new NotSupportedException("Origin is not supported in WebDriver BiDi.");
+
     internal override IEnvironment Environment { get; }
+
+    /// <inheritdoc/>
+    public override Task<Extension> ExtensionAsync()
+        => throw new NotSupportedException("Extension is not supported in WebDriver BiDi.");
 
     public void Dispose()
     {

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -106,6 +106,9 @@ namespace PuppeteerSharp
         public abstract Task UninstallExtensionAsync(string id);
 
         /// <inheritdoc/>
+        public abstract Task<IReadOnlyDictionary<string, Extension>> GetExtensionsAsync();
+
+        /// <inheritdoc/>
         public async Task<IPage[]> PagesAsync(bool includeAll = false)
             => (await Task.WhenAll(
                 BrowserContexts().Select(t => t.PagesAsync(includeAll))).ConfigureAwait(false))

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -37,6 +37,7 @@ public class CdpBrowser : Browser
     private readonly ILogger<Browser> _logger;
     private readonly bool _handleDevToolsAsPage;
     private readonly bool _networkEnabled;
+    private readonly Dictionary<string, Extension> _extensions = new();
     private Task _closeTask;
 
     internal CdpBrowser(
@@ -207,6 +208,7 @@ public class CdpBrowser : Browser
         var response = await Connection.SendAsync<ExtensionsLoadUnpackedResponse>(
             "Extensions.loadUnpacked",
             new ExtensionsLoadUnpackedRequest { Path = path }).ConfigureAwait(false);
+        _extensions.Remove(response.Id);
         return response.Id;
     }
 
@@ -214,6 +216,36 @@ public class CdpBrowser : Browser
     public override async Task UninstallExtensionAsync(string id)
     {
         await Connection.SendAsync("Extensions.uninstall", new ExtensionsUninstallRequest { Id = id }).ConfigureAwait(false);
+        _extensions.Remove(id);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IReadOnlyDictionary<string, Extension>> GetExtensionsAsync()
+    {
+        var response = await Connection.SendAsync<ExtensionsGetExtensionsResponse>("Extensions.getExtensions")
+            .ConfigureAwait(false);
+
+        var extensionsMap = new Dictionary<string, Extension>();
+
+        foreach (var info in response.Extensions)
+        {
+            if (_extensions.TryGetValue(info.Id, out var existing))
+            {
+                extensionsMap[info.Id] = existing;
+            }
+            else
+            {
+                extensionsMap[info.Id] = new CdpExtension(info.Id, info.Version, info.Name, this);
+            }
+        }
+
+        _extensions.Clear();
+        foreach (var kvp in extensionsMap)
+        {
+            _extensions[kvp.Key] = kvp.Value;
+        }
+
+        return extensionsMap;
     }
 
     internal static async Task<CdpBrowser> CreateAsync(

--- a/lib/PuppeteerSharp/Cdp/CdpExtension.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpExtension.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using PuppeteerSharp.Cdp.Messaging;
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// CDP implementation of <see cref="Extension"/>.
+/// </summary>
+internal class CdpExtension : Extension
+{
+    private readonly CdpBrowser _browser;
+
+    internal CdpExtension(string id, string version, string name, CdpBrowser browser)
+        : base(id, version, name)
+    {
+        _browser = browser;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IReadOnlyList<WebWorker>> WorkersAsync()
+    {
+        var targets = _browser.Targets();
+
+        var workers = new List<WebWorker>();
+        foreach (var target in targets)
+        {
+            var targetUrl = target.Url;
+            if (target.Type == TargetType.ServiceWorker &&
+                targetUrl.StartsWith("chrome-extension://" + Id, System.StringComparison.Ordinal))
+            {
+                var worker = await target.WorkerAsync().ConfigureAwait(false);
+                if (worker != null)
+                {
+                    workers.Add(worker);
+                }
+            }
+        }
+
+        return workers;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IReadOnlyList<IPage>> PagesAsync()
+    {
+        var targets = _browser.Targets();
+
+        var pages = new List<IPage>();
+        foreach (var target in targets)
+        {
+            var targetUrl = target.Url;
+            if ((target.Type == TargetType.Page || target.Type == TargetType.BackgroundPage) &&
+                targetUrl.StartsWith("chrome-extension://" + Id, System.StringComparison.Ordinal))
+            {
+                var page = await target.PageAsync().ConfigureAwait(false);
+                if (page != null)
+                {
+                    pages.Add(page);
+                }
+            }
+        }
+
+        return pages;
+    }
+
+    /// <inheritdoc/>
+    public override async Task TriggerActionAsync(IPage page)
+    {
+        var cdpPage = (CdpPage)page;
+        await _browser.Connection.SendAsync("Extensions.triggerAction", new ExtensionsTriggerActionRequest
+        {
+            Id = Id,
+            TargetId = cdpPage.TabId,
+        }).ConfigureAwait(false);
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -21,6 +21,7 @@
 //  * SOFTWARE.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -72,6 +73,8 @@ public class CdpFrame : Frame
     internal Accessibility Accessibility { get; }
 
     internal CdpPage CdpPage => Page as CdpPage;
+
+    internal ConcurrentDictionary<string, IsolatedWorld> ExtensionWorlds { get; } = new();
 
     internal override Frame ParentFrame => FrameManager.FrameTree.GetParentFrame(Id);
 
@@ -272,6 +275,10 @@ public class CdpFrame : Frame
         return (ElementHandle)await parentFrame.MainRealm.AdoptBackendNodeAsync(response.BackendNodeId).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
+    public override IReadOnlyList<Realm> ExtensionRealms()
+        => ExtensionWorlds.Values.Cast<Realm>().ToList();
+
     internal bool IsOopFrame() => Client != FrameManager.Client;
 
     internal async Task AddPreloadScriptAsync(CdpPreloadScript preloadScript)
@@ -370,6 +377,17 @@ public class CdpFrame : Frame
             MainWorld.FrameUpdated();
             PuppeteerWorld.FrameUpdated();
         }
+    }
+
+    /// <inheritdoc/>
+    protected internal override void OnDetach()
+    {
+        foreach (var world in ExtensionWorlds.Values)
+        {
+            world.Detach();
+        }
+
+        ExtensionWorlds.Clear();
     }
 
     /// <inheritdoc />

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -807,6 +807,10 @@ public class CdpPage : Page
         }
     }
 
+    /// <inheritdoc/>
+    public override IReadOnlyList<Realm> ExtensionRealms()
+        => ((Frame)MainFrame).ExtensionRealms();
+
     internal static async Task<Page> CreateAsync(
         CdpCDPSession client,
         CdpTarget target,

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -14,6 +14,7 @@ namespace PuppeteerSharp.Cdp
     internal class FrameManager : IDisposable, IAsyncDisposable, IFrameProvider
     {
         private const int TimeForWaitingForSwap = 200;
+        private const string ChromeExtensionPrefix = "chrome-extension://";
         private static readonly string UtilityWorldName = "__puppeteer_utility_world__" + typeof(FrameManager).Assembly.GetName().Version.ToString();
 
         private readonly ConcurrentDictionary<string, ExecutionContext> _contextIdToContext = new();
@@ -276,6 +277,21 @@ namespace PuppeteerSharp.Cdp
         internal Task RegisterSpeculativeSessionAsync(CDPSession client)
             => NetworkManager.AddClientAsync(client);
 
+        private static bool IsExtensionOrigin(string origin)
+            => !string.IsNullOrEmpty(origin) && origin.StartsWith(ChromeExtensionPrefix, StringComparison.Ordinal);
+
+        private static string ExtractExtensionId(string origin)
+        {
+            if (!IsExtensionOrigin(origin))
+            {
+                return null;
+            }
+
+            var pathPart = origin.Substring(ChromeExtensionPrefix.Length);
+            var slashIndex = pathPart.IndexOf('/');
+            return slashIndex == -1 ? pathPart : pathPart.Substring(0, slashIndex);
+        }
+
         private CdpFrame GetFrame(string frameId) => FrameTree.GetById(frameId);
 
         private void Client_MessageReceived(object sender, MessageEventArgs e)
@@ -412,6 +428,24 @@ namespace PuppeteerSharp.Cdp
                     // connections so we might end up creating multiple isolated worlds.
                     // We can use either.
                     world = frame.PuppeteerWorld;
+                }
+                else if (IsExtensionOrigin(contextPayload.Origin))
+                {
+                    var extId = ExtractExtensionId(contextPayload.Origin);
+
+                    if (extId == null)
+                    {
+                        _logger.LogError("Error while parsing extension id from origin: {Origin}", contextPayload.Origin);
+                        return;
+                    }
+
+                    if (!frame.ExtensionWorlds.TryGetValue(extId, out world))
+                    {
+                        world = new IsolatedWorld(frame, null, TimeoutSettings, false);
+                        world.SetWorldId(extId);
+                        world.SetOrigin(contextPayload.Origin);
+                        frame.ExtensionWorlds[extId] = world;
+                    }
                 }
             }
 

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionInfo.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionInfo.cs
@@ -1,0 +1,11 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class ExtensionInfo
+    {
+        public string Id { get; set; }
+
+        public string Version { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsGetExtensionsResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsGetExtensionsResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class ExtensionsGetExtensionsResponse
+    {
+        public List<ExtensionInfo> Extensions { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsTriggerActionRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsTriggerActionRequest.cs
@@ -1,0 +1,9 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class ExtensionsTriggerActionRequest
+    {
+        public string Id { get; set; }
+
+        public string TargetId { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/ContextPayload.cs
+++ b/lib/PuppeteerSharp/ContextPayload.cs
@@ -7,5 +7,7 @@ namespace PuppeteerSharp
         public ContextPayloadAuxData AuxData { get; set; }
 
         public string Name { get; set; }
+
+        public string Origin { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Extension.cs
+++ b/lib/PuppeteerSharp/Extension.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Represents an Extension instance installed in the browser.
+    /// </summary>
+    /// <remarks>
+    /// <para>This API is experimental.</para>
+    /// </remarks>
+    public abstract class Extension
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Extension"/> class.
+        /// </summary>
+        /// <param name="id">The extension ID.</param>
+        /// <param name="version">The extension version.</param>
+        /// <param name="name">The extension name.</param>
+        protected Extension(string id, string version, string name)
+        {
+            Id = id;
+            Version = version;
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the ID of the extension.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Gets the version of the extension.
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// Gets the name of the extension.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Returns the list of the currently active service workers of the extension.
+        /// </summary>
+        /// <returns>A task that resolves to the list of web workers.</returns>
+        public abstract Task<IReadOnlyList<WebWorker>> WorkersAsync();
+
+        /// <summary>
+        /// Returns the list of the visible pages of the extension.
+        /// </summary>
+        /// <returns>A task that resolves to the list of pages.</returns>
+        public abstract Task<IReadOnlyList<IPage>> PagesAsync();
+
+        /// <summary>
+        /// Triggers an extension default action on the given page.
+        /// </summary>
+        /// <param name="page">The page to trigger the action on.</param>
+        /// <returns>A task that completes when the action is triggered.</returns>
+        public abstract Task TriggerActionAsync(IPage page);
+    }
+}

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -454,11 +454,25 @@ namespace PuppeteerSharp
             Detached = true;
             MainWorld.Detach();
             PuppeteerWorld.Detach();
+            OnDetach();
             FrameDetached?.Invoke(this, EventArgs.Empty);
         }
 
         internal void OnFrameSwappedByActivation()
             => FrameSwappedByActivation?.Invoke(this, EventArgs.Empty);
+
+        /// <summary>
+        /// Called when this frame is being detached. Subclasses can override to perform additional cleanup.
+        /// </summary>
+        protected internal virtual void OnDetach()
+        {
+        }
+
+        /// <summary>
+        /// Retrieves the list of extension realms within this frame.
+        /// </summary>
+        /// <returns>A list of <see cref="Realm"/> instances representing extension execution contexts.</returns>
+        public abstract IReadOnlyList<Realm> ExtensionRealms();
 
         /// <summary>
         /// Gets the prompts manager for the current client.

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -410,6 +410,12 @@ namespace PuppeteerSharp
             return null;
         }
 
+        /// <summary>
+        /// Retrieves the list of extension realms within this frame.
+        /// </summary>
+        /// <returns>A list of <see cref="Realm"/> instances representing extension execution contexts.</returns>
+        public abstract IReadOnlyList<Realm> ExtensionRealms();
+
         internal void ClearDocumentHandle() => _documentTask = null;
 
         internal void OnLoadingStarted() => HasStartedLoading = true;
@@ -467,12 +473,6 @@ namespace PuppeteerSharp
         protected internal virtual void OnDetach()
         {
         }
-
-        /// <summary>
-        /// Retrieves the list of extension realms within this frame.
-        /// </summary>
-        /// <returns>A list of <see cref="Realm"/> instances representing extension execution contexts.</returns>
-        public abstract IReadOnlyList<Realm> ExtensionRealms();
 
         /// <summary>
         /// Gets the prompts manager for the current client.

--- a/lib/PuppeteerSharp/IBrowser.cs
+++ b/lib/PuppeteerSharp/IBrowser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -329,6 +330,14 @@ namespace PuppeteerSharp
         /// <param name="id">The extension ID to uninstall.</param>
         /// <returns>A task that completes when the extension is uninstalled.</returns>
         Task UninstallExtensionAsync(string id);
+
+        /// <summary>
+        /// Returns a map of installed extensions, keyed by extension ID.
+        /// In Chrome, this is only available if the browser was created using pipe mode
+        /// and the <c>--enable-unsafe-extension-debugging</c> flag is set.
+        /// </summary>
+        /// <returns>A task that resolves to a dictionary of extension ID to <see cref="Extension"/>.</returns>
+        Task<IReadOnlyDictionary<string, Extension>> GetExtensionsAsync();
 
         /// <summary>
         /// Creates a Chrome Devtools Protocol session attached to the browser.

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -1578,5 +1578,11 @@ namespace PuppeteerSharp
         /// <param name="bypass">When <c>true</c> bypasses service worker.</param>
         /// <returns>A task that resolves when the message is sent to the browser.</returns>
         Task SetBypassServiceWorkerAsync(bool bypass);
+
+        /// <summary>
+        /// Returns the extension content-script realms associated with the page's main frame.
+        /// </summary>
+        /// <returns>A read-only list of extension <see cref="Realm"/> instances.</returns>
+        IReadOnlyList<Realm> ExtensionRealms();
     }
 }

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -21,12 +21,17 @@ namespace PuppeteerSharp
 
     internal class IsolatedWorld : Realm, IDisposable, IAsyncDisposable
     {
+        internal const string MainWorldId = "__main_world__";
+        internal const string PuppeteerWorldId = "__puppeteer_utility_world__";
+
         private readonly ILogger _logger;
         private readonly List<string> _contextBindings = new();
         private readonly TaskQueue _bindingQueue = new();
         private bool _detached;
         private TaskCompletionSource<ExecutionContext> _contextResolveTaskWrapper = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private ExecutionContext _context;
+        private string _worldId;
+        private string _origin;
 
         public IsolatedWorld(
             Frame frame,
@@ -37,10 +42,52 @@ namespace PuppeteerSharp
             Frame = frame;
             Worker = worker;
             IsMainWorld = isMainWorld;
+            _worldId = isMainWorld ? MainWorldId : PuppeteerWorldId;
             _logger = Client.LoggerFactory.CreateLogger<IsolatedWorld>();
 
             _detached = false;
             FrameUpdated();
+        }
+
+        /// <inheritdoc/>
+        public override string Origin => _origin;
+
+        public void Dispose()
+        {
+            _bindingQueue.Dispose();
+            var context = _context;
+            _context = null;
+            context?.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _bindingQueue.DisposeAsync().ConfigureAwait(false);
+            var context = _context;
+            _context = null;
+            if (context != null)
+            {
+                await context.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override async Task<Extension> ExtensionAsync()
+        {
+            if (Worker != null)
+            {
+                throw new PuppeteerException("Unable to get extension from a worker Realm.");
+            }
+
+            if (_worldId == MainWorldId || _worldId == PuppeteerWorldId)
+            {
+                return null;
+            }
+
+            // _worldId is the extension ID for extension worlds
+            var extensions = await ((IPage)((CdpFrame)Frame).FrameManager.Page).Browser.GetExtensionsAsync().ConfigureAwait(false);
+            extensions.TryGetValue(_worldId, out var extension);
+            return extension;
         }
 
         /// <summary>
@@ -62,26 +109,11 @@ namespace PuppeteerSharp
 
         private WebWorker Worker { get; }
 
-        public void Dispose()
-        {
-            _bindingQueue.Dispose();
-            var context = _context;
-            _context = null;
-            context?.Dispose();
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            await _bindingQueue.DisposeAsync().ConfigureAwait(false);
-            var context = _context;
-            _context = null;
-            if (context != null)
-            {
-                await context.DisposeAsync().ConfigureAwait(false);
-            }
-        }
-
         internal void FrameUpdated() => Client.MessageReceived += Client_MessageReceived;
+
+        internal void SetOrigin(string origin) => _origin = origin;
+
+        internal void SetWorldId(string worldId) => _worldId = worldId;
 
         internal async Task AddBindingToContextAsync(ExecutionContext context, string name)
         {

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -52,6 +52,25 @@ namespace PuppeteerSharp
         /// <inheritdoc/>
         public override string Origin => _origin;
 
+        /// <summary>
+        /// This property is not upstream. It's helpful for debugging.
+        /// </summary>
+        internal bool IsMainWorld { get; }
+
+        internal Frame Frame { get; }
+
+        internal ICDPSession Client => Frame?.Client ?? Worker?.Client;
+
+        internal CdpCDPSession CdpCDPSession => (CdpCDPSession)Client;
+
+        internal bool HasContext => _contextResolveTaskWrapper?.Task.IsCompleted == true;
+
+        internal ConcurrentDictionary<string, Binding> Bindings { get; } = new();
+
+        internal override IEnvironment Environment => (IEnvironment)Frame ?? Worker;
+
+        private WebWorker Worker { get; }
+
         public void Dispose()
         {
             _bindingQueue.Dispose();
@@ -89,25 +108,6 @@ namespace PuppeteerSharp
             extensions.TryGetValue(_worldId, out var extension);
             return extension;
         }
-
-        /// <summary>
-        /// This property is not upstream. It's helpful for debugging.
-        /// </summary>
-        internal bool IsMainWorld { get; }
-
-        internal Frame Frame { get; }
-
-        internal ICDPSession Client => Frame?.Client ?? Worker?.Client;
-
-        internal CdpCDPSession CdpCDPSession => (CdpCDPSession)Client;
-
-        internal bool HasContext => _contextResolveTaskWrapper?.Task.IsCompleted == true;
-
-        internal ConcurrentDictionary<string, Binding> Bindings { get; } = new();
-
-        internal override IEnvironment Environment => (IEnvironment)Frame ?? Worker;
-
-        private WebWorker Worker { get; }
 
         internal void FrameUpdated() => Client.MessageReceived += Client_MessageReceived;
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -898,6 +898,13 @@ namespace PuppeteerSharp
         /// <inheritdoc />
         public abstract Task SetBypassServiceWorkerAsync(bool bypass);
 
+        /// <summary>
+        /// Retrieves the list of extension realms inside the main frame of this page.
+        /// Shortcut for <c>MainFrame.ExtensionRealms()</c>.
+        /// </summary>
+        /// <returns>A list of <see cref="Realm"/> instances representing extension execution contexts.</returns>
+        public abstract IReadOnlyList<Realm> ExtensionRealms();
+
         internal void OnPopup(IPage popupPage) => Popup?.Invoke(this, new PopupEventArgs { PopupPage = popupPage });
 
         /// <summary>

--- a/lib/PuppeteerSharp/Realm.cs
+++ b/lib/PuppeteerSharp/Realm.cs
@@ -3,13 +3,32 @@ using System.Threading.Tasks;
 
 namespace PuppeteerSharp
 {
-    internal abstract class Realm(TimeoutSettings timeoutSettings)
+    /// <summary>
+    /// Represents an execution context (realm) within a frame or worker.
+    /// </summary>
+    public abstract class Realm(TimeoutSettings timeoutSettings)
     {
+        /// <summary>
+        /// Gets the origin that created this Realm.
+        /// For example, a Chrome extension content script would have an origin like
+        /// <c>chrome-extension://&lt;extension-id&gt;</c>.
+        /// </summary>
+        /// <remarks>This API is experimental.</remarks>
+        public abstract string Origin { get; }
+
         internal TaskManager TaskManager { get; } = new();
 
         internal TimeoutSettings TimeoutSettings { get; } = timeoutSettings;
 
         internal abstract IEnvironment Environment { get; }
+
+        /// <summary>
+        /// Returns the extension that created this realm, if the realm was created from an Extension.
+        /// An example of this is an extension content script running on a page.
+        /// </summary>
+        /// <returns>A task that resolves to the <see cref="Extension"/> that created this realm, or <c>null</c>.</returns>
+        /// <remarks>This API is experimental.</remarks>
+        public abstract Task<Extension> ExtensionAsync();
 
         internal abstract Task<IJSHandle> AdoptHandleAsync(IJSHandle handle);
 


### PR DESCRIPTION
Implements changes from https://github.com/puppeteer/puppeteer/pull/14824

## Summary
- Adds `ExtensionRealms()` to `Page` and `Frame` returning extension content-script realms
- Adds `Origin` property and `ExtensionAsync()` to `Realm`
- Tracks extension worlds in `CdpFrame` via `ExtensionWorlds` dictionary
- `FrameManager` detects extension origins and routes them to extension worlds
- BiDi throws `NotSupportedException` for unsupported methods
- Adds `RealmsTests` with 3 tests matching upstream `cdp/realms.spec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)