### PR TITLE
feat: add Path and Enabled metadata to Extension class

### DIFF
--- a/lib/PuppeteerSharp.Tests/ExtensionsTests/ExtensionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/ExtensionsTests/ExtensionsTests.cs
@@ -41,5 +41,35 @@ namespace PuppeteerSharp.Tests.ExtensionsTests
             var worker = await serviceWorkerTarget.WorkerAsync();
             Assert.That(await worker.EvaluateFunctionAsync<int>("() => globalThis.MAGIC"), Is.EqualTo(42));
         }
+
+        [Test, PuppeteerTest("extensions.spec", "extensions", "should list extensions and their properties")]
+        public async Task ShouldListExtensionsAndTheirProperties()
+        {
+            var options = new LaunchOptions
+            {
+                Headless = false,
+                EnableExtensions = true,
+                Pipe = true,
+            };
+
+            await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+
+            var extensionId = await browser.InstallExtensionAsync(_extensionPath);
+
+            await browser.WaitForTargetAsync(t =>
+                t.Url.Contains(extensionId) && t.Type == TargetType.ServiceWorker);
+
+            var extensions = await browser.GetExtensionsAsync();
+            var extension = extensions[extensionId];
+
+            Assert.That(extension, Is.Not.Null);
+            Assert.That(extension.Name, Is.EqualTo("Simple extension"));
+            Assert.That(extension.Version, Is.EqualTo("0.1"));
+            Assert.That(extension.Path, Is.EqualTo(_extensionPath));
+            Assert.That(extension.Enabled, Is.True);
+            Assert.That(extension.Id, Is.EqualTo(extensionId));
+
+            await browser.UninstallExtensionAsync(extensionId);
+        }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -238,7 +238,7 @@ public class CdpBrowser : Browser
             }
             else
             {
-                extensionsMap[info.Id] = new CdpExtension(info.Id, info.Version, info.Name, this);
+                extensionsMap[info.Id] = new CdpExtension(info.Id, info.Version, info.Name, info.Path, info.Enabled, this);
             }
         }
 

--- a/lib/PuppeteerSharp/Cdp/CdpExtension.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpExtension.cs
@@ -12,8 +12,8 @@ internal class CdpExtension : Extension
 {
     private readonly CdpBrowser _browser;
 
-    internal CdpExtension(string id, string version, string name, CdpBrowser browser)
-        : base(id, version, name)
+    internal CdpExtension(string id, string version, string name, string path, bool enabled, CdpBrowser browser)
+        : base(id, version, name, path, enabled)
     {
         _browser = browser;
     }

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionInfo.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionInfo.cs
@@ -7,5 +7,9 @@ namespace PuppeteerSharp.Cdp.Messaging
         public string Version { get; set; }
 
         public string Name { get; set; }
+
+        public string Path { get; set; }
+
+        public bool Enabled { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Extension.cs
+++ b/lib/PuppeteerSharp/Extension.cs
@@ -17,11 +17,15 @@ namespace PuppeteerSharp
         /// <param name="id">The extension ID.</param>
         /// <param name="version">The extension version.</param>
         /// <param name="name">The extension name.</param>
-        protected Extension(string id, string version, string name)
+        /// <param name="path">The file system path of the extension.</param>
+        /// <param name="enabled">Whether the extension is enabled.</param>
+        protected Extension(string id, string version, string name, string path, bool enabled)
         {
             Id = id;
             Version = version;
             Name = name;
+            Path = path;
+            Enabled = enabled;
         }
 
         /// <summary>
@@ -38,6 +42,16 @@ namespace PuppeteerSharp
         /// Gets the name of the extension.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Gets the path in the file system where the extension is located.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the extension is enabled.
+        /// </summary>
+        public bool Enabled { get; }
 
         /// <summary>
         /// Returns the list of the currently active service workers of the extension.


### PR DESCRIPTION
## Summary

Implements upstream Puppeteer PR [#14870](https://github.com/puppeteer/puppeteer/pull/14870): adds `path` and `enabled` metadata to the `Extension` object.

### Changes

- `Extension` base class: added `Path` (file system path) and `Enabled` (whether the extension is enabled) properties
- `CdpExtension`: updated constructor to accept and forward `path` and `enabled` to base class
- `ExtensionInfo` (CDP messaging): added `Path` and `Enabled` deserialization fields to receive values from `Extensions.getExtensions` CDP response
- `CdpBrowser`: passes `info.Path` and `info.Enabled` when constructing `CdpExtension`
- `ExtensionsTests`: added `ShouldListExtensionsAndTheirProperties` test matching upstream `extensions.spec > extensions > should list extensions and their properties`

## Test plan

- [x] New test `ShouldListExtensionsAndTheirProperties` asserts `extension.Path == extensionPath` and `extension.Enabled == true`
- [x] All changed files compile without errors
- [x] New test passes locally with Chrome CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)