### PR TITLE
fix: disable WebUIReloadButton experiment in Chrome launcher

### DIFF
--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -63,6 +63,7 @@ namespace PuppeteerSharp
                 "AcceptCHFrame",
                 "MediaRouter",
                 "OptimizationHints",
+                "WebUIReloadButton",
                 "IPH_ReadingModePageActionLabel",
                 "ReadAnythingOmniboxChip",
                 "ProcessPerSiteUpToMainFrameThreshold",


### PR DESCRIPTION
## Summary

Implements changes from https://github.com/puppeteer/puppeteer/pull/14925.

- Adds `WebUIReloadButton` to the list of disabled Chrome features in `ChromeLauncher.cs`
- The `WebUIReloadButton` experiment creates additional targets (`browser_ui` type and a corresponding tab target) that interfere with `TargetManager` and cause test failures

## Changes

- `/lib/PuppeteerSharp/ChromeLauncher.cs`: Added `WebUIReloadButton` to `disabledFeatures` list

## Test plan

- [x] Build passes with no errors or warnings
- [ ] Run TargetManager tests to confirm no extra targets appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)