### PR TITLE
feat: roll Chrome to 147.0.7727.24 (#14797)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "146.0.7680.153";
+        public static string DefaultBuildId => "147.0.7727.24";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
## Summary

Implements changes from upstream Puppeteer PR [#14797](https://github.com/puppeteer/puppeteer/pull/14797).

- Updates default Chrome build ID from `146.0.7680.153` to `147.0.7727.24` in `Chrome.DefaultBuildId`
- The `chromium-bidi` version remains unchanged at `14.0.0` (no update needed)
- The `devtools-protocol` version bump (`0.0.1581282` → `0.0.1595872`) is an npm dependency with no equivalent in PuppeteerSharp

## Changes

- `lib/PuppeteerSharp/BrowserData/Chrome.cs`: Updated `DefaultBuildId` to `147.0.7727.24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)