### PR TITLE
Add FedCM Initiator Type

### DIFF
--- a/lib/PuppeteerSharp/InitiatorType.cs
+++ b/lib/PuppeteerSharp/InitiatorType.cs
@@ -40,4 +40,10 @@ public enum InitiatorType
     /// Other.
     /// </summary>
     Other,
+
+    /// <summary>
+    /// FedCM.
+    /// </summary>
+    [EnumMember(Value = "FedCM")]
+    FedCm,
 }


### PR DESCRIPTION
I started getting json serialization exceptions `Unknown value 'FedCM' for enum InitiatorType` 

Looking at [chrome dev tools protocol ](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-Initiator) it is indeed there.

So, I added it to the enum.

I wasn't sure if we wanted `Other` to be last always or to maintain its numeric order... so I was conservative and put `FedCm` at the end.