### PR TITLE
Implement upstream PR #14946 - Roll Firefox to 150.0.2

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_150.0.1";
+        public const string DefaultBuildId = "stable_150.0.2";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Bumps the default Firefox build id from `stable_150.0.1` to `stable_150.0.2` to mirror upstream Puppeteer.

Upstream PR: https://github.com/puppeteer/puppeteer/pull/14946

The chromium-bidi pin (`14.0.0`) already matches upstream, so no other changes were needed.