### PR TITLE
feat: implement URL allowlist for network restrictions (upstream #14897, #14931)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -371,6 +371,101 @@
     "comment": "Verifies URL blocklist enforcement when connecting to a browser via WebSocket, which is not applicable for pipe mode"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "PASS in Chrome >= 149; FAIL in older revisions"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should block window.location.href navigation to URLs not in the allowlist",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "PASS in Chrome >= 149; FAIL in older revisions"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should detach from targets violating allowlist when connecting to a running browser",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "PASS in Chrome >= 149; FAIL in older revisions"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should detach from targets violating allowlist when connecting to a running browser",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "pipe"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "Verifies URL allowlist enforcement when connecting to a browser via WebSocket, which is not applicable for pipe mode"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should fail fetch requests to URLs not in the allowlist",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "PASS in Chrome >= 149; FAIL in older revisions"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should prevent loading of subresources not in the allowlist (e.g., images)",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "PASS in Chrome >= 149; FAIL in older revisions"
+  },
+  {
     "testIdPattern": "[network.spec] network Page.setBypassServiceWorker *",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -171,4 +171,215 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
         // Navigation should succeed as chrome:// URLs usually bypass the network
         Assert.That(page.Url, Is.EqualTo(chromeUrl));
     }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should only allow navigation to URLs in the allowlist")]
+    public async Task ShouldOnlyAllowNavigationToUrlsInAllowlist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.Allowlist = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/empty.html";
+        var blockedUrl = TestConstants.ServerUrl + "/title.html";
+
+        await page.GoToAsync(allowedUrl);
+
+        Exception error = null;
+        await page.GoToAsync(blockedUrl).ContinueWith(t =>
+        {
+            if (t.IsFaulted)
+            {
+                error = t.Exception?.InnerException ?? t.Exception;
+            }
+
+            return t;
+        });
+
+        Assert.That(page.Url, Is.Not.EqualTo(blockedUrl));
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error.Message, Does.Contain("net::ERR_INTERNET_DISCONNECTED"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block window.location.href navigation to URLs not in the allowlist")]
+    public async Task ShouldBlockWindowLocationHrefNavigationToUrlsNotInAllowlist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.Allowlist = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/empty.html";
+        var blockedUrl = TestConstants.ServerUrl + "/title.html";
+
+        await page.GoToAsync(allowedUrl);
+
+        var navTask = page.WaitForNavigationAsync(new NavigationOptions { Timeout = 2000 }).ContinueWith(t => t.IsFaulted ? null : t.Result);
+        await page.EvaluateFunctionAsync("url => { window.location.href = url; }", blockedUrl);
+        await navTask;
+
+        var finalUrl = page.Url;
+        var content = await page.GetContentAsync();
+        Assert.That(finalUrl, Is.Not.EqualTo(blockedUrl));
+        Assert.That(content, Does.Not.Contain("Woof-Woof"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should fail fetch requests to URLs not in the allowlist")]
+    public async Task ShouldFailFetchRequestsToUrlsNotInAllowlist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.Allowlist = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/empty.html";
+        var blockedUrl = TestConstants.ServerUrl + "/title.html";
+
+        await page.GoToAsync(allowedUrl);
+
+        var fetchError = await page.EvaluateFunctionAsync<string>(
+            @"async (url) => {
+                try {
+                    await fetch(url);
+                    return null;
+                } catch (e) {
+                    return e.message;
+                }
+            }",
+            blockedUrl);
+
+        Assert.That(fetchError, Does.Contain("Failed to fetch"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should prevent loading of subresources not in the allowlist (e.g., images)")]
+    public async Task ShouldPreventLoadingOfSubresourcesNotInAllowlist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.Allowlist = ["*://*:*/empty.html", "*://*:*/one-style.css"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/one-style.css";
+        var blockedUrl = TestConstants.ServerUrl + "/pptr.png";
+
+        var failedRequests = new Dictionary<string, string>();
+        var finishedRequests = new HashSet<string>();
+
+        page.RequestFailed += (_, e) =>
+        {
+            failedRequests[e.Request.Url] = e.Request.FailureText;
+        };
+        page.RequestFinished += (_, e) =>
+        {
+            finishedRequests.Add(e.Request.Url);
+        };
+
+        await page.GoToAsync(TestConstants.EmptyPage);
+
+        await page.SetContentAsync(
+            $@"<img src=""{blockedUrl}"" />
+               <link rel=""stylesheet"" href=""{allowedUrl}"" />",
+            new NavigationOptions { WaitUntil = [WaitUntilNavigation.Networkidle0] });
+
+        Assert.That(failedRequests.ContainsKey(blockedUrl), Is.True);
+        Assert.That(failedRequests[blockedUrl], Does.Contain("net::ERR_INTERNET_DISCONNECTED"));
+        Assert.That(finishedRequests.Contains(allowedUrl), Is.True);
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should detach from targets violating allowlist when connecting to a running browser")]
+    public async Task ShouldDetachFromTargetsViolatingAllowlistWhenConnectingToRunningBrowser()
+    {
+        await using var originalBrowser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions(), TestConstants.LoggerFactory);
+        var blockedUrl = TestConstants.ServerUrl + "/title.html";
+
+        var page = await originalBrowser.NewPageAsync();
+        await page.GoToAsync(blockedUrl);
+
+        var wsEndpoint = originalBrowser.WebSocketEndpoint;
+
+        IBrowser connectedBrowser = null;
+        try
+        {
+            connectedBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserWSEndpoint = wsEndpoint,
+                Allowlist = ["*://*:*/empty.html"],
+            });
+
+            var targets = connectedBrowser.Targets();
+            var blockedTarget = Array.Find(targets, t => t.Url == blockedUrl);
+
+            Assert.That(blockedTarget, Is.Null);
+        }
+        finally
+        {
+            connectedBrowser?.Disconnect();
+            await page.CloseAsync();
+        }
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should throw an error when both blocklist and allowlist are specified")]
+    public async Task ShouldThrowAnErrorWhenBothBlocklistAndAllowlistAreSpecified()
+    {
+        var launchOptions = TestConstants.DefaultBrowserOptions();
+        launchOptions.BlockList = ["*://*:*/empty.html"];
+        launchOptions.Allowlist = ["*://*:*/empty.html"];
+
+        Exception launchError = null;
+        try
+        {
+            await using var browser = await Puppeteer.LaunchAsync(launchOptions, TestConstants.LoggerFactory);
+        }
+        catch (Exception ex)
+        {
+            launchError = ex;
+        }
+
+        Assert.That(launchError, Is.Not.Null);
+        Assert.That(launchError.Message, Does.Contain("Cannot specify both blocklist and allowlist"));
+
+        await using var originalBrowser = await Puppeteer.LaunchAsync(TestConstants.DefaultBrowserOptions(), TestConstants.LoggerFactory);
+        var wsEndpoint = originalBrowser.WebSocketEndpoint;
+
+        Exception connectError = null;
+        try
+        {
+            await using var connectedBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserWSEndpoint = wsEndpoint,
+                BlockList = ["*://*:*/empty.html"],
+                Allowlist = ["*://*:*/empty.html"],
+            });
+        }
+        catch (Exception ex)
+        {
+            connectError = ex;
+        }
+
+        Assert.That(connectError, Is.Not.Null);
+        Assert.That(connectError.Message, Does.Contain("Cannot specify both blocklist and allowlist"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should throw an error for an invalid pattern")]
+    public async Task ShouldThrowAnErrorForAnInvalidPattern()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["(invalid pattern"];
+
+        Exception error = null;
+        try
+        {
+            await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        }
+        catch (Exception ex)
+        {
+            error = ex;
+        }
+
+        Assert.That(error, Is.Not.Null);
+    }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Cdp.Messaging;
@@ -53,7 +54,8 @@ public class CdpBrowser : Browser
         bool handleDevToolsAsPage = false,
         bool networkEnabled = true,
         bool issuesEnabled = true,
-        string[] blockList = null)
+        string[] blockList = null,
+        string[] allowList = null)
     {
         BrowserType = browser;
         DefaultViewport = defaultViewport;
@@ -87,7 +89,8 @@ public class CdpBrowser : Browser
                 connection,
                 CreateTarget,
                 targetFilterCallback,
-                blockList);
+                blockList,
+                allowList);
         }
     }
 
@@ -267,8 +270,19 @@ public class CdpBrowser : Browser
         bool handleDevToolsAsPage = false,
         bool networkEnabled = true,
         bool issuesEnabled = true,
-        string[] blockList = null)
+        string[] blockList = null,
+        string[] allowList = null)
     {
+        if (allowList != null)
+        {
+            var versionResponse = await connection.SendAsync<BrowserGetVersionResponse>("Browser.getVersion").ConfigureAwait(false);
+            var match = Regex.Match(versionResponse.Product, @"\d+");
+            if (match.Success && int.TryParse(match.Value, out var majorVersion) && majorVersion < 149)
+            {
+                throw new PuppeteerException("The Allowlist option requires Chrome 149 or greater.");
+            }
+        }
+
         var browser = new CdpBrowser(
             browserToCreate,
             connection,
@@ -281,7 +295,8 @@ public class CdpBrowser : Browser
             handleDevToolsAsPage,
             networkEnabled,
             issuesEnabled,
-            blockList);
+            blockList,
+            allowList);
 
         try
         {

--- a/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
@@ -31,6 +31,7 @@ namespace PuppeteerSharp.Cdp
         private readonly ConcurrentSet<string> _targetsIdsForInit = [];
 
         private readonly string[] _blockList;
+        private readonly string[] _allowList;
 
         // This is false until the connection-level Target.setAutoAttach request is
         // done. It indicates whether we are running the initial auto-attach step or
@@ -41,12 +42,22 @@ namespace PuppeteerSharp.Cdp
             Connection connection,
             Func<TargetInfo, CDPSession, CDPSession, CdpTarget> targetFactoryFunc,
             Func<Target, bool> targetFilterFunc,
-            string[] blockList = null)
+            string[] blockList = null,
+            string[] allowList = null)
         {
+            if (blockList != null && allowList != null)
+            {
+                throw new PuppeteerException("Cannot specify both blocklist and allowlist");
+            }
+
+            ValidateUrlPatterns(blockList);
+            ValidateUrlPatterns(allowList);
+
             _connection = connection;
             _targetFilterFunc = targetFilterFunc;
             _targetFactoryFunc = targetFactoryFunc;
             _blockList = blockList;
+            _allowList = allowList;
             _logger = _connection.LoggerFactory.CreateLogger<ChromeTargetManager>();
             _connection.MessageReceived += OnMessageReceived;
             _connection.SessionDetached += Connection_SessionDetached;
@@ -90,6 +101,42 @@ namespace PuppeteerSharp.Cdp
         }
 
         public IEnumerable<ITarget> GetChildTargets(ITarget target) => target.ChildTargets;
+
+        private static void ValidateUrlPatterns(string[] patterns)
+        {
+            if (patterns == null)
+            {
+                return;
+            }
+
+            foreach (var pattern in patterns)
+            {
+                // Basic validation to catch common URLPattern syntax errors (e.g., unbalanced parentheses).
+                // .NET has no native URLPattern API, so this only checks a subset of URLPattern invariants.
+                // The URLPattern spec rejects patterns with unbalanced parentheses.
+                var depth = 0;
+                foreach (var c in pattern)
+                {
+                    if (c == '(')
+                    {
+                        depth++;
+                    }
+                    else if (c == ')')
+                    {
+                        depth--;
+                        if (depth < 0)
+                        {
+                            throw new PuppeteerException($"Invalid URLPattern: '{pattern}'. Unbalanced parentheses.");
+                        }
+                    }
+                }
+
+                if (depth != 0)
+                {
+                    throw new PuppeteerException($"Invalid URLPattern: '{pattern}'. Unbalanced parentheses.");
+                }
+            }
+        }
 
         private static bool MatchesUrlPattern(string url, string pattern)
         {
@@ -404,7 +451,10 @@ namespace PuppeteerSharp.Cdp
 
         private bool IsUrlAllowed(string url)
         {
-            if (_blockList == null || _blockList.Length == 0)
+            var hasBlockList = _blockList != null && _blockList.Length > 0;
+            var hasAllowList = _allowList != null && _allowList.Length > 0;
+
+            if (!hasBlockList && !hasAllowList)
             {
                 return true;
             }
@@ -415,19 +465,28 @@ namespace PuppeteerSharp.Cdp
                 return true;
             }
 
-            foreach (var pattern in _blockList)
+            if (hasBlockList)
             {
-                try
+                foreach (var pattern in _blockList)
                 {
                     if (MatchesUrlPattern(url, pattern))
                     {
                         return false;
                     }
                 }
-                catch (Exception ex)
+            }
+
+            if (hasAllowList)
+            {
+                foreach (var pattern in _allowList)
                 {
-                    _logger.LogError(ex, "Invalid URL pattern: {Pattern}", pattern);
+                    if (MatchesUrlPattern(url, pattern))
+                    {
+                        return true;
+                    }
                 }
+
+                return false;
             }
 
             return true;
@@ -435,25 +494,64 @@ namespace PuppeteerSharp.Cdp
 
         private async Task MaybeSetupNetworkBlockListAsync(CDPSession session)
         {
-            if (_blockList == null || _blockList.Length == 0)
+            var hasBlockList = _blockList != null && _blockList.Length > 0;
+            var hasAllowList = _allowList != null && _allowList.Length > 0;
+
+            if (!hasBlockList && !hasAllowList)
             {
                 return;
             }
 
-            var matchedNetworkConditions = Array.ConvertAll(_blockList, pattern => new MatchedNetworkCondition
+            var matchedNetworkConditions = new List<MatchedNetworkCondition>();
+
+            if (hasBlockList)
             {
-                UrlPattern = pattern,
-                Latency = 0,
-                DownloadThroughput = -1,
-                UploadThroughput = -1,
-            });
+                foreach (var pattern in _blockList)
+                {
+                    matchedNetworkConditions.Add(new MatchedNetworkCondition
+                    {
+                        UrlPattern = pattern,
+                        Offline = true,
+                        Latency = 0,
+                        DownloadThroughput = -1,
+                        UploadThroughput = -1,
+                    });
+                }
+            }
+
+            if (hasAllowList)
+            {
+                foreach (var pattern in _allowList)
+                {
+                    matchedNetworkConditions.Add(new MatchedNetworkCondition
+                    {
+                        UrlPattern = pattern,
+                        Offline = false,
+                        Latency = 0,
+                        DownloadThroughput = -1,
+                        UploadThroughput = -1,
+                    });
+                }
+
+                // Block everything else
+                matchedNetworkConditions.Add(new MatchedNetworkCondition
+                {
+                    UrlPattern = string.Empty,
+                    Offline = true,
+                    Latency = 0,
+                    DownloadThroughput = -1,
+                    UploadThroughput = -1,
+                });
+            }
 
             await session.SendAsync(
                 "Network.emulateNetworkConditionsByRule",
                 new NetworkEmulateNetworkConditionsByRuleRequest
                 {
-                    MatchedNetworkConditions = matchedNetworkConditions,
-                    Offline = true,
+                    // 'Offline' at the request level is for legacy blocklist compatibility (deprecated in Chrome 149).
+                    // Only set it when using a blocklist; allowlist mode uses per-rule offline flags instead.
+                    Offline = hasBlockList ? true : null,
+                    MatchedNetworkConditions = matchedNetworkConditions.ToArray(),
                 }).ConfigureAwait(false);
         }
     }

--- a/lib/PuppeteerSharp/Cdp/Messaging/MatchedNetworkCondition.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/MatchedNetworkCondition.cs
@@ -4,6 +4,8 @@ namespace PuppeteerSharp.Cdp.Messaging
     {
         public string UrlPattern { get; set; }
 
+        public bool Offline { get; set; }
+
         public double Latency { get; set; }
 
         public double DownloadThroughput { get; set; }

--- a/lib/PuppeteerSharp/Cdp/Messaging/NetworkEmulateNetworkConditionsByRuleRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/NetworkEmulateNetworkConditionsByRuleRequest.cs
@@ -4,6 +4,6 @@ namespace PuppeteerSharp.Cdp.Messaging
     {
         public MatchedNetworkCondition[] MatchedNetworkConditions { get; set; }
 
-        public bool Offline { get; set; }
+        public bool? Offline { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -126,12 +126,49 @@ namespace PuppeteerSharp
         /// <para>
         /// Currently only supported for CDP connections.
         /// </para>
+        /// <para>
+        /// Cannot be used along with <see cref="Allowlist"/>.
+        /// </para>
         /// </remarks>
         /// <example>
         /// Pattern to block a specific domain: <c>*://example.com/*</c>
         /// Pattern to block all subdomains: <c>*://*.evil.com/*</c>.
         /// </example>
         public string[] BlockList { get; set; }
+
+        /// <summary>
+        /// A list of URL patterns to allow. When set, the browser can only access URLs matching these patterns.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <strong>Requires Chrome 149+.</strong>
+        /// </para>
+        /// <para>
+        /// This option allows you to restrict the browser from accessing any URLs
+        /// except for those that match the patterns in the allowlist.
+        /// It uses the standard <see href="https://urlpattern.spec.whatwg.org/">URLPattern</see> API to match URLs.
+        /// </para>
+        /// <para>
+        /// When connecting to an existing browser, Puppeteer will silently detach from any
+        /// already open targets that violate the patterns.
+        /// </para>
+        /// <para>
+        /// For any network requests made by the browser (including navigations and
+        /// subresources like images or scripts), the request will fail with an error
+        /// if the URL does not match any pattern in the allowlist.
+        /// </para>
+        /// <para>
+        /// Currently only supported for CDP connections.
+        /// </para>
+        /// <para>
+        /// Cannot be used along with <see cref="BlockList"/>.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// Pattern to allow a specific domain: <c>*://example.com/*</c>
+        /// Pattern to allow all subdomains: <c>*://*.example.com/*</c>.
+        /// </example>
+        public string[] Allowlist { get; set; }
 
         /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -263,12 +263,45 @@ namespace PuppeteerSharp
         /// <para>
         /// Currently only supported for CDP connections.
         /// </para>
+        /// <para>
+        /// Cannot be used along with <see cref="Allowlist"/>.
+        /// </para>
         /// </remarks>
         /// <example>
         /// Pattern to block a specific domain: <c>*://example.com/*</c>
         /// Pattern to block all subdomains: <c>*://*.evil.com/*</c>.
         /// </example>
         public string[] BlockList { get; set; }
+
+        /// <summary>
+        /// A list of URL patterns to allow. When set, the browser can only access URLs matching these patterns.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <strong>Requires Chrome 149+.</strong>
+        /// </para>
+        /// <para>
+        /// This option allows you to restrict the browser from accessing any URLs
+        /// except for those that match the patterns in the allowlist.
+        /// It uses the standard <see href="https://urlpattern.spec.whatwg.org/">URLPattern</see> API to match URLs.
+        /// </para>
+        /// <para>
+        /// For any network requests made by the browser (including navigations and
+        /// subresources like images or scripts), the request will fail with an error
+        /// if the URL does not match any pattern in the allowlist.
+        /// </para>
+        /// <para>
+        /// Currently only supported for CDP connections.
+        /// </para>
+        /// <para>
+        /// Cannot be used along with <see cref="BlockList"/>.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// Pattern to allow a specific domain: <c>*://example.com/*</c>
+        /// Pattern to allow all subdomains: <c>*://*.example.com/*</c>.
+        /// </example>
+        public string[] Allowlist { get; set; }
 
         /// <summary>
         /// Callback to decide if Puppeteer should connect to a given target or not.

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -62,6 +62,11 @@ namespace PuppeteerSharp
                 throw new ArgumentNullException(nameof(options));
             }
 
+            if (options.BlockList != null && options.Allowlist != null)
+            {
+                throw new PuppeteerException("Cannot specify both blocklist and allowlist");
+            }
+
             EnsureSingleLaunchOrConnect();
             _browser = options.Browser;
 
@@ -189,7 +194,8 @@ namespace PuppeteerSharp
                                 handleDevToolsAsPage: options.HandleDevToolsAsPage,
                                 networkEnabled: options.NetworkEnabled,
                                 issuesEnabled: options.IssuesEnabled,
-                                blockList: options.BlockList)
+                                blockList: options.BlockList,
+                                allowList: options.Allowlist)
                             .ConfigureAwait(false);
                     }
 
@@ -417,6 +423,11 @@ namespace PuppeteerSharp
 
         private async Task<IBrowser> ConnectCdpAsync(string browserWSEndpoint, ConnectOptions options)
         {
+            if (options.BlockList != null && options.Allowlist != null)
+            {
+                throw new PuppeteerException("Cannot specify both blocklist and allowlist");
+            }
+
             CdpConnection connection = null;
             try
             {
@@ -444,7 +455,8 @@ namespace PuppeteerSharp
                         options.HandleDevToolsAsPage,
                         options.NetworkEnabled,
                         options.IssuesEnabled,
-                        options.BlockList)
+                        options.BlockList,
+                        options.Allowlist)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Implements changes from:
- https://github.com/puppeteer/puppeteer/pull/14897 — URL allowlist for network restrictions
- https://github.com/puppeteer/puppeteer/pull/14931 — Fix: do not set global offline flag for allowlist

### Changes

- Adds `Allowlist` property to `LaunchOptions` and `ConnectOptions` (requires Chrome 149+)
- `ChromeTargetManager` now handles both blocklist and allowlist URL patterns
- Fixes the global `offline` flag in `Network.emulateNetworkConditionsByRule`: only set to `true` when a blocklist is active; when using an allowlist, the flag is omitted (per-rule offline flags handle blocking instead)
- Adds `ValidateUrlPatterns` to catch malformed URLPattern syntax (unbalanced parentheses) at construction time
- `NetworkEmulateNetworkConditionsByRuleRequest.Offline` changed from `bool` to `bool?` to support omitting the field
- `MatchedNetworkCondition` gains an `Offline` property for per-rule blocking/allowing
- New tests: allowlist navigation, fetch blocking, subresource blocking, connect detach, mutual exclusion, and invalid pattern validation
- Upstream test expectations updated for tests requiring Chrome 149+

## Test plan

- [ ] Build passes: `dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj` ✅
- [ ] New allowlist tests are marked FAIL in upstream expectations (require Chrome 149+)
- [ ] Blocklist tests continue to work unchanged
- [ ] Both blocklist + allowlist specified throws a `PuppeteerException`
- [ ] Invalid URL patterns throw at launch/connect time

🤖 Generated with [Claude Code](https://claude.com/claude-code)