### PR TITLE
feat: roll Firefox to 150.0 (upstream PR #14900)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -885,7 +885,7 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[console.spec] console should work for different console API calls with timing functions",
+    "testIdPattern": "[console.spec] console should work for different console API calls with group functions",
     "platforms": [
       "darwin",
       "linux",
@@ -898,7 +898,7 @@
     "expectations": [
       "FAIL"
     ],
-    "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1866749"
+    "comment": "Failing since 150.0 due to https://bugzilla.mozilla.org/show_bug.cgi?id=1866749, reported as https://github.com/w3c/webdriver-bidi/issues/1097"
   },
   {
     "testIdPattern": "[CDPSession.spec] Target.createCDPSession *",
@@ -1081,21 +1081,6 @@
       "FAIL"
     ],
     "comment": "shell always emulates a focused page"
-  },
-  {
-    "testIdPattern": "[emulation.spec] Emulation Page.emulateNetworkConditions should support offline",
-    "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "Not supported by WebDriver BiDi"
   },
   {
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should replace symbols with undefined",
@@ -2702,6 +2687,20 @@
     "comment": "We can't connect to a browser started with pipe:true"
   },
   {
+    "testIdPattern": "[fixtures.spec] Fixtures should dump browser process stderr",
+    "platforms": [
+      "win32"
+    ],
+    "parameters": [
+      "firefox",
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "See https://github.com/puppeteer/puppeteer/issues/14774"
+  },
+  {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should support framesets",
     "platforms": [
       "darwin",
@@ -3498,38 +3497,6 @@
       "FAIL"
     ],
     "comment": "Unknown command emulation.setScriptingEnabled"
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.setOfflineMode should emulate navigator.onLine",
-    "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox",
-      "webDriverBiDi"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "Not supported by WebDriver BiDi"
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.setOfflineMode should work",
-    "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox",
-      "webDriverBiDi"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "Not supported by WebDriver BiDi"
   },
   {
     "testIdPattern": "[page.spec] Page Page.setUserAgent should work with additional userAgentMetdata",


### PR DESCRIPTION
## Summary

Syncs with upstream Puppeteer [PR #14900](https://github.com/puppeteer/puppeteer/pull/14900) — rolls Firefox to 150.0.

- The `Firefox.DefaultBuildId` was already updated to `stable_150.0` in a prior commit (#3407)
- This PR syncs `TestExpectations.upstream.json` with the upstream expectation changes from PR #14900:
  - Renames console spec test ID from "timing functions" to "group functions" with updated bugzilla/w3c comment
  - Removes `emulateNetworkConditions should support offline` FAIL expectation for Firefox (now passing in 150.0)
  - Removes two `Page.setOfflineMode` FAIL expectations for Firefox BiDi (now passing in 150.0)
  - Adds `fixtures.spec should dump browser process stderr` SKIP for Firefox/webDriverBiDi on win32 (see puppeteer/puppeteer#14774)

## Test plan

- [x] Main library builds successfully with no errors
- [ ] Run Firefox BiDi test suite to verify offline mode tests now pass
- [ ] Verify console group functions test still fails as expected on Firefox BiDi

🤖 Generated with [Claude Code](https://claude.com/claude-code)