### PR TITLE
fix: do not open DevTools if it is already open

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -349,24 +349,29 @@ public class CdpBrowser : Browser
             "Target.openDevTools",
             new TargetActivateTargetRequest { TargetId = pageTargetId }).ConfigureAwait(false);
 
+        return await GetDevToolsTargetPageAsync(openDevToolsResponse.TargetId).ConfigureAwait(false);
+    }
+
+    internal async Task<IPage> GetDevToolsTargetPageAsync(string devtoolsTargetId)
+    {
         var target = await WaitForTargetAsync(
-            t => ((CdpTarget)t).TargetId == openDevToolsResponse.TargetId).ConfigureAwait(false) as CdpTarget;
+            t => ((CdpTarget)t).TargetId == devtoolsTargetId).ConfigureAwait(false) as CdpTarget;
 
         if (target == null)
         {
-            throw new PuppeteerException($"Missing target for DevTools page (id = {pageTargetId})");
+            throw new PuppeteerException($"Missing target for DevTools page (id = {devtoolsTargetId})");
         }
 
         var initialized = await target.InitializedTask.ConfigureAwait(false) == InitializationStatus.Success;
         if (!initialized)
         {
-            throw new PuppeteerException($"Failed to create target for DevTools page (id = {pageTargetId})");
+            throw new PuppeteerException($"Failed to create target for DevTools page (id = {devtoolsTargetId})");
         }
 
         var page = await target.PageAsync().ConfigureAwait(false);
         if (page == null)
         {
-            throw new PuppeteerException($"Failed to create a DevTools Page for target (id = {pageTargetId})");
+            throw new PuppeteerException($"Failed to create a DevTools Page for target (id = {devtoolsTargetId})");
         }
 
         return page;

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -191,6 +191,12 @@ public class CdpPage : Page
     {
         var pageTargetId = PrimaryTarget.TargetId;
         var browser = (CdpBrowser)Browser;
+        var devtoolsTargetId = await browser.HasDevToolsTargetAsync(pageTargetId).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(devtoolsTargetId))
+        {
+            return await browser.GetDevToolsTargetPageAsync(devtoolsTargetId).ConfigureAwait(false);
+        }
+
         return await browser.CreateDevToolsPageAsync(pageTargetId).ConfigureAwait(false);
     }
 

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -373,7 +373,7 @@ namespace PuppeteerSharp
         Task CloseAsync(PageCloseOptions options = null);
 
         /// <summary>
-        /// Opens DevTools for the current Page and returns the DevTools Page.
+        /// Opens DevTools for this page if not already open and returns the DevTools page.
         /// This method is only available in Chrome.
         /// </summary>
         /// <returns>A <see cref="Task{IPage}"/> that completes with the DevTools page.</returns>


### PR DESCRIPTION
## Summary

Ports upstream Puppeteer PR [#14922](https://github.com/puppeteer/puppeteer/pull/14922).

- Extracts `GetDevToolsTargetPageAsync(string devtoolsTargetId)` as a new method in `CdpBrowser`, refactoring `CreateDevToolsPageAsync` to delegate to it
- Updates `CdpPage.OpenDevToolsAsync()` to first check if a DevTools target already exists via `HasDevToolsTargetAsync` — if so, returns the existing DevTools page without re-opening (which would steal focus)
- Updates the `IPage.OpenDevToolsAsync` XML doc comment to reflect the new "if not already open" behavior

**Problem**: Opening DevTools steals focus. If DevTools was already open and the page called `openDevTools()` again (e.g., from a background tab), it would steal focus unnecessarily.

**Fix**: Check for an existing DevTools target first. If one exists, return the existing DevTools page instead of triggering `Target.openDevTools` again.

## Test plan

- [ ] Build passes: `dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj` — succeeded with 0 warnings/errors
- [ ] Existing DevTools tests should continue to pass
- [ ] Manual verify: calling `OpenDevToolsAsync()` twice returns the same DevTools page without re-focusing

🤖 Generated with [Claude Code](https://claude.com/claude-code)