### PR TITLE
chore: sync WebMCP test expectations from upstream PR #14918 (#14918)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -4766,6 +4766,51 @@
     "comment": "Experimental support for WebMCP requires Chrome 149+."
   },
   {
+    "testIdPattern": "[webmcp.spec] Page.webmcp should fire toolinvoked events",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "PASS"
+    ]
+  },
+  {
+    "testIdPattern": "[webmcp.spec] Page.webmcp should fire toolresponded event with errorText",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "PASS"
+    ]
+  },
+  {
+    "testIdPattern": "[webmcp.spec] Page.webmcp should fire toolresponded event with exception",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "PASS"
+    ]
+  },
+  {
     "testIdPattern": "[webmcp.spec] Page.webmcp should remove tools on frame navigation",
     "platforms": [
       "darwin",


### PR DESCRIPTION
## Summary

Ports the test-expectations portion of upstream PR [puppeteer/puppeteer#14918](https://github.com/puppeteer/puppeteer/pull/14918). Adds three new PASS expectations for WebMCP tests that started passing in Chrome 148:

- `should fire toolinvoked events`
- `should fire toolresponded event with errorText`
- `should fire toolresponded event with exception`

The Chrome version bump in #14918 (148.0.7778.56) was already superseded by PR #3446 which rolled to 148.0.7778.97. The `@ts-expect-error` removals in `WebMCP.ts` are TypeScript-only and have no PuppeteerSharp equivalent (`CdpWebMcp.cs` uses dynamic CDP message parsing).

The three referenced tests aren't ported to PuppeteerSharp yet, so the expectations don't activate today — but the file now stays in sync with upstream for when they do get ported.

## Test plan

- [x] `dotnet build` succeeds with 0 errors / 0 warnings
- [x] JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)