### PR TITLE
Implement upstream PR #14862: Target.AsPageAsync returns same Page instance

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiFrameTarget.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiFrameTarget.cs
@@ -52,8 +52,7 @@ internal class BidiFrameTarget : Target
         return Task.FromResult<IPage>(_page);
     }
 
-    public override Task<IPage> AsPageAsync()
-        => Task.FromResult(BidiPage.From((BidiBrowserContext)_frame.Page.BrowserContext, _frame.BrowsingContext) as IPage);
+    public override Task<IPage> AsPageAsync() => Task.FromResult<IPage>(_frame.Page as BidiPage);
 
     public override Task<ICDPSession> CreateCDPSessionAsync() => throw new PuppeteerException("Not supported");
 }

--- a/lib/PuppeteerSharp/Bidi/BidiPageTarget.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPageTarget.cs
@@ -41,10 +41,7 @@ internal class BidiPageTarget(BidiPage page) : Target
 
     public override Task<IPage> PageAsync() => Task.FromResult<IPage>(page);
 
-    public override Task<IPage> AsPageAsync()
-#pragma warning disable CA2000
-        => Task.FromResult(BidiPage.From((BidiBrowserContext)page.BrowserContext, page.BidiMainFrame.BrowsingContext) as IPage);
-#pragma warning restore CA2000
+    public override Task<IPage> AsPageAsync() => Task.FromResult<IPage>(page);
 
     public override Task<ICDPSession> CreateCDPSessionAsync()
         => page.CreateCDPSessionAsync();

--- a/lib/PuppeteerSharp/Cdp/CdpPageTarget.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPageTarget.cs
@@ -30,6 +30,21 @@ namespace PuppeteerSharp.Cdp
         internal Task<Page> PageTask { get; set; }
 
         /// <inheritdoc/>
+        public override async Task<IPage> AsPageAsync()
+        {
+            if (PageTask != null)
+            {
+                var page = await PageTask.ConfigureAwait(false);
+                if (page != null)
+                {
+                    return page;
+                }
+            }
+
+            return await base.AsPageAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public override async Task<IPage> PageAsync()
         {
             if (PageTask == null)


### PR DESCRIPTION
Implements changes from https://github.com/puppeteer/puppeteer/pull/14862

- `BidiPageTarget.AsPageAsync()`: returns cached `page` directly
- `BidiFrameTarget.AsPageAsync()`: returns `_frame.Page` directly  
- `CdpPageTarget.AsPageAsync()`: returns existing page from `PageTask` when available