### PR TITLE
fix: roll to Chrome 148.0.7778.97

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "147.0.7727.57";
+        public static string DefaultBuildId => "148.0.7778.97";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
## Summary

- Rolls Chrome `DefaultBuildId` from `147.0.7727.57` to `148.0.7778.97`
- Matches upstream puppeteer-core-v24.43.0 release (puppeteer/puppeteer#14929)

## Test plan

- [x] Main PuppeteerSharp library builds with 0 errors and 0 warnings across all target frameworks (netstandard2.0, net8.0, net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)