### PR TITLE
fix: remove PartitionAllocSchedulerLoopQuarantineTaskControlledPurge from disabled features

### DIFF
--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -68,7 +68,6 @@ namespace PuppeteerSharp
                 "ReadAnythingOmniboxChip",
                 "ProcessPerSiteUpToMainFrameThreshold",
                 "IsolateSandboxedIframes",
-                "PartitionAllocSchedulerLoopQuarantineTaskControlledPurge",
             };
 
             disabledFeatures.AddRange(userDisabledFeatures);


### PR DESCRIPTION
## Summary

Implements changes from https://github.com/puppeteer/puppeteer/pull/14872.

- Removes `PartitionAllocSchedulerLoopQuarantineTaskControlledPurge` from the list of disabled Chrome features in `ChromeLauncher.cs`
- The underlying Chromium bug (crbug.com/489314676) has been fixed upstream, so the workaround is no longer needed

## Test plan

- [x] Build succeeds with 0 warnings and 0 errors
- No functional tests needed — this is a one-line removal of a now-unnecessary feature flag workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)