### PR TITLE
Implement upstream PR #14784: console event on WebWorkers

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -3934,6 +3934,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[worker.spec] Workers console should return remote objects",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "BiDi does not support getting a Handle for log args"
+  },
+  {
     "testIdPattern": "[worker.spec] Workers should report errors",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Helpers;
@@ -9,6 +10,14 @@ namespace PuppeteerSharp.Tests.WorkerTests
     {
         public PageWorkerTests() : base()
         {
+        }
+
+        private async Task<WebWorker> CreateWorkerAsync()
+        {
+            var workerCreatedTcs = new TaskCompletionSource<WebWorker>();
+            Page.WorkerCreated += (_, e) => workerCreatedTcs.TrySetResult(e.Worker);
+            await Page.EvaluateFunctionAsync("() => new Worker('data:text/javascript,1')");
+            return await workerCreatedTcs.Task;
         }
 
         [Test, PuppeteerTest("worker.spec", "Workers", "Page.workers")]
@@ -132,6 +141,174 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(worker.Url, Does.Contain("worker.js"));
             await worker.CloseAsync();
             Assert.That(await workerClosedTcs.Task, Is.SameAs(worker));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work")]
+        public async Task ConsoleShouldWork()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.log('hello', 5, {foo: 'bar'})");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Text, Does.Contain("hello").And.Contain("5"));
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Log));
+            Assert.That(message.Args, Has.Count.EqualTo(3));
+            Assert.That(await message.Args[0].JsonValueAsync<string>(), Is.EqualTo("hello"));
+            Assert.That(await message.Args[1].JsonValueAsync<int>(), Is.EqualTo(5));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for Error instances")]
+        public async Task ConsoleShouldWorkForErrorInstances()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.log(new Error('test error'))");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Text, Does.Contain("test error").Or.EqualTo("JSHandle@error"));
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Log));
+            Assert.That(message.Args, Has.Count.EqualTo(1));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should return the first line of the error message in text()")]
+        public async Task ConsoleShouldReturnFirstLineOfErrorMessageInText()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.log(new Error('test error\\nsecond line'))");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Text, Does.Contain("test error").Or.EqualTo("JSHandle@error"));
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Log));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.trace")]
+        public async Task ConsoleShouldWorkForConsoleTrace()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.trace('calling console.trace')");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Trace));
+            Assert.That(message.Text, Is.EqualTo("calling console.trace"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.dir")]
+        public async Task ConsoleShouldWorkForConsoleDir()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.dir('calling console.dir')");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Dir));
+            Assert.That(message.Text, Is.EqualTo("calling console.dir"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.warn")]
+        public async Task ConsoleShouldWorkForConsoleWarn()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.warn('calling console.warn')");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Warning));
+            Assert.That(message.Text, Is.EqualTo("calling console.warn"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.error")]
+        public async Task ConsoleShouldWorkForConsoleError()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.error('calling console.error')");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Error));
+            Assert.That(message.Text, Is.EqualTo("calling console.error"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.log with promise")]
+        public async Task ConsoleShouldWorkForConsoleLogWithPromise()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync("() => console.log(Promise.resolve('should not wait until resolved!'))");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Type, Is.EqualTo(ConsoleType.Log));
+            Assert.That(message.Text, Does.Contain("promise").Or.Contain("Promise"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for different console API calls with timing functions")]
+        public async Task ConsoleShouldWorkForTimingFunctions()
+        {
+            var worker = await CreateWorkerAsync();
+            var messages = new List<ConsoleMessage>();
+            worker.Console += (_, e) => messages.Add(e.Message);
+
+            await worker.EvaluateFunctionAsync(@"() => {
+                console.time('calling console.time');
+                console.timeEnd('calling console.time');
+            }");
+
+            Assert.That(messages, Has.Count.EqualTo(1));
+            Assert.That(messages[0].Type, Is.EqualTo(ConsoleType.TimeEnd));
+            Assert.That(messages[0].Text, Does.Contain("calling console.time"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for different console API calls with group functions")]
+        public async Task ConsoleShouldWorkForGroupFunctions()
+        {
+            var worker = await CreateWorkerAsync();
+            var messages = new List<ConsoleMessage>();
+            worker.Console += (_, e) => messages.Add(e.Message);
+
+            await worker.EvaluateFunctionAsync(@"() => {
+                console.group('calling console.group');
+                console.groupEnd();
+            }");
+
+            Assert.That(messages, Has.Count.EqualTo(2));
+            Assert.That(messages[0].Type, Is.EqualTo(ConsoleType.StartGroup));
+            Assert.That(messages[1].Type, Is.EqualTo(ConsoleType.EndGroup));
+            Assert.That(messages[0].Text, Does.Contain("calling console.group"));
+        }
+
+        [Test, PuppeteerTest("worker.spec", "Workers > console", "should return remote objects")]
+        public async Task ConsoleShouldReturnRemoteObjects()
+        {
+            var worker = await CreateWorkerAsync();
+            var consoleTcs = new TaskCompletionSource<ConsoleMessage>();
+            worker.Console += (_, e) => consoleTcs.TrySetResult(e.Message);
+
+            await worker.EvaluateFunctionAsync(@"() => {
+                globalThis.test = 1;
+                console.log(1, 2, 3, globalThis);
+            }");
+
+            var message = await consoleTcs.Task.WithTimeout();
+            Assert.That(message.Text, Does.Contain("1 2 3"));
+            Assert.That(message.Args, Has.Count.EqualTo(4));
         }
 
         [Test, PuppeteerTest("worker.spec", "Workers", "should work with waitForNetworkIdle")]

--- a/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
@@ -143,7 +143,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(await workerClosedTcs.Task, Is.SameAs(worker));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work")]
         public async Task ConsoleShouldWork()
         {
             var worker = await CreateWorkerAsync();
@@ -160,7 +160,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(await message.Args[1].JsonValueAsync<int>(), Is.EqualTo(5));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for Error instances")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for Error instances")]
         public async Task ConsoleShouldWorkForErrorInstances()
         {
             var worker = await CreateWorkerAsync();
@@ -175,7 +175,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Args, Has.Count.EqualTo(1));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should return the first line of the error message in text()")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should return the first line of the error message in text()")]
         public async Task ConsoleShouldReturnFirstLineOfErrorMessageInText()
         {
             var worker = await CreateWorkerAsync();
@@ -189,7 +189,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Type, Is.EqualTo(ConsoleType.Log));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.trace")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for console.trace")]
         public async Task ConsoleShouldWorkForConsoleTrace()
         {
             var worker = await CreateWorkerAsync();
@@ -203,7 +203,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Text, Is.EqualTo("calling console.trace"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.dir")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for console.dir")]
         public async Task ConsoleShouldWorkForConsoleDir()
         {
             var worker = await CreateWorkerAsync();
@@ -217,7 +217,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Text, Is.EqualTo("calling console.dir"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.warn")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for console.warn")]
         public async Task ConsoleShouldWorkForConsoleWarn()
         {
             var worker = await CreateWorkerAsync();
@@ -231,7 +231,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Text, Is.EqualTo("calling console.warn"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.error")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for console.error")]
         public async Task ConsoleShouldWorkForConsoleError()
         {
             var worker = await CreateWorkerAsync();
@@ -245,7 +245,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Text, Is.EqualTo("calling console.error"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for console.log with promise")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for console.log with promise")]
         public async Task ConsoleShouldWorkForConsoleLogWithPromise()
         {
             var worker = await CreateWorkerAsync();
@@ -259,7 +259,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(message.Text, Does.Contain("promise").Or.Contain("Promise"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for different console API calls with timing functions")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for different console API calls with timing functions")]
         public async Task ConsoleShouldWorkForTimingFunctions()
         {
             var worker = await CreateWorkerAsync();
@@ -276,7 +276,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(messages[0].Text, Does.Contain("calling console.time"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should work for different console API calls with group functions")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should work for different console API calls with group functions")]
         public async Task ConsoleShouldWorkForGroupFunctions()
         {
             var worker = await CreateWorkerAsync();
@@ -294,7 +294,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.That(messages[0].Text, Does.Contain("calling console.group"));
         }
 
-        [Test, PuppeteerTest("worker.spec", "Workers > console", "should return remote objects")]
+        [Test, PuppeteerTest("worker.spec", "Workers console", "should return remote objects")]
         public async Task ConsoleShouldReturnRemoteObjects()
         {
             var worker = await CreateWorkerAsync();

--- a/lib/PuppeteerSharp/Bidi/BidiWorkerRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiWorkerRealm.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using PuppeteerSharp.Bidi.Core;
 using PuppeteerSharp.Helpers;
+using WebDriverBiDi.Script;
 
 namespace PuppeteerSharp.Bidi;
 
@@ -93,9 +94,65 @@ internal class BidiWorkerRealm : BidiRealm
         _realm.Log += OnLog;
     }
 
+    private static ConsoleType ConvertConsoleMessageLevel(string method) => method switch
+    {
+        "group" => ConsoleType.StartGroup,
+        "groupCollapsed" => ConsoleType.StartGroupCollapsed,
+        "groupEnd" => ConsoleType.EndGroup,
+        "log" => ConsoleType.Log,
+        "debug" => ConsoleType.Debug,
+        "info" => ConsoleType.Info,
+        "error" => ConsoleType.Error,
+        "warn" => ConsoleType.Warning,
+        "dir" => ConsoleType.Dir,
+        "dirxml" => ConsoleType.Dirxml,
+        "table" => ConsoleType.Table,
+        "trace" => ConsoleType.Trace,
+        "clear" => ConsoleType.Clear,
+        "assert" => ConsoleType.Assert,
+        "profile" => ConsoleType.Profile,
+        "profileEnd" => ConsoleType.ProfileEnd,
+        "count" => ConsoleType.Count,
+        "timeEnd" => ConsoleType.TimeEnd,
+        "verbose" => ConsoleType.Verbose,
+        "timeStamp" => ConsoleType.Timestamp,
+        _ => ConsoleType.Log,
+    };
+
+    private static ConsoleMessageLocation GetStackTraceLocation(StackTrace stackTrace)
+    {
+        if (stackTrace?.CallFrames?.Count > 0)
+        {
+            var callFrame = stackTrace.CallFrames[0];
+            return new ConsoleMessageLocation
+            {
+                URL = callFrame.Url,
+                LineNumber = (int)callFrame.LineNumber,
+                ColumnNumber = (int)callFrame.ColumnNumber,
+            };
+        }
+
+        return null;
+    }
+
+    private static IList<ConsoleMessageLocation> GetStackTrace(StackTrace stackTrace)
+    {
+        if (stackTrace?.CallFrames?.Count > 0)
+        {
+            return stackTrace.CallFrames.Select(callFrame => new ConsoleMessageLocation
+            {
+                URL = callFrame.Url,
+                LineNumber = (int)callFrame.LineNumber,
+                ColumnNumber = (int)callFrame.ColumnNumber,
+            }).ToList();
+        }
+
+        return [];
+    }
+
     private void OnLog(object sender, WebDriverBiDi.Log.EntryAddedEventArgs args)
     {
-        if (_worker.Console == null || args.Type != "console")
+        if (args.Type != "console")
         {
             return;
         }
@@ -124,62 +181,6 @@ internal class BidiWorkerRealm : BidiRealm
         var stackTrace = GetStackTrace(args.StackTrace);
         var consoleMessage = new ConsoleMessage(ConvertConsoleMessageLevel(args.Method), text, handleArgs, location, stackTrace);
         _worker.OnConsole(new ConsoleEventArgs(consoleMessage));
-    }
-
-    private static ConsoleType ConvertConsoleMessageLevel(string method) => method switch
-    {
-        "group" => ConsoleType.StartGroup,
-        "groupCollapsed" => ConsoleType.StartGroupCollapsed,
-        "groupEnd" => ConsoleType.EndGroup,
-        "log" => ConsoleType.Log,
-        "debug" => ConsoleType.Debug,
-        "info" => ConsoleType.Info,
-        "error" => ConsoleType.Error,
-        "warn" => ConsoleType.Warning,
-        "dir" => ConsoleType.Dir,
-        "dirxml" => ConsoleType.Dirxml,
-        "table" => ConsoleType.Table,
-        "trace" => ConsoleType.Trace,
-        "clear" => ConsoleType.Clear,
-        "assert" => ConsoleType.Assert,
-        "profile" => ConsoleType.Profile,
-        "profileEnd" => ConsoleType.ProfileEnd,
-        "count" => ConsoleType.Count,
-        "timeEnd" => ConsoleType.TimeEnd,
-        "verbose" => ConsoleType.Verbose,
-        "timeStamp" => ConsoleType.Timestamp,
-        _ => ConsoleType.Log,
-    };
-
-    private static ConsoleMessageLocation GetStackTraceLocation(WebDriverBiDi.Script.StackTrace stackTrace)
-    {
-        if (stackTrace?.CallFrames?.Count > 0)
-        {
-            var callFrame = stackTrace.CallFrames[0];
-            return new ConsoleMessageLocation
-            {
-                URL = callFrame.Url,
-                LineNumber = (int)callFrame.LineNumber,
-                ColumnNumber = (int)callFrame.ColumnNumber,
-            };
-        }
-
-        return null;
-    }
-
-    private static IList<ConsoleMessageLocation> GetStackTrace(WebDriverBiDi.Script.StackTrace stackTrace)
-    {
-        if (stackTrace?.CallFrames?.Count > 0)
-        {
-            return stackTrace.CallFrames.Select(callFrame => new ConsoleMessageLocation
-            {
-                URL = callFrame.Url,
-                LineNumber = (int)callFrame.LineNumber,
-                ColumnNumber = (int)callFrame.ColumnNumber,
-            }).ToList();
-        }
-
-        return [];
     }
 }
 

--- a/lib/PuppeteerSharp/Bidi/BidiWorkerRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiWorkerRealm.cs
@@ -22,6 +22,8 @@
 
 #if !CDP_ONLY
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using PuppeteerSharp.Bidi.Core;
 using PuppeteerSharp.Helpers;
@@ -85,10 +87,99 @@ internal class BidiWorkerRealm : BidiRealm
         _realm.Destroyed += (sender, args) => Dispose();
         _realm.Updated += (sender, args) =>
         {
-            // Reset PuppeteerUtil when the realm is updated
             _puppeteerUtil = null;
             TaskManager.RerunAll();
         };
+        _realm.Log += OnLog;
+    }
+
+    private void OnLog(object sender, WebDriverBiDi.Log.EntryAddedEventArgs args)
+    {
+        if (_worker.Console == null || args.Type != "console")
+        {
+            return;
+        }
+
+        var handleArgs = args.Arguments?.Select(arg => (IJSHandle)CreateHandle(arg)).ToArray() ?? [];
+
+        var logEntryText = args.Text;
+        var text = string.Join(
+            " ",
+            handleArgs.Select(arg =>
+            {
+                if (arg is BidiJSHandle { IsPrimitiveValue: true } jsHandle)
+                {
+                    return BidiDeserializer.Deserialize(jsHandle.RemoteValue);
+                }
+
+                if (arg is BidiJSHandle { RemoteValue.Type: RemoteValueType.Error } && !string.IsNullOrEmpty(logEntryText))
+                {
+                    return (object)logEntryText.Split('\n')[0];
+                }
+
+                return arg.ToString();
+            })).Trim();
+
+        var location = GetStackTraceLocation(args.StackTrace);
+        var stackTrace = GetStackTrace(args.StackTrace);
+        var consoleMessage = new ConsoleMessage(ConvertConsoleMessageLevel(args.Method), text, handleArgs, location, stackTrace);
+        _worker.OnConsole(new ConsoleEventArgs(consoleMessage));
+    }
+
+    private static ConsoleType ConvertConsoleMessageLevel(string method) => method switch
+    {
+        "group" => ConsoleType.StartGroup,
+        "groupCollapsed" => ConsoleType.StartGroupCollapsed,
+        "groupEnd" => ConsoleType.EndGroup,
+        "log" => ConsoleType.Log,
+        "debug" => ConsoleType.Debug,
+        "info" => ConsoleType.Info,
+        "error" => ConsoleType.Error,
+        "warn" => ConsoleType.Warning,
+        "dir" => ConsoleType.Dir,
+        "dirxml" => ConsoleType.Dirxml,
+        "table" => ConsoleType.Table,
+        "trace" => ConsoleType.Trace,
+        "clear" => ConsoleType.Clear,
+        "assert" => ConsoleType.Assert,
+        "profile" => ConsoleType.Profile,
+        "profileEnd" => ConsoleType.ProfileEnd,
+        "count" => ConsoleType.Count,
+        "timeEnd" => ConsoleType.TimeEnd,
+        "verbose" => ConsoleType.Verbose,
+        "timeStamp" => ConsoleType.Timestamp,
+        _ => ConsoleType.Log,
+    };
+
+    private static ConsoleMessageLocation GetStackTraceLocation(WebDriverBiDi.Script.StackTrace stackTrace)
+    {
+        if (stackTrace?.CallFrames?.Count > 0)
+        {
+            var callFrame = stackTrace.CallFrames[0];
+            return new ConsoleMessageLocation
+            {
+                URL = callFrame.Url,
+                LineNumber = (int)callFrame.LineNumber,
+                ColumnNumber = (int)callFrame.ColumnNumber,
+            };
+        }
+
+        return null;
+    }
+
+    private static IList<ConsoleMessageLocation> GetStackTrace(WebDriverBiDi.Script.StackTrace stackTrace)
+    {
+        if (stackTrace?.CallFrames?.Count > 0)
+        {
+            return stackTrace.CallFrames.Select(callFrame => new ConsoleMessageLocation
+            {
+                URL = callFrame.Url,
+                LineNumber = (int)callFrame.LineNumber,
+                ColumnNumber = (int)callFrame.ColumnNumber,
+            }).ToList();
+        }
+
+        return [];
     }
 }
 

--- a/lib/PuppeteerSharp/Bidi/Core/DedicatedWorkerRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/DedicatedWorkerRealm.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using PuppeteerSharp.Helpers;
+using WebDriverBiDi.Log;
 using WebDriverBiDi.Script;
 
 namespace PuppeteerSharp.Bidi.Core;
@@ -42,6 +43,8 @@ internal class DedicatedWorkerRealm : Realm, IDedicatedWorkerOwnerRealm
     }
 
     public event EventHandler<WorkerRealmEventArgs> Worker;
+
+    public event EventHandler<EntryAddedEventArgs> Log;
 
     public override Session Session => _owners.FirstOrDefault()?.Session;
 
@@ -64,11 +67,17 @@ internal class DedicatedWorkerRealm : Realm, IDedicatedWorkerOwnerRealm
 
     private void Initialize()
     {
-        // Listen to realm destruction
         Session.Driver.Script.OnRealmDestroyed.AddObserver(OnRealmDestroyed);
-
-        // Listen to nested worker creation
         Session.Driver.Script.OnRealmCreated.AddObserver(OnDedicatedRealmCreated);
+        Session.LogEntryAdded += OnLogEntryAdded;
+    }
+
+    private void OnLogEntryAdded(object sender, EntryAddedEventArgs args)
+    {
+        if (args.Source.RealmId == Id)
+        {
+            Log?.Invoke(this, args);
+        }
     }
 
     private void OnRealmDestroyed(RealmDestroyedEventArgs args)

--- a/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
@@ -21,10 +21,12 @@
 //  * SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Cdp;
@@ -160,11 +162,45 @@ public class CdpWebWorker : WebWorker
     private async Task OnConsoleAPICalledAsync(MessageEventArgs e)
     {
         var consoleData = e.MessageData.ToObject<PageConsoleResponse>();
-        await _consoleAPICalled(
-            consoleData.Type,
-            consoleData.Args.Select(i => new CdpJSHandle(World, i)).ToArray(),
-            consoleData.StackTrace)
-                .ConfigureAwait(false);
+        var handles = consoleData.Args.Select(i => new CdpJSHandle(World, i)).ToArray<IJSHandle>();
+
+        if (Console != null)
+        {
+            var tokens = handles.Select(i =>
+            {
+                var handle = (ICdpHandle)i;
+                if (handle.RemoteObject.Subtype == RemoteObjectSubtype.Error && !string.IsNullOrEmpty(handle.RemoteObject.Description))
+                {
+                    return handle.RemoteObject.Description.Split('\n')[0];
+                }
+
+                return handle.RemoteObject.ObjectId != null || handle.RemoteObject.Type == RemoteObjectType.Object
+                    ? i.ToString()
+                    : RemoteObjectHelper.ValueFromRemoteObject<object>(handle.RemoteObject)?.ToString() ?? "null";
+            });
+
+            var location = new ConsoleMessageLocation();
+            var stackTraceLocations = new List<ConsoleMessageLocation>();
+            if (consoleData.StackTrace?.CallFrames?.Length > 0)
+            {
+                foreach (var callFrame in consoleData.StackTrace.CallFrames)
+                {
+                    stackTraceLocations.Add(new ConsoleMessageLocation
+                    {
+                        URL = callFrame.URL,
+                        LineNumber = callFrame.LineNumber,
+                        ColumnNumber = callFrame.ColumnNumber,
+                    });
+                }
+
+                location = stackTraceLocations[0];
+            }
+
+            var consoleMessage = new ConsoleMessage(consoleData.Type, string.Join(" ", tokens), handles, location, stackTraceLocations);
+            OnConsole(new ConsoleEventArgs(consoleMessage));
+        }
+
+        await _consoleAPICalled(consoleData.Type, handles, consoleData.StackTrace).ConfigureAwait(false);
     }
 
     private void OnExecutionContextCreated(RuntimeExecutionContextCreatedResponse e)

--- a/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
@@ -164,41 +164,38 @@ public class CdpWebWorker : WebWorker
         var consoleData = e.MessageData.ToObject<PageConsoleResponse>();
         var handles = consoleData.Args.Select(i => new CdpJSHandle(World, i)).ToArray<IJSHandle>();
 
-        if (Console != null)
+        var tokens = handles.Select(i =>
         {
-            var tokens = handles.Select(i =>
+            var handle = (ICdpHandle)i;
+            if (handle.RemoteObject.Subtype == RemoteObjectSubtype.Error && !string.IsNullOrEmpty(handle.RemoteObject.Description))
             {
-                var handle = (ICdpHandle)i;
-                if (handle.RemoteObject.Subtype == RemoteObjectSubtype.Error && !string.IsNullOrEmpty(handle.RemoteObject.Description))
-                {
-                    return handle.RemoteObject.Description.Split('\n')[0];
-                }
-
-                return handle.RemoteObject.ObjectId != null || handle.RemoteObject.Type == RemoteObjectType.Object
-                    ? i.ToString()
-                    : RemoteObjectHelper.ValueFromRemoteObject<object>(handle.RemoteObject)?.ToString() ?? "null";
-            });
-
-            var location = new ConsoleMessageLocation();
-            var stackTraceLocations = new List<ConsoleMessageLocation>();
-            if (consoleData.StackTrace?.CallFrames?.Length > 0)
-            {
-                foreach (var callFrame in consoleData.StackTrace.CallFrames)
-                {
-                    stackTraceLocations.Add(new ConsoleMessageLocation
-                    {
-                        URL = callFrame.URL,
-                        LineNumber = callFrame.LineNumber,
-                        ColumnNumber = callFrame.ColumnNumber,
-                    });
-                }
-
-                location = stackTraceLocations[0];
+                return handle.RemoteObject.Description.Split('\n')[0];
             }
 
-            var consoleMessage = new ConsoleMessage(consoleData.Type, string.Join(" ", tokens), handles, location, stackTraceLocations);
-            OnConsole(new ConsoleEventArgs(consoleMessage));
+            return handle.RemoteObject.ObjectId != null || handle.RemoteObject.Type == RemoteObjectType.Object
+                ? i.ToString()
+                : RemoteObjectHelper.ValueFromRemoteObject<object>(handle.RemoteObject)?.ToString() ?? "null";
+        });
+
+        var location = new ConsoleMessageLocation();
+        var stackTraceLocations = new List<ConsoleMessageLocation>();
+        if (consoleData.StackTrace?.CallFrames?.Length > 0)
+        {
+            foreach (var callFrame in consoleData.StackTrace.CallFrames)
+            {
+                stackTraceLocations.Add(new ConsoleMessageLocation
+                {
+                    URL = callFrame.URL,
+                    LineNumber = callFrame.LineNumber,
+                    ColumnNumber = callFrame.ColumnNumber,
+                });
+            }
+
+            location = stackTraceLocations[0];
         }
+
+        var consoleMessage = new ConsoleMessage(consoleData.Type, string.Join(" ", tokens), handles, location, stackTraceLocations);
+        OnConsole(new ConsoleEventArgs(consoleMessage));
 
         await _consoleAPICalled(consoleData.Type, handles, consoleData.StackTrace).ConfigureAwait(false);
     }

--- a/lib/PuppeteerSharp/WebWorker.cs
+++ b/lib/PuppeteerSharp/WebWorker.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using System;
 using System.Threading.Tasks;
 
 namespace PuppeteerSharp
@@ -25,6 +25,11 @@ namespace PuppeteerSharp
         {
             Url = url;
         }
+
+        /// <summary>
+        /// Fired when the worker calls a console API method.
+        /// </summary>
+        public event EventHandler<ConsoleEventArgs> Console;
 
         /// <summary>
         /// Gets the Worker URL.
@@ -101,5 +106,7 @@ namespace PuppeteerSharp
         public abstract Task CloseAsync();
 
         internal virtual Realm GetMainRealm() => World;
+
+        internal void OnConsole(ConsoleEventArgs e) => Console?.Invoke(this, e);
     }
 }


### PR DESCRIPTION
Implements changes from https://github.com/puppeteer/puppeteer/pull/14784

## Summary
- Adds `Console` event (`EventHandler<ConsoleEventArgs>`) to `WebWorker`
- `CdpWebWorker`: fires `Console` on worker when console API is called
- `BidiWorkerRealm`: subscribes to `DedicatedWorkerRealm.Log` and fires `Console`
- `DedicatedWorkerRealm`: adds `Log` event filtered by realm ID from `Session.LogEntryAdded`
- Adds 11 tests under `Workers > console` matching upstream spec
- Adds upstream expectation: BiDi FAIL for "should return remote objects"

🤖 Generated with [Claude Code](https://claude.com/claude-code)