### PR TITLE
Fix #3448: correct CDP_ONLY condition check and missing using guards

### DIFF
--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -29,9 +29,12 @@ jobs:
       if: env.NUGET_TOKEN_TEST_EXISTS != ''
       run: |
         dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --api-key ${{secrets.NUGET_INT_API_KEY}} --source https://apiint.nugettest.org/v3/index.json
-    - name: Build (CDP only)
+    - name: Restore (CDP only)
       run: |
-        dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
+        dotnet restore lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY
+    - name: Build and Pack (CDP only)
+      run: |
+        dotnet pack lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
         ls ./lib/PuppeteerSharp/bin/Release
     - name: NugetPush to int.nuget.org (CDP only)
       env:

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -32,9 +32,12 @@ jobs:
       if: env.NUGET_TOKEN_EXISTS != ''
       run: |
         dotnet nuget push ./lib/PuppeteerSharp/bin/Release/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
-    - name: Build (CDP only)
+    - name: Restore (CDP only)
       run: |
-        dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
+        dotnet restore lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY
+    - name: Build and Pack (CDP only)
+      run: |
+        dotnet pack lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
         ls ./lib/PuppeteerSharp/bin/Release
     - name: NugetPush to nuget.org (CDP only)
       env:

--- a/lib/PuppeteerSharp/Bidi/BidiDeserializer.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiDeserializer.cs
@@ -23,9 +23,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using WebDriverBiDi.Script;
 
 #if !CDP_ONLY
+
+using WebDriverBiDi.Script;
 
 namespace PuppeteerSharp.Bidi;
 

--- a/lib/PuppeteerSharp/Bidi/Core/ScreenshotParameters.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/ScreenshotParameters.cs
@@ -20,9 +20,9 @@
 //  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  * SOFTWARE.
 
-using WebDriverBiDi.BrowsingContext;
-
 #if !CDP_ONLY
+
+using WebDriverBiDi.BrowsingContext;
 
 namespace PuppeteerSharp.Bidi.Core;
 

--- a/lib/PuppeteerSharp/Bidi/Core/Session.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/Session.cs
@@ -25,13 +25,14 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
+
+#if !CDP_ONLY
+
 using WebDriverBiDi;
 using WebDriverBiDi.BrowsingContext;
 using WebDriverBiDi.Input;
 using WebDriverBiDi.Network;
 using WebDriverBiDi.Session;
-
-#if !CDP_ONLY
 
 namespace PuppeteerSharp.Bidi.Core;
 

--- a/lib/PuppeteerSharp/Bidi/Core/SetViewportOptions.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/SetViewportOptions.cs
@@ -20,9 +20,9 @@
 //  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  * SOFTWARE.
 
-using WebDriverBiDi.BrowsingContext;
-
 #if !CDP_ONLY
+
+using WebDriverBiDi.BrowsingContext;
 
 namespace PuppeteerSharp.Bidi.Core;
 

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="WebDriverBiDi" Version="0.0.49" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
+    <PackageReference Include="WebDriverBiDi" Version="0.0.49" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
@@ -55,11 +55,11 @@
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(DefineConstants)' != 'CDP_ONLY' ">
+  <PropertyGroup Condition=" !$(DefineConstants.Contains('CDP_ONLY')) ">
     <ChromiumBidiVersion>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)Bidi/chromium-bidi.version').Trim())</ChromiumBidiVersion>
     <MapperTabPath>$(MSBuildThisFileDirectory)Bidi/mapperTab.js</MapperTabPath>
   </PropertyGroup>
-  <Target Name="DownloadMapperTab" BeforeTargets="PrepareForBuild" Condition=" '$(DefineConstants)' != 'CDP_ONLY' AND !Exists('$(MapperTabPath)') ">
+  <Target Name="DownloadMapperTab" BeforeTargets="PrepareForBuild" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) AND !Exists('$(MapperTabPath)') ">
     <PropertyGroup>
       <_TarballUrl>https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-$(ChromiumBidiVersion).tgz</_TarballUrl>
       <_TarballPath>$(IntermediateOutputPath)chromium-bidi-$(ChromiumBidiVersion).tgz</_TarballPath>
@@ -75,7 +75,7 @@
   </Target>
   <ItemGroup>
     <EmbeddedResource Include="Injected\injected.js" />
-    <EmbeddedResource Include="Bidi\mapperTab.js" Condition=" '$(DefineConstants)' != 'CDP_ONLY' " />
+    <EmbeddedResource Include="Bidi\mapperTab.js" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />


### PR DESCRIPTION
Fixes #3448

The `'$(DefineConstants)' != 'CDP_ONLY'` condition in `PuppeteerSharp.csproj` never worked correctly — when built with `/p:DefineConstants=CDP_ONLY`, MSBuild sets `DefineConstants` to `RELEASE;CDP_ONLY` (or `DEBUG;CDP_ONLY`), so the equality check always passed and `WebDriverBiDi` was always included. Switched to `!$(DefineConstants.Contains('CDP_ONLY'))` which works regardless of build configuration prefix.

Four files (`BidiDeserializer.cs`, `ScreenshotParameters.cs`, `SetViewportOptions.cs`, `Session.cs`) had `using WebDriverBiDi...` directives outside their `#if !CDP_ONLY` guards, which would cause compile errors when the package is excluded. Moved those usings inside the conditional blocks.

Updated both NuGet publish workflows to add a `dotnet restore /p:DefineConstants=CDP_ONLY` step before building the CDP-only package. Without this, the project.assets.json (written during the prior sln restore) still lists WebDriverBiDi and NuGet pack reads from it regardless of build conditions — so the `PuppeteerSharp.Cdp` package was shipping with an unnecessary WebDriverBiDi dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)