### PR TITLE
feat(cdp): support autofilling address fields (upstream PR #14826)

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/address.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/address.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+  <form id="testform" method="post">
+    <table>
+      <tbody>
+        <tr>
+          <td><label for="name">Name</label></td>
+          <td><input size="40" id="name" name="name" autocomplete="name" /></td>
+        </tr>
+        <tr>
+          <td><label for="street">Street</label></td>
+          <td><input size="40" id="street" name="street" autocomplete="street-address" /></td>
+        </tr>
+        <tr>
+          <td><label for="city">City</label></td>
+          <td><input size="40" id="city" name="city" autocomplete="address-level2" /></td>
+        </tr>
+        <tr>
+          <td><label for="zipcode">Zip Code</label></td>
+          <td><input size="10" id="zipcode" name="zipcode" autocomplete="postal-code" /></td>
+        </tr>
+      </tbody>
+    </table>
+    <input type="submit" value="Submit">
+  </form>
+</body>
+</html>

--- a/lib/PuppeteerSharp.Tests/AutofillTests/AutofillTests.cs
+++ b/lib/PuppeteerSharp.Tests/AutofillTests/AutofillTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Nunit;
@@ -31,6 +32,35 @@ namespace PuppeteerSharp.Tests.AutofillTests
                 return result.join(',');
             }");
             Assert.That(result, Is.EqualTo("John Smith,4444444444444444,01,2030,Submit"));
+        }
+
+        [Test, PuppeteerTest("autofill.spec", "ElementHandle.autofill", "should fill out an address")]
+        public async Task ShouldFillOutAnAddress()
+        {
+            await Page.GoToAsync(TestConstants.ServerUrl + "/address.html");
+            var name = await Page.WaitForSelectorAsync("#name");
+            await name.AutofillAsync(new AutofillData
+            {
+                Address = new AutofillAddressData
+                {
+                    Fields = new List<AutofillAddressFieldEntry>
+                    {
+                        new AutofillAddressFieldEntry { Name = AutofillAddressField.NameFull, Value = "Jane Doe" },
+                        new AutofillAddressFieldEntry { Name = AutofillAddressField.AddressHomeStreetAddress, Value = "123 Main St" },
+                        new AutofillAddressFieldEntry { Name = AutofillAddressField.AddressHomeCity, Value = "Anytown" },
+                        new AutofillAddressFieldEntry { Name = AutofillAddressField.AddressHomeZip, Value = "12345" },
+                    },
+                },
+            });
+
+            var result = await Page.EvaluateFunctionAsync<string>(@"() => {
+                const result = [];
+                for (const el of document.querySelectorAll('input')) {
+                    result.push(el.value);
+                }
+                return result.join(',');
+            }");
+            Assert.That(result, Is.EqualTo("Jane Doe,123 Main St,Anytown,12345,Submit"));
         }
     }
 }

--- a/lib/PuppeteerSharp/AutofillAddressData.cs
+++ b/lib/PuppeteerSharp/AutofillAddressData.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Address data for autofilling.
+    /// See https://chromedevtools.github.io/devtools-protocol/tot/Autofill/#type-Address.
+    /// </summary>
+    public class AutofillAddressData
+    {
+        /// <summary>
+        /// Gets or sets the address fields to fill.
+        /// Each entry has a <c>Name</c> (see <see cref="AutofillAddressField"/>) and a <c>Value</c>.
+        /// </summary>
+        public List<AutofillAddressFieldEntry> Fields { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/AutofillAddressField.cs
+++ b/lib/PuppeteerSharp/AutofillAddressField.cs
@@ -1,0 +1,55 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Supported autofill address field names.
+    /// See https://source.chromium.org/chromium/chromium/src/+/main:components/autofill/core/browser/field_types.cc
+    /// for the full list of supported fields.
+    /// </summary>
+    public static class AutofillAddressField
+    {
+        /// <summary>First name.</summary>
+        public const string NameFirst = "NAME_FIRST";
+
+        /// <summary>Middle name.</summary>
+        public const string NameMiddle = "NAME_MIDDLE";
+
+        /// <summary>Last name.</summary>
+        public const string NameLast = "NAME_LAST";
+
+        /// <summary>Full name.</summary>
+        public const string NameFull = "NAME_FULL";
+
+        /// <summary>Email address.</summary>
+        public const string EmailAddress = "EMAIL_ADDRESS";
+
+        /// <summary>Phone home number.</summary>
+        public const string PhoneHomeNumber = "PHONE_HOME_NUMBER";
+
+        /// <summary>Phone home city and number.</summary>
+        public const string PhoneHomeCityAndNumber = "PHONE_HOME_CITY_AND_NUMBER";
+
+        /// <summary>Phone home whole number.</summary>
+        public const string PhoneHomeWholeNumber = "PHONE_HOME_WHOLE_NUMBER";
+
+        /// <summary>Address home line 1.</summary>
+        public const string AddressHomeLine1 = "ADDRESS_HOME_LINE1";
+
+        /// <summary>Address home line 2.</summary>
+        public const string AddressHomeLine2 = "ADDRESS_HOME_LINE2";
+
+        /// <summary>Address home street address.</summary>
+        public const string AddressHomeStreetAddress = "ADDRESS_HOME_STREET_ADDRESS";
+
+        /// <summary>Address home city.</summary>
+        public const string AddressHomeCity = "ADDRESS_HOME_CITY";
+
+        /// <summary>Address home state.</summary>
+        public const string AddressHomeState = "ADDRESS_HOME_STATE";
+
+        /// <summary>Address home zip code.</summary>
+        public const string AddressHomeZip = "ADDRESS_HOME_ZIP";
+
+        /// <summary>Address home country.</summary>
+        public const string AddressHomeCountry = "ADDRESS_HOME_COUNTRY";
+    }
+}

--- a/lib/PuppeteerSharp/AutofillAddressFieldEntry.cs
+++ b/lib/PuppeteerSharp/AutofillAddressFieldEntry.cs
@@ -1,0 +1,19 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Represents a single autofill address field name/value pair.
+    /// </summary>
+    public class AutofillAddressFieldEntry
+    {
+        /// <summary>
+        /// Gets or sets the field type name.
+        /// Use constants from <see cref="AutofillAddressField"/> or a raw CDP field name string.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the field value.
+        /// </summary>
+        public string Value { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/AutofillData.cs
+++ b/lib/PuppeteerSharp/AutofillData.cs
@@ -2,12 +2,20 @@ namespace PuppeteerSharp
 {
     /// <summary>
     /// Data for autofilling form fields.
+    /// Provide either <see cref="CreditCard"/> or <see cref="Address"/>, but not both.
     /// </summary>
     public class AutofillData
     {
         /// <summary>
         /// Gets or sets the credit card data.
+        /// See https://chromedevtools.github.io/devtools-protocol/tot/Autofill/#type-CreditCard.
         /// </summary>
         public CreditCardData CreditCard { get; set; }
+
+        /// <summary>
+        /// Gets or sets the address data.
+        /// See https://chromedevtools.github.io/devtools-protocol/tot/Autofill/#type-Address.
+        /// </summary>
+        public AutofillAddressData Address { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpElementHandle.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpElementHandle.cs
@@ -198,6 +198,7 @@ public class CdpElementHandle : ElementHandle, ICdpHandle
                 FieldId = fieldId,
                 FrameId = frameId,
                 Card = data.CreditCard,
+                Address = data.Address,
             }).ConfigureAwait(false);
     }
 

--- a/lib/PuppeteerSharp/Cdp/Messaging/AutofillTriggerRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/AutofillTriggerRequest.cs
@@ -7,5 +7,7 @@ namespace PuppeteerSharp.Cdp.Messaging
         public string FrameId { get; set; }
 
         public CreditCardData Card { get; set; }
+
+        public AutofillAddressData Address { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Implements changes from https://github.com/puppeteer/puppeteer/pull/14826.

Previously, `ElementHandle.AutofillAsync()` only accepted `CreditCard` data. This PR extends `AutofillData` to optionally accept standard `Address` fields and passes them to the `Autofill.trigger` CDP command.

### Changes

- Added `AutofillAddressField` static class with CDP field name constants (e.g. `NAME_FULL`, `ADDRESS_HOME_CITY`)
- Added `AutofillAddressData` class representing address fields for CDP autofill
- Added `AutofillAddressFieldEntry` class representing individual field name/value pairs
- Updated `AutofillData` to include an optional `Address` property (mutually exclusive with `CreditCard`)
- Updated `AutofillTriggerRequest` to include the `Address` field
- Updated `CdpElementHandle.AutofillAsync` to pass `data.Address` to CDP
- Added `address.html` test asset with a name/street/city/zip form
- Added `ShouldFillOutAnAddress` test mirroring upstream

## Test plan

- [x] `ShouldFillOutACreditCard` — existing test, still passes
- [x] `ShouldFillOutAnAddress` — new test, passes with Chrome/CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)