### PR TITLE
Implement upstream PR #14873: URL blocklist for network access restriction

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -311,6 +311,66 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "firefox"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "CDP-specific feature, not supported in Firefox"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "CDP-specific feature, not supported in WebDriver BiDi"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "chrome-headless-shell"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "Not supported by chrome-headless-shell"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should detach from targets violating blocklist when connecting to a running browser",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "pipe"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "Verifies URL blocklist enforcement when connecting to a browser via WebSocket, which is not applicable for pipe mode"
+  },
+  {
     "testIdPattern": "[network.spec] network Page.setBypassServiceWorker *",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.NetworkRestrictionTests;
+
+public class NetworkRestrictionsTests : PuppeteerBaseTest
+{
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block page.goto when the destination is in the blocklist")]
+    public async Task ShouldBlockPageGotoWhenDestinationIsInBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/title.html";
+        var blockedUrl = TestConstants.ServerUrl + "/empty.html";
+
+        await page.GoToAsync(allowedUrl);
+
+        Exception error = null;
+        await page.GoToAsync(blockedUrl).ContinueWith(t =>
+        {
+            if (t.IsFaulted)
+            {
+                error = t.Exception?.InnerException ?? t.Exception;
+            }
+
+            return t;
+        });
+
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error.Message, Does.Contain("net::ERR_INTERNET_DISCONNECTED"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block window.location.href navigation to URLs in the blocklist")]
+    public async Task ShouldBlockWindowLocationHrefNavigationToUrlsInBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/title.html";
+        var blockedUrl = TestConstants.ServerUrl + "/empty.html";
+
+        await page.GoToAsync(allowedUrl);
+
+        var navTask = page.WaitForNavigationAsync(new NavigationOptions { Timeout = 2000 }).ContinueWith(t => t.IsFaulted ? null : t.Result);
+        await page.EvaluateFunctionAsync("url => { window.location.href = url; }", blockedUrl);
+        await navTask;
+
+        var finalUrl = page.Url;
+        Assert.That(finalUrl, Is.Not.EqualTo(blockedUrl));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should fail fetch requests to URLs in the blocklist")]
+    public async Task ShouldFailFetchRequestsToUrlsInBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/title.html";
+        var blockedUrl = TestConstants.ServerUrl + "/empty.html";
+
+        await page.GoToAsync(allowedUrl);
+
+        var fetchError = await page.EvaluateFunctionAsync<string>(
+            @"async (url) => {
+                try {
+                    await fetch(url);
+                    return null;
+                } catch (e) {
+                    return e.message;
+                }
+            }",
+            blockedUrl);
+
+        Assert.That(fetchError, Is.Not.Null.And.Not.Empty);
+        Assert.That(fetchError, Does.Contain("Failed to fetch"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should prevent loading of blocklisted subresources (e.g., images)")]
+    public async Task ShouldPreventLoadingOfBlocklistedSubresources()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/pptr.png"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/one-style.css";
+        var blockedUrl = TestConstants.ServerUrl + "/pptr.png";
+
+        var failedRequests = new Dictionary<string, string>();
+        var finishedRequests = new HashSet<string>();
+
+        page.RequestFailed += (_, e) =>
+        {
+            failedRequests[e.Request.Url] = e.Request.FailureText;
+        };
+        page.RequestFinished += (_, e) =>
+        {
+            finishedRequests.Add(e.Request.Url);
+        };
+
+        await page.GoToAsync(TestConstants.EmptyPage);
+
+        await page.SetContentAsync(
+            $@"<img src=""{blockedUrl}"" />
+               <link rel=""stylesheet"" href=""{allowedUrl}"" />",
+            new NavigationOptions { WaitUntil = [WaitUntilNavigation.Networkidle0] });
+
+        Assert.That(failedRequests.ContainsKey(blockedUrl), Is.True);
+        Assert.That(failedRequests[blockedUrl], Does.Contain("net::ERR_INTERNET_DISCONNECTED"));
+        Assert.That(finishedRequests.Contains(allowedUrl), Is.True);
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should detach from targets violating blocklist when connecting to a running browser")]
+    public async Task ShouldDetachFromTargetsViolatingBlocklistWhenConnectingToRunningBrowser()
+    {
+        await using var originalBrowser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions(), TestConstants.LoggerFactory);
+        var blockedUrl = TestConstants.ServerUrl + "/empty.html";
+
+        var page = await originalBrowser.NewPageAsync();
+        await page.GoToAsync(blockedUrl);
+
+        var wsEndpoint = originalBrowser.WebSocketEndpoint;
+
+        IBrowser connectedBrowser = null;
+        try
+        {
+            connectedBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserWSEndpoint = wsEndpoint,
+                BlockList = ["*://*:*/empty.html"],
+            });
+
+            var targets = connectedBrowser.Targets();
+            var blockedTarget = Array.Find(targets, t => t.Url == blockedUrl);
+
+            Assert.That(blockedTarget, Is.Null);
+        }
+        finally
+        {
+            connectedBrowser?.Disconnect();
+            await page.CloseAsync();
+        }
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should not block chrome://version/ even if it matches blocklist")]
+    public async Task ShouldNotBlockChromeVersionEvenIfItMatchesBlocklist()
+    {
+        const string chromeUrl = "chrome://version/";
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = [chromeUrl];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        await page.GoToAsync(chromeUrl);
+
+        // Navigation should succeed as chrome:// URLs usually bypass the network
+        Assert.That(page.Url, Is.EqualTo(chromeUrl));
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -52,7 +52,8 @@ public class CdpBrowser : Browser
         Func<Target, bool> isPageTargetFunc = null,
         bool handleDevToolsAsPage = false,
         bool networkEnabled = true,
-        bool issuesEnabled = true)
+        bool issuesEnabled = true,
+        string[] blockList = null)
     {
         BrowserType = browser;
         DefaultViewport = defaultViewport;
@@ -85,7 +86,8 @@ public class CdpBrowser : Browser
             TargetManager = new ChromeTargetManager(
                 connection,
                 CreateTarget,
-                targetFilterCallback);
+                targetFilterCallback,
+                blockList);
         }
     }
 
@@ -264,7 +266,8 @@ public class CdpBrowser : Browser
         Action<IBrowser> initAction = null,
         bool handleDevToolsAsPage = false,
         bool networkEnabled = true,
-        bool issuesEnabled = true)
+        bool issuesEnabled = true,
+        string[] blockList = null)
     {
         var browser = new CdpBrowser(
             browserToCreate,
@@ -277,7 +280,8 @@ public class CdpBrowser : Browser
             isPageTargetCallback,
             handleDevToolsAsPage,
             networkEnabled,
-            issuesEnabled);
+            issuesEnabled,
+            blockList);
 
         try
         {

--- a/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Cdp.Messaging;
@@ -29,6 +30,8 @@ namespace PuppeteerSharp.Cdp
         // initializeDeferred.
         private readonly ConcurrentSet<string> _targetsIdsForInit = [];
 
+        private readonly string[] _blockList;
+
         // This is false until the connection-level Target.setAutoAttach request is
         // done. It indicates whether we are running the initial auto-attach step or
         // if we are handling targets after that.
@@ -37,11 +40,13 @@ namespace PuppeteerSharp.Cdp
         public ChromeTargetManager(
             Connection connection,
             Func<TargetInfo, CDPSession, CDPSession, CdpTarget> targetFactoryFunc,
-            Func<Target, bool> targetFilterFunc)
+            Func<Target, bool> targetFilterFunc,
+            string[] blockList = null)
         {
             _connection = connection;
             _targetFilterFunc = targetFilterFunc;
             _targetFactoryFunc = targetFactoryFunc;
+            _blockList = blockList;
             _logger = _connection.LoggerFactory.CreateLogger<ChromeTargetManager>();
             _connection.MessageReceived += OnMessageReceived;
             _connection.SessionDetached += Connection_SessionDetached;
@@ -85,6 +90,16 @@ namespace PuppeteerSharp.Cdp
         }
 
         public IEnumerable<ITarget> GetChildTargets(ITarget target) => target.ChildTargets;
+
+        private static bool MatchesUrlPattern(string url, string pattern)
+        {
+            // Convert URLPattern glob syntax to a regex pattern.
+            // Supported wildcards: * matches any sequence of characters (within segment),
+            // and the leading *:// matches any scheme.
+            // This is a simplified implementation covering the common cases used in tests.
+            var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+            return Regex.IsMatch(url, regexPattern, RegexOptions.IgnoreCase);
+        }
 
         private void OnMessageReceived(object sender, MessageEventArgs e)
         {
@@ -238,6 +253,14 @@ namespace PuppeteerSharp.Cdp
                 return;
             }
 
+            // If we connect to a browser that is already open,
+            // immediately detach from any tab that is on the blocklist.
+            if (!_initialAttachDone && !IsUrlAllowed(targetInfo.Url))
+            {
+                await SilentDetachAsync(session, parentConnection).ConfigureAwait(false);
+                return;
+            }
+
             if (targetInfo.Type == TargetType.ServiceWorker)
             {
                 await SilentDetachAsync(session, parentConnection).ConfigureAwait(false);
@@ -315,6 +338,7 @@ namespace PuppeteerSharp.Cdp
                         Flatten = true,
                         AutoAttach = true,
                     }),
+                    MaybeSetupNetworkBlockListAsync(session),
                     session.SendAsync("Runtime.runIfWaitingForDebugger")).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -376,6 +400,61 @@ namespace PuppeteerSharp.Cdp
 
             _attachedTargetsByTargetId.TryRemove(target.TargetId, out _);
             TargetGone?.Invoke(this, new TargetChangedArgs { Target = target });
+        }
+
+        private bool IsUrlAllowed(string url)
+        {
+            if (_blockList == null || _blockList.Length == 0)
+            {
+                return true;
+            }
+
+            // Always allow internal or setup pages
+            if (string.IsNullOrEmpty(url) || url == "about:blank")
+            {
+                return true;
+            }
+
+            foreach (var pattern in _blockList)
+            {
+                try
+                {
+                    if (MatchesUrlPattern(url, pattern))
+                    {
+                        return false;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Invalid URL pattern: {Pattern}", pattern);
+                }
+            }
+
+            return true;
+        }
+
+        private async Task MaybeSetupNetworkBlockListAsync(CDPSession session)
+        {
+            if (_blockList == null || _blockList.Length == 0)
+            {
+                return;
+            }
+
+            var matchedNetworkConditions = Array.ConvertAll(_blockList, pattern => new MatchedNetworkCondition
+            {
+                UrlPattern = pattern,
+                Latency = 0,
+                DownloadThroughput = -1,
+                UploadThroughput = -1,
+            });
+
+            await session.SendAsync(
+                "Network.emulateNetworkConditionsByRule",
+                new NetworkEmulateNetworkConditionsByRuleRequest
+                {
+                    MatchedNetworkConditions = matchedNetworkConditions,
+                    Offline = true,
+                }).ConfigureAwait(false);
         }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/Messaging/MatchedNetworkCondition.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/MatchedNetworkCondition.cs
@@ -1,0 +1,13 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class MatchedNetworkCondition
+    {
+        public string UrlPattern { get; set; }
+
+        public double Latency { get; set; }
+
+        public double DownloadThroughput { get; set; }
+
+        public double UploadThroughput { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/NetworkEmulateNetworkConditionsByRuleRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/NetworkEmulateNetworkConditionsByRuleRequest.cs
@@ -1,0 +1,9 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class NetworkEmulateNetworkConditionsByRuleRequest
+    {
+        public MatchedNetworkCondition[] MatchedNetworkConditions { get; set; }
+
+        public bool Offline { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -107,6 +107,33 @@ namespace PuppeteerSharp
         public ProtocolType Protocol { get; set; } = ProtocolType.Cdp;
 
         /// <summary>
+        /// A list of URL patterns to block.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This option allows you to restrict the browser from accessing specific
+        /// URLs or origins. It uses the standard <see href="https://urlpattern.spec.whatwg.org/">URLPattern</see> API to match URLs.
+        /// </para>
+        /// <para>
+        /// When connecting to an existing browser, Puppeteer will silently detach from any
+        /// already open targets that violate the patterns.
+        /// </para>
+        /// <para>
+        /// For any network requests made by the browser (including navigations and
+        /// subresources like images or scripts), the request will fail with an error
+        /// if the URL matches a blocked pattern.
+        /// </para>
+        /// <para>
+        /// Currently only supported for CDP connections.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// Pattern to block a specific domain: <c>*://example.com/*</c>
+        /// Pattern to block all subdomains: <c>*://*.evil.com/*</c>.
+        /// </example>
+        public string[] BlockList { get; set; }
+
+        /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.
         /// </summary>
         internal Func<Target, bool> IsPageTarget { get; set; }

--- a/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
@@ -142,6 +142,8 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(MouseEventType))]
 [JsonSerializable(typeof(NavigatedWithinDocumentResponse))]
 [JsonSerializable(typeof(NavigationType))]
+[JsonSerializable(typeof(MatchedNetworkCondition))]
+[JsonSerializable(typeof(NetworkEmulateNetworkConditionsByRuleRequest))]
 [JsonSerializable(typeof(NetworkEmulateNetworkConditionsRequest))]
 [JsonSerializable(typeof(NetworkGetCookiesRequest))]
 [JsonSerializable(typeof(NetworkGetCookiesResponse))]

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -248,6 +248,29 @@ namespace PuppeteerSharp
         public ProtocolType Protocol { get; set; }
 
         /// <summary>
+        /// A list of URL patterns to block.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This option allows you to restrict the browser from accessing specific
+        /// URLs or origins. It uses the standard <see href="https://urlpattern.spec.whatwg.org/">URLPattern</see> API to match URLs.
+        /// </para>
+        /// <para>
+        /// For any network requests made by the browser (including navigations and
+        /// subresources like images or scripts), the request will fail with an error
+        /// if the URL matches a blocked pattern.
+        /// </para>
+        /// <para>
+        /// Currently only supported for CDP connections.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// Pattern to block a specific domain: <c>*://example.com/*</c>
+        /// Pattern to block all subdomains: <c>*://*.evil.com/*</c>.
+        /// </example>
+        public string[] BlockList { get; set; }
+
+        /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.
         /// </summary>
         internal Func<Target, bool> IsPageTarget { get; set; }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -188,7 +188,8 @@ namespace PuppeteerSharp
                                 options.IsPageTarget,
                                 handleDevToolsAsPage: options.HandleDevToolsAsPage,
                                 networkEnabled: options.NetworkEnabled,
-                                issuesEnabled: options.IssuesEnabled)
+                                issuesEnabled: options.IssuesEnabled,
+                                blockList: options.BlockList)
                             .ConfigureAwait(false);
                     }
 
@@ -442,7 +443,8 @@ namespace PuppeteerSharp
                         options.InitAction,
                         options.HandleDevToolsAsPage,
                         options.NetworkEnabled,
-                        options.IssuesEnabled)
+                        options.IssuesEnabled,
+                        options.BlockList)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Implements changes from https://github.com/puppeteer/puppeteer/pull/14873 which adds a URL blocklist feature to restrict browser network access.

- Adds `BlockList` property to `ConnectOptions` and `LaunchOptions` accepting URL patterns
- Updates `ChromeTargetManager` to silently detach from already-open targets violating the blocklist on initial connect
- Uses `Network.emulateNetworkConditionsByRule` CDP command to fail network requests matching blocked URL patterns
- Adds new `NetworkEmulateNetworkConditionsByRuleRequest` and `MatchedNetworkCondition` messaging classes
- Adds test file `NetworkRestrictionsTests.cs` with 6 tests covering all upstream test cases
- Adds test expectations to skip on Firefox, WebDriverBiDi, chrome-headless-shell, and pipe mode (CDP-only feature)

## Test plan

- [x] All 6 `NetworkRestrictionsTests` pass on Chrome/CDP
- [x] Existing `ConnectTests` and `TargetManagerTests` pass without regression
- [x] Main library and Nunit projects build without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)