### PR TITLE
chore: bump version to 24.42.0

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>24.40.0</PackageVersion>
-    <ReleaseVersion>24.40.0</ReleaseVersion>
-    <AssemblyVersion>24.40.0</AssemblyVersion>
-    <FileVersion>24.40.0</FileVersion>
+    <PackageVersion>24.42.0</PackageVersion>
+    <ReleaseVersion>24.42.0</ReleaseVersion>
+    <AssemblyVersion>24.42.0</AssemblyVersion>
+    <FileVersion>24.42.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Bumps PuppeteerSharp version from 24.40.0 to 24.42.0 to match upstream `puppeteer-core-v24.42.0`.

## Related PRs
- #3427 — add metadata to extensions object (#14870)
- #3428 — cdp: support autofilling address (#14826)
- #3429 — implement URL blocklist to restrict access to unauthorized sites (#14873)
- #3430 — remove PartitionAllocSchedulerLoopQuarantineTaskControlledPurge from disabled features (#14872)
- #3431 — roll to Chrome 147.0.7727.57 (#14869)

🤖 Generated with [Claude Code](https://claude.com/claude-code)