### PR TITLE
fix: roll to Firefox 150.0.1

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_150.0";
+        public const string DefaultBuildId = "stable_150.0.1";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
## Summary

- Rolls Firefox `DefaultBuildId` from `stable_150.0` to `stable_150.0.1` to match upstream Puppeteer PR [#14923](https://github.com/puppeteer/puppeteer/pull/14923)
- No test expectation changes required (upstream PR only changed the browser pin)

## Test plan

- [x] Main library builds successfully with no errors
- [ ] CI will validate Firefox BiDi tests against the new Firefox 150.0.1 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)