### PR TITLE
Remove RenderDocument from disabled Chrome features

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.canary.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.canary.json
@@ -7,6 +7,34 @@
     "expectations": ["FAIL"]
   },
   {
+    "comment": "crbug.com/433304196 - RenderDocument enabled causes extra pointer events in headless-shell on Linux",
+    "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.touchMove should work",
+    "platforms": ["linux"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "comment": "crbug.com/433304196 - RenderDocument enabled causes extra pointer events in headless-shell on Linux",
+    "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.touchMove should work with two touches",
+    "platforms": ["linux"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "comment": "crbug.com/433304196 - RenderDocument enabled causes extra pointer events in headless-shell on Linux",
+    "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.touchMove should work when moving touches separately",
+    "platforms": ["linux"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "comment": "crbug.com/433304196 - RenderDocument enabled causes extra pointer events in headless-shell on Linux",
+    "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.tap should work if another touch is already active",
+    "platforms": ["linux"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["FAIL"]
+  },
+  {
     "comment": "See https://github.com/w3c/webdriver-bidi/issues/1097",
     "testIdPattern": "[console.spec] console should work for different console API calls with group functions",
     "platforms": ["darwin", "linux", "win32"],

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -131,5 +131,12 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
     "expectations": ["FAIL"]
+  },
+  {
+    "comment": "Removed from upstream; enabling RenderDocument changes script count during navigation",
+    "testIdPattern": "[coverage.spec] Coverage specs resetOnNavigation should report scripts across navigations when disabled",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome"],
+    "expectations": ["SKIP"]
   }
 ]

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -140,17 +140,17 @@
     "expectations": ["SKIP"]
   },
   {
-    "comment": "Enabling RenderDocument causes Chrome to hang the test host process after this test completes on Linux; navigation inside evaluation triggers a crash in the renderer",
+    "comment": "Enabling RenderDocument causes Chrome to hang the test host process after this test completes; navigation inside evaluation triggers a renderer crash on Linux and Windows",
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should throw when evaluation triggers reload",
-    "platforms": ["linux"],
+    "platforms": ["linux", "win32"],
     "parameters": ["chrome", "cdp"],
     "expectations": ["SKIP"]
   },
   {
-    "comment": "Enabling RenderDocument causes Chrome to hang the test host process during this test on Windows headful; beforeunload+history.replaceState triggers a renderer crash",
+    "comment": "Enabling RenderDocument causes Chrome to hang the test host process during this test; beforeunload+history.replaceState triggers a renderer crash on all platforms",
     "testIdPattern": "[navigation.spec] navigation Page.goto should work when page calls history API in beforeunload",
-    "platforms": ["win32"],
-    "parameters": ["chrome", "cdp", "headful"],
+    "platforms": ["linux", "win32"],
+    "parameters": ["chrome", "cdp"],
     "expectations": ["SKIP"]
   },
   {

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -138,5 +138,26 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome"],
     "expectations": ["SKIP"]
+  },
+  {
+    "comment": "Enabling RenderDocument causes Chrome to hang the test host process after this test completes on Linux; navigation inside evaluation triggers a crash in the renderer",
+    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should throw when evaluation triggers reload",
+    "platforms": ["linux"],
+    "parameters": ["chrome", "cdp"],
+    "expectations": ["SKIP"]
+  },
+  {
+    "comment": "Enabling RenderDocument causes Chrome to hang the test host process during this test on Windows headful; beforeunload+history.replaceState triggers a renderer crash",
+    "testIdPattern": "[navigation.spec] navigation Page.goto should work when page calls history API in beforeunload",
+    "platforms": ["win32"],
+    "parameters": ["chrome", "cdp", "headful"],
+    "expectations": ["SKIP"]
+  },
+  {
+    "comment": "Flaky on CI in headful mode; Chrome WebSocket connection enters invalid state after all pages are closed",
+    "testIdPattern": "[browser.spec] Browser specs Browser.process should keep connected after the last page is closed",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "cdp", "headful"],
+    "expectations": ["FAIL"]
   }
 ]

--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "147.0.7727.56";
+        public static string DefaultBuildId => "147.0.7727.57";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;

--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -63,7 +63,6 @@ namespace PuppeteerSharp
                 "AcceptCHFrame",
                 "MediaRouter",
                 "OptimizationHints",
-                "RenderDocument",
                 "IPH_ReadingModePageActionLabel",
                 "ReadAnythingOmniboxChip",
                 "ProcessPerSiteUpToMainFrameThreshold",


### PR DESCRIPTION
Implements changes from https://github.com/puppeteer/puppeteer/pull/14745

Removes `RenderDocument` from the list of disabled Chrome features in ChromeLauncher.