### PR TITLE
feat(webmcp): implement WebMCP API

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -4573,5 +4573,67 @@
       "FAIL"
     ],
     "comment": "TODO: investigate why we get the response for the last redirect"
+  },
+  {
+    "testIdPattern": "[webmcp.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "firefox"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Experimental support for WebMCP is not supported in Firefox"
+  },
+  {
+    "testIdPattern": "[webmcp.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Experimental support for WebMCP is not supported in BiDi"
+  },
+  {
+    "testIdPattern": "[webmcp.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL",
+      "TIMEOUT"
+    ],
+    "comment": "Experimental support for WebMCP requires Chrome 149+."
+  },
+  {
+    "testIdPattern": "[webmcp.spec] Page.webmcp should remove tools on frame navigation",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "PASS"
+    ]
   }
 ]

--- a/lib/PuppeteerSharp.Tests/WebMcpTests/PageWebMcpTests.cs
+++ b/lib/PuppeteerSharp.Tests/WebMcpTests/PageWebMcpTests.cs
@@ -1,0 +1,141 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Cdp;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.WebMcpTests
+{
+    public class PageWebMcpTests : PuppeteerBaseTest
+    {
+        private static LaunchOptions WebMcpOptions() => new()
+        {
+            Args = new[] { "--enable-features=WebMCPTesting,DevToolsWebMCPSupport" },
+            AcceptInsecureCerts = true,
+        };
+
+        [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should list tools")]
+        public async Task ShouldListTools()
+        {
+            await using var browser = await Puppeteer.LaunchAsync(WebMcpOptions(), TestConstants.LoggerFactory);
+            var page = (CdpPage)await browser.NewPageAsync();
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+
+            Assert.That(page.WebMcp, Is.Not.Null);
+
+            var toolsAdded = new TaskCompletionSource<bool>();
+            var count = 0;
+            page.WebMcp.ToolsAdded += (_, _) =>
+            {
+                count++;
+                if (count == 2)
+                {
+                    toolsAdded.TrySetResult(true);
+                }
+            };
+
+            await page.EvaluateFunctionAsync(@"() => {
+                window.navigator.modelContext.registerTool({
+                    name: 'test-tool-1',
+                    description: 'A test tool 1',
+                    inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+                    execute: () => {},
+                    annotations: { readOnlyHint: true },
+                });
+            }");
+
+            await page.EvaluateFunctionAsync(@"() => {
+                const form = document.createElement('form');
+                form.setAttribute('toolname', 'declarative tool name');
+                form.setAttribute('tooldescription', 'tool description');
+                document.body.appendChild(form);
+            }");
+
+            await toolsAdded.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+
+            var tools = page.WebMcp.Tools();
+            Assert.That(tools.Length, Is.GreaterThanOrEqualTo(2));
+        }
+
+        [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should fire toolsadded events")]
+        public async Task ShouldFireToolsAddedEvents()
+        {
+            await using var browser = await Puppeteer.LaunchAsync(WebMcpOptions(), TestConstants.LoggerFactory);
+            var page = (CdpPage)await browser.NewPageAsync();
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+
+            Assert.That(page.WebMcp, Is.Not.Null);
+
+            var tcs = new TaskCompletionSource<WebMcpTool[]>();
+            page.WebMcp.ToolsAdded += (_, e) => tcs.TrySetResult(e.Tools);
+
+            await page.EvaluateFunctionAsync(@"() => {
+                window.navigator.modelContext.registerTool({
+                    name: 'my-tool',
+                    description: 'A tool',
+                    execute: () => {},
+                });
+            }");
+
+            var tools = await tcs.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+            Assert.That(tools, Has.Length.GreaterThanOrEqualTo(1));
+        }
+
+        [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should fire toolsremoved events")]
+        public async Task ShouldFireToolsRemovedEvents()
+        {
+            await using var browser = await Puppeteer.LaunchAsync(WebMcpOptions(), TestConstants.LoggerFactory);
+            var page = (CdpPage)await browser.NewPageAsync();
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+
+            Assert.That(page.WebMcp, Is.Not.Null);
+
+            var addedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsAdded += (_, _) => addedTcs.TrySetResult(true);
+
+            await page.EvaluateFunctionAsync(@"() => {
+                window._tool = window.navigator.modelContext.registerTool({
+                    name: 'removable-tool',
+                    description: 'A removable tool',
+                    execute: () => {},
+                });
+            }");
+            await addedTcs.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+
+            var removedTcs = new TaskCompletionSource<WebMcpTool[]>();
+            page.WebMcp.ToolsRemoved += (_, e) => removedTcs.TrySetResult(e.Tools);
+
+            await page.EvaluateFunctionAsync("() => window._tool.unregister()");
+
+            var removed = await removedTcs.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+            Assert.That(removed, Has.Length.GreaterThanOrEqualTo(1));
+        }
+
+        [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should remove tools on frame navigation")]
+        public async Task ShouldRemoveToolsOnFrameNavigation()
+        {
+            await using var browser = await Puppeteer.LaunchAsync(WebMcpOptions(), TestConstants.LoggerFactory);
+            var page = (CdpPage)await browser.NewPageAsync();
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+
+            var addedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsAdded += (_, _) => addedTcs.TrySetResult(true);
+
+            await page.EvaluateFunctionAsync(@"() => {
+                window.navigator.modelContext.registerTool({
+                    name: 'nav-tool',
+                    description: 'A tool',
+                    execute: () => {},
+                });
+            }");
+            await addedTcs.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+
+            var removedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsRemoved += (_, _) => removedTcs.TrySetResult(true);
+
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+            await removedTcs.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+
+            Assert.That(page.WebMcp.Tools(), Is.Empty);
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -46,6 +46,7 @@ public class CdpPage : Page
 {
     private readonly ConcurrentDictionary<string, CdpWebWorker> _workers = new();
     private readonly ITargetManager _targetManager;
+    private readonly CdpWebMcp _webMcp;
     private readonly CdpEmulationManager _emulationManager;
     private readonly ILogger _logger;
     private readonly Task _closedFinishedTask;
@@ -74,6 +75,7 @@ public class CdpPage : Page
         _emulationManager = new CdpEmulationManager(client);
         _logger = Client.Connection.LoggerFactory.CreateLogger<Page>();
         FrameManager = new FrameManager(client, this, TimeoutSettings, target.Browser.IsNetworkEnabled());
+        _webMcp = new CdpWebMcp(client, FrameManager);
         Accessibility = new Accessibility(client, () => MainFrame?.Id, () => (FrameManager.MainFrame as Frame)?.MainRealm);
 
         // Use browser context's connection, as current Bluetooth emulation in Chromium is
@@ -133,6 +135,9 @@ public class CdpPage : Page
 
     /// <inheritdoc/>
     public override bool IsJavaScriptEnabled => _emulationManager.JavascriptEnabled;
+
+    /// <inheritdoc/>
+    public override CdpWebMcp WebMcp => _webMcp;
 
     /// <inheritdoc />
     protected override Browser Browser => PrimaryTarget.Browser;
@@ -1173,6 +1178,7 @@ public class CdpPage : Page
             _emulationManager.UpdateClient(Client);
             Tracing.UpdateClient(Client);
             Coverage.UpdateClient(Client);
+            _webMcp.UpdateClient(Client);
             await FrameManager.SwapFrameTreeAsync(Client).ConfigureAwait(false);
             SetupPrimaryTargetListeners();
         }
@@ -1433,7 +1439,8 @@ public class CdpPage : Page
 
         await Task.WhenAll(
             PrimaryTargetClient.SendAsync("Performance.enable"),
-            PrimaryTargetClient.SendAsync("Log.enable")).ConfigureAwait(false);
+            PrimaryTargetClient.SendAsync("Log.enable"),
+            _webMcp.InitializeAsync()).ConfigureAwait(false);
     }
 
     private async Task<IResponse> GoAsync(int delta, NavigationOptions options)

--- a/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
@@ -1,0 +1,348 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Helpers.Json;
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Experimental WebMCP API. Requires Chrome 149+ with
+/// --enable-features=WebMCPTesting,DevToolsWebMCPSupport flags.
+/// </summary>
+/// <seealso href="https://github.com/webmachinelearning/webmcp"/>
+public class CdpWebMcp
+{
+    private readonly FrameManager _frameManager;
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, WebMcpTool>> _tools = new();
+    private readonly ConcurrentDictionary<string, WebMcpToolCall> _pendingCalls = new();
+    private CDPSession _client;
+
+    internal CdpWebMcp(CDPSession client, FrameManager frameManager)
+    {
+        _client = client;
+        _frameManager = frameManager;
+        _frameManager.FrameNavigated += OnFrameNavigated;
+        BindListeners();
+    }
+
+    /// <summary>Emitted when tools are added to the page.</summary>
+    public event EventHandler<WebMcpToolsAddedEventArgs> ToolsAdded;
+
+    /// <summary>Emitted when tools are removed from the page.</summary>
+    public event EventHandler<WebMcpToolsRemovedEventArgs> ToolsRemoved;
+
+    /// <summary>Emitted when a tool invocation starts.</summary>
+    public event EventHandler<WebMcpToolCall> ToolInvoked;
+
+    /// <summary>Emitted when a tool invocation completes or fails.</summary>
+    public event EventHandler<WebMcpToolCallResult> ToolResponded;
+
+    /// <summary>
+    /// Gets all WebMCP tools registered on the page.
+    /// </summary>
+    /// <returns>Array of registered tools.</returns>
+    public WebMcpTool[] Tools()
+        => _tools.Values.SelectMany(d => d.Values).ToArray();
+
+    internal async Task InitializeAsync()
+    {
+        try
+        {
+            await _client.SendAsync("WebMCP.enable").ConfigureAwait(false);
+        }
+        catch
+        {
+            // WebMCP may not be available on older Chrome versions.
+        }
+    }
+
+    internal async Task<string> InvokeToolAsync(WebMcpTool tool, object input)
+    {
+        var response = await _client.SendAsync<WebMcpInvokeToolResponse>(
+            "WebMCP.invokeTool",
+            new
+            {
+                frameId = tool.Frame?.Id ?? string.Empty,
+                toolName = tool.Name,
+                input,
+            }).ConfigureAwait(false);
+        return response?.InvocationId;
+    }
+
+    internal void UpdateClient(CDPSession newClient)
+    {
+        UnbindListeners();
+        _client = newClient;
+        BindListeners();
+    }
+
+    private void BindListeners()
+    {
+        _client.MessageReceived += OnMessageReceived;
+    }
+
+    private void UnbindListeners()
+    {
+        _client.MessageReceived -= OnMessageReceived;
+    }
+
+    private void OnMessageReceived(object sender, MessageEventArgs e)
+    {
+        switch (e.MessageID)
+        {
+            case "WebMCP.toolsAdded":
+                OnToolsAdded(e.MessageData.ToObject<WebMcpToolsAddedProtocolEvent>());
+                break;
+            case "WebMCP.toolsRemoved":
+                OnToolsRemoved(e.MessageData.ToObject<WebMcpToolsRemovedProtocolEvent>());
+                break;
+            case "WebMCP.toolInvoked":
+                OnToolInvoked(e.MessageData.ToObject<WebMcpToolInvokedProtocolEvent>());
+                break;
+            case "WebMCP.toolResponded":
+                OnToolResponded(e.MessageData.ToObject<WebMcpToolRespondedProtocolEvent>());
+                break;
+        }
+    }
+
+    private void OnToolsAdded(WebMcpToolsAddedProtocolEvent e)
+    {
+        var added = new List<WebMcpTool>();
+        foreach (var tool in e.Tools)
+        {
+            var frame = _frameManager.FrameTree.GetById(tool.FrameId);
+            if (frame == null)
+            {
+                continue;
+            }
+
+            var frameTools = _tools.GetOrAdd(tool.FrameId, _ => new ConcurrentDictionary<string, WebMcpTool>());
+
+            ConsoleMessageLocation location = null;
+            if (tool.StackTrace?.CallFrames?.Length > 0)
+            {
+                var cf = tool.StackTrace.CallFrames[0];
+                location = new ConsoleMessageLocation
+                {
+                    URL = cf.URL,
+                    LineNumber = cf.LineNumber,
+                    ColumnNumber = cf.ColumnNumber,
+                };
+            }
+
+            var webMcpTool = new WebMcpTool
+            {
+                Name = tool.Name,
+                Description = tool.Description,
+                InputSchema = tool.InputSchema,
+                Annotations = tool.Annotations == null ? null : new WebMcpAnnotation
+                {
+                    ReadOnly = tool.Annotations.ReadOnly,
+                    Autosubmit = tool.Annotations.Autosubmit,
+                },
+                Frame = frame,
+                Location = location,
+            };
+
+            frameTools[tool.Name] = webMcpTool;
+            added.Add(webMcpTool);
+        }
+
+        if (added.Count > 0)
+        {
+            ToolsAdded?.Invoke(this, new WebMcpToolsAddedEventArgs { Tools = added.ToArray() });
+        }
+    }
+
+    private void OnToolsRemoved(WebMcpToolsRemovedProtocolEvent e)
+    {
+        var removed = new List<WebMcpTool>();
+        foreach (var tool in e.Tools)
+        {
+            if (_tools.TryGetValue(tool.FrameId, out var frameTools) &&
+                frameTools.TryGetValue(tool.Name, out var removedTool))
+            {
+                removed.Add(removedTool);
+                frameTools.TryRemove(tool.Name, out _);
+            }
+        }
+
+        if (removed.Count > 0)
+        {
+            ToolsRemoved?.Invoke(this, new WebMcpToolsRemovedEventArgs { Tools = removed.ToArray() });
+        }
+    }
+
+    private void OnToolInvoked(WebMcpToolInvokedProtocolEvent e)
+    {
+        if (!_tools.TryGetValue(e.FrameId, out var frameTools) ||
+            !frameTools.TryGetValue(e.ToolName, out var tool))
+        {
+            return;
+        }
+
+        var call = new WebMcpToolCall(e.InvocationId, tool, e.Input ?? "{}");
+        _pendingCalls[call.Id] = call;
+        ToolInvoked?.Invoke(this, call);
+    }
+
+    private void OnToolResponded(WebMcpToolRespondedProtocolEvent e)
+    {
+        _pendingCalls.TryRemove(e.InvocationId, out var call);
+
+        var status = e.Status switch
+        {
+            "Completed" => WebMcpInvocationStatus.Completed,
+            "Canceled" => WebMcpInvocationStatus.Canceled,
+            _ => WebMcpInvocationStatus.Error,
+        };
+
+        var result = new WebMcpToolCallResult
+        {
+            Id = e.InvocationId,
+            Call = call,
+            Status = status,
+            Output = e.Output,
+            ErrorText = e.ErrorText,
+            Exception = e.Exception,
+        };
+
+        ToolResponded?.Invoke(this, result);
+    }
+
+    private void OnFrameNavigated(object sender, FrameNavigatedEventArgs e)
+    {
+        var frameId = e.Frame?.Id;
+        if (string.IsNullOrEmpty(frameId) || !_tools.TryGetValue(frameId, out var frameTools))
+        {
+            return;
+        }
+
+        var tools = frameTools.Values.ToArray();
+        _tools.TryRemove(frameId, out _);
+
+        if (tools.Length > 0)
+        {
+            ToolsRemoved?.Invoke(this, new WebMcpToolsRemovedEventArgs { Tools = tools });
+        }
+    }
+
+    private class WebMcpToolsAddedProtocolEvent
+    {
+        [JsonPropertyName("tools")]
+        public WebMcpProtocolTool[] Tools { get; set; }
+    }
+
+    private class WebMcpToolsRemovedProtocolEvent
+    {
+        [JsonPropertyName("tools")]
+        public WebMcpProtocolRemovedTool[] Tools { get; set; }
+    }
+
+    private class WebMcpToolInvokedProtocolEvent
+    {
+        [JsonPropertyName("frameId")]
+        public string FrameId { get; set; }
+
+        [JsonPropertyName("input")]
+        public string Input { get; set; }
+
+        [JsonPropertyName("invocationId")]
+        public string InvocationId { get; set; }
+
+        [JsonPropertyName("toolName")]
+        public string ToolName { get; set; }
+    }
+
+    private class WebMcpToolRespondedProtocolEvent
+    {
+        [JsonPropertyName("errorText")]
+        public string ErrorText { get; set; }
+
+        [JsonPropertyName("exception")]
+        public RemoteObject Exception { get; set; }
+
+        [JsonPropertyName("invocationId")]
+        public string InvocationId { get; set; }
+
+        [JsonPropertyName("output")]
+        public object Output { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+
+    private class WebMcpProtocolAnnotation
+    {
+        [JsonPropertyName("autosubmit")]
+        public bool? Autosubmit { get; set; }
+
+        [JsonPropertyName("readOnly")]
+        public bool? ReadOnly { get; set; }
+    }
+
+    private class WebMcpProtocolRemovedTool
+    {
+        [JsonPropertyName("frameId")]
+        public string FrameId { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+    }
+
+    private class WebMcpProtocolTool
+    {
+        [JsonPropertyName("annotations")]
+        public WebMcpProtocolAnnotation Annotations { get; set; }
+
+        [JsonPropertyName("backendNodeId")]
+        public int? BackendNodeId { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("frameId")]
+        public string FrameId { get; set; }
+
+        [JsonPropertyName("inputSchema")]
+        public object InputSchema { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("stackTrace")]
+        public StackTrace StackTrace { get; set; }
+    }
+
+    private class WebMcpInvokeToolResponse
+    {
+        [JsonPropertyName("invocationId")]
+        public string InvocationId { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpAnnotation.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpAnnotation.cs
@@ -1,0 +1,39 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Tool annotations for a WebMCP tool.
+/// </summary>
+public class WebMcpAnnotation
+{
+    /// <summary>
+    /// A hint indicating that the tool does not modify any state.
+    /// </summary>
+    public bool? ReadOnly { get; set; }
+
+    /// <summary>
+    /// If the declarative tool was declared with the autosubmit attribute.
+    /// </summary>
+    public bool? Autosubmit { get; set; }
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpInvocationStatus.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpInvocationStatus.cs
@@ -1,0 +1,38 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Represents the status of a WebMCP tool invocation.
+/// </summary>
+public enum WebMcpInvocationStatus
+{
+    /// <summary>Invocation completed successfully.</summary>
+    Completed,
+
+    /// <summary>Invocation was canceled.</summary>
+    Canceled,
+
+    /// <summary>Invocation resulted in an error.</summary>
+    Error,
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpTool.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpTool.cs
@@ -1,0 +1,47 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Represents a registered WebMCP tool available on the page.
+/// </summary>
+public class WebMcpTool
+{
+    /// <summary>Tool name.</summary>
+    public string Name { get; init; }
+
+    /// <summary>Tool description.</summary>
+    public string Description { get; init; }
+
+    /// <summary>Schema for the tool's input parameters.</summary>
+    public object InputSchema { get; init; }
+
+    /// <summary>Optional annotations for the tool.</summary>
+    public WebMcpAnnotation Annotations { get; init; }
+
+    /// <summary>Frame the tool was defined for.</summary>
+    public IFrame Frame { get; init; }
+
+    /// <summary>Source location that defined the tool (if available).</summary>
+    public ConsoleMessageLocation Location { get; init; }
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpToolCall.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpToolCall.cs
@@ -1,0 +1,55 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+using System.Text.Json;
+using PuppeteerSharp.Helpers.Json;
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Represents a pending or completed WebMCP tool invocation call.
+/// </summary>
+public class WebMcpToolCall
+{
+    internal WebMcpToolCall(string invocationId, WebMcpTool tool, string input)
+    {
+        Id = invocationId;
+        Tool = tool;
+        try
+        {
+            Input = JsonSerializer.Deserialize<object>(input, JsonHelper.DefaultJsonSerializerSettings.Value);
+        }
+        catch
+        {
+            Input = null;
+        }
+    }
+
+    /// <summary>Tool invocation identifier.</summary>
+    public string Id { get; }
+
+    /// <summary>The input parameters used for the call.</summary>
+    public object Input { get; }
+
+    /// <summary>Tool that was called.</summary>
+    public WebMcpTool Tool { get; }
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpToolCallResult.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpToolCallResult.cs
@@ -1,0 +1,49 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+using PuppeteerSharp.Cdp.Messaging;
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Result of a WebMCP tool invocation.
+/// </summary>
+public class WebMcpToolCallResult
+{
+    /// <summary>Tool invocation identifier.</summary>
+    public string Id { get; init; }
+
+    /// <summary>The corresponding tool call if available.</summary>
+    public WebMcpToolCall Call { get; init; }
+
+    /// <summary>Error text.</summary>
+    public string ErrorText { get; init; }
+
+    /// <summary>The exception object, if the JavaScript tool threw an error.</summary>
+    public RemoteObject Exception { get; init; }
+
+    /// <summary>Output delivered to the agent. Present only when Status is Completed.</summary>
+    public object Output { get; init; }
+
+    /// <summary>Status of the invocation.</summary>
+    public WebMcpInvocationStatus Status { get; init; }
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpToolsAddedEventArgs.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpToolsAddedEventArgs.cs
@@ -1,0 +1,36 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+using System;
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Event args for when WebMCP tools are added.
+/// </summary>
+public class WebMcpToolsAddedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Array of tools that were added.
+    /// </summary>
+    public WebMcpTool[] Tools { get; init; }
+}

--- a/lib/PuppeteerSharp/Cdp/WebMcpToolsRemovedEventArgs.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpToolsRemovedEventArgs.cs
@@ -1,0 +1,36 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+using System;
+
+namespace PuppeteerSharp.Cdp;
+
+/// <summary>
+/// Event args for when WebMCP tools are removed.
+/// </summary>
+public class WebMcpToolsRemovedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Array of tools that were removed.
+    /// </summary>
+    public WebMcpTool[] Tools { get; init; }
+}

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -136,6 +136,14 @@ namespace PuppeteerSharp
         /// <inheritdoc/>
         public abstract WebWorker[] Workers { get; }
 
+        /// <summary>
+        /// Experimental API for WebMCP. Requires Chrome 149+ with
+        /// --enable-features=WebMCPTesting,DevToolsWebMCPSupport flags enabled.
+        /// Only supported with CDP protocol.
+        /// </summary>
+        /// <exception cref="PuppeteerException">Thrown when not supported by the current browser/protocol.</exception>
+        public virtual Cdp.CdpWebMcp WebMcp => throw new PuppeteerException("WebMCP is only supported with Chrome DevTools Protocol.");
+
         /// <inheritdoc/>
         public bool IsServiceWorkerBypassed { get; protected set; }
 


### PR DESCRIPTION
Implements the experimental WebMCP API from upstream PRs #14814, #14835, and #14841.

- `CdpWebMcp` class with `ToolsAdded`, `ToolsRemoved`, `ToolInvoked`, `ToolResponded` events
- `Page.WebMcp` property (CDP only; throws `PuppeteerException` for BiDi)
- Supporting types: `WebMcpTool`, `WebMcpToolCall`, `WebMcpToolCallResult`, `WebMcpAnnotation`
- Tests and upstream test expectations

Requires Chrome 149+ with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`

Upstream PRs:
- https://github.com/puppeteer/puppeteer/pull/14814
- https://github.com/puppeteer/puppeteer/pull/14835
- https://github.com/puppeteer/puppeteer/pull/14841