### PR TITLE
feat(webmcp): add UntrustedContent annotation support

### DIFF
--- a/lib/PuppeteerSharp.Tests/WebMcpTests/PageWebMcpTests.cs
+++ b/lib/PuppeteerSharp.Tests/WebMcpTests/PageWebMcpTests.cs
@@ -39,8 +39,10 @@ namespace PuppeteerSharp.Tests.WebMcpTests
                     name: 'test-tool-1',
                     description: 'A test tool 1',
                     inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
-                    execute: () => {},
-                    annotations: { readOnlyHint: true },
+                    execute: (params) => {
+                        return params.text;
+                    },
+                    annotations: { readOnlyHint: true, untrustedContentHint: true },
                 });
             }");
 
@@ -55,6 +57,9 @@ namespace PuppeteerSharp.Tests.WebMcpTests
 
             var tools = page.WebMcp.Tools();
             Assert.That(tools.Length, Is.GreaterThanOrEqualTo(2));
+            Assert.That(tools[0].Annotations, Is.Not.Null);
+            Assert.That(tools[0].Annotations!.ReadOnly, Is.True);
+            Assert.That(tools[0].Annotations!.UntrustedContent, Is.True);
         }
 
         [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should fire toolsadded events")]

--- a/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
@@ -164,6 +164,7 @@ public class CdpWebMcp
                 Annotations = tool.Annotations == null ? null : new WebMcpAnnotation
                 {
                     ReadOnly = tool.Annotations.ReadOnly,
+                    UntrustedContent = tool.Annotations.UntrustedContent,
                     Autosubmit = tool.Annotations.Autosubmit,
                 },
                 Frame = frame,
@@ -306,6 +307,9 @@ public class CdpWebMcp
 
         [JsonPropertyName("readOnly")]
         public bool? ReadOnly { get; set; }
+
+        [JsonPropertyName("untrustedContent")]
+        public bool? UntrustedContent { get; set; }
     }
 
     private class WebMcpProtocolRemovedTool

--- a/lib/PuppeteerSharp/Cdp/WebMcpAnnotation.cs
+++ b/lib/PuppeteerSharp/Cdp/WebMcpAnnotation.cs
@@ -33,6 +33,11 @@ public class WebMcpAnnotation
     public bool? ReadOnly { get; set; }
 
     /// <summary>
+    /// A hint indicating that the tool output may contain untrusted content, ex: UGC, 3rd party data.
+    /// </summary>
+    public bool? UntrustedContent { get; set; }
+
+    /// <summary>
     /// If the declarative tool was declared with the autosubmit attribute.
     /// </summary>
     public bool? Autosubmit { get; set; }


### PR DESCRIPTION
## Summary

Ports upstream Puppeteer PR [#14901](https://github.com/puppeteer/puppeteer/pull/14901) — adds support for the `untrustedContentHint` WebMCP annotation.

- Added `UntrustedContent` property to `WebMcpAnnotation` class
- Added `untrustedContent` JSON field to the internal `WebMcpProtocolAnnotation` private class in `CdpWebMcp`
- Map `UntrustedContent` when creating `WebMcpAnnotation` from protocol events
- Updated `ShouldListTools` test to set `untrustedContentHint: true` and assert `UntrustedContent` is `true`

## Test plan

- [ ] Build passes: `dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj`
- [ ] `ShouldListTools` test registers a tool with `untrustedContentHint: true` and asserts `Annotations.UntrustedContent == true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)