### PR TITLE
fix: roll to Chrome 147.0.7727.57

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "147.0.7727.56";
+        public static string DefaultBuildId => "147.0.7727.57";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
## Summary

- Updates default Chrome build ID from `147.0.7727.56` to `147.0.7727.57`
- Implements upstream PR https://github.com/puppeteer/puppeteer/pull/14869

## Test plan

- [ ] Build passes
- [ ] No functional code changes — this is a browser pin update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)