### PR TITLE
fix: reject BiDi URL restrictions

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -382,4 +382,51 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
 
         Assert.That(error, Is.Not.Null);
     }
+
+    [Test, PuppeteerTest("BrowserConnector.test", "BrowserConnector _connectToBrowser", "should reject blocklist for WebDriver BiDi connections")]
+    public void ShouldRejectBlocklistForWebDriverBiDiConnections()
+    {
+        var connectOptions = new ConnectOptions
+        {
+            BrowserWSEndpoint = "ws://localhost:1234",
+            Protocol = ProtocolType.WebdriverBiDi,
+            BlockList = ["https://example.com/*"],
+        };
+
+        var error = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await Puppeteer.ConnectAsync(connectOptions));
+
+        Assert.That(error.Message, Does.Contain("blocklist and allowlist are only supported with the CDP protocol"));
+    }
+
+    [Test, PuppeteerTest("BrowserConnector.test", "BrowserConnector _connectToBrowser", "should reject allowlist for WebDriver BiDi connections")]
+    public void ShouldRejectAllowlistForWebDriverBiDiConnections()
+    {
+        var connectOptions = new ConnectOptions
+        {
+            BrowserWSEndpoint = "ws://localhost:1234",
+            Protocol = ProtocolType.WebdriverBiDi,
+            Allowlist = ["https://example.com/*"],
+        };
+
+        var error = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await Puppeteer.ConnectAsync(connectOptions));
+
+        Assert.That(error.Message, Does.Contain("blocklist and allowlist are only supported with the CDP protocol"));
+    }
+
+    [Test, PuppeteerTest("FirefoxLauncher.test", "FirefoxLauncher launch", "should reject blocklist for the default Firefox WebDriver BiDi protocol")]
+    public void ShouldRejectBlocklistForDefaultFirefoxWebDriverBiDiProtocol()
+    {
+        var options = new LaunchOptions
+        {
+            Browser = SupportedBrowser.Firefox,
+            BlockList = ["https://example.com/*"],
+        };
+
+        var error = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await Puppeteer.LaunchAsync(options));
+
+        Assert.That(error.Message, Does.Contain("blocklist and allowlist are only supported with the CDP protocol"));
+    }
 }

--- a/lib/PuppeteerSharp/Helpers/UrlRestrictionsValidator.cs
+++ b/lib/PuppeteerSharp/Helpers/UrlRestrictionsValidator.cs
@@ -1,0 +1,56 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+namespace PuppeteerSharp.Helpers
+{
+    /// <summary>
+    /// Provides validation for URL restriction options (blocklist/allowlist).
+    /// </summary>
+    internal static class UrlRestrictionsValidator
+    {
+        /// <summary>
+        /// Validates that the URL restrictions (<paramref name="blockList"/>/<paramref name="allowList"/>)
+        /// are supported by the given <paramref name="protocol"/>. URL restrictions are only enforced by
+        /// the CDP target/navigation path; BiDi connections (and Firefox's default BiDi launch path) do
+        /// not support them.
+        /// </summary>
+        /// <param name="protocol">The protocol that the connection or launch is using.</param>
+        /// <param name="blockList">The blocklist URL patterns.</param>
+        /// <param name="allowList">The allowlist URL patterns.</param>
+        /// <exception cref="PuppeteerException">
+        /// Thrown if both <paramref name="blockList"/> and <paramref name="allowList"/> are specified,
+        /// or if either is specified together with <see cref="ProtocolType.WebdriverBiDi"/>.
+        /// </exception>
+        public static void AssertSupportedUrlRestrictions(ProtocolType protocol, string[] blockList, string[] allowList)
+        {
+            if (blockList != null && allowList != null)
+            {
+                throw new PuppeteerException("Cannot specify both blocklist and allowlist");
+            }
+
+            if (protocol == ProtocolType.WebdriverBiDi && (blockList != null || allowList != null))
+            {
+                throw new PuppeteerException("blocklist and allowlist are only supported with the CDP protocol");
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -15,6 +15,7 @@ using PuppeteerSharp.Bidi;
 using PuppeteerSharp.BrowserData;
 using PuppeteerSharp.Cdp;
 using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Helpers.Json;
 #if !CDP_ONLY
 using WebDriverBiDi;
@@ -62,11 +63,6 @@ namespace PuppeteerSharp
                 throw new ArgumentNullException(nameof(options));
             }
 
-            if (options.BlockList != null && options.Allowlist != null)
-            {
-                throw new PuppeteerException("Cannot specify both blocklist and allowlist");
-            }
-
             EnsureSingleLaunchOrConnect();
             _browser = options.Browser;
 
@@ -79,6 +75,8 @@ namespace PuppeteerSharp
 
                 options.Protocol = ProtocolType.WebdriverBiDi;
             }
+
+            UrlRestrictionsValidator.AssertSupportedUrlRestrictions(options.Protocol, options.BlockList, options.Allowlist);
 
             var executable = options.ExecutablePath;
             if (executable == null)
@@ -277,6 +275,8 @@ namespace PuppeteerSharp
                 throw new PuppeteerException("Exactly one of browserWSEndpoint or browserURL must be passed to puppeteer.connect");
             }
 
+            UrlRestrictionsValidator.AssertSupportedUrlRestrictions(options.Protocol, options.BlockList, options.Allowlist);
+
             var browserWSEndpoint = string.IsNullOrEmpty(options.BrowserURL)
                 ? options.BrowserWSEndpoint
                 : await GetWSEndpointAsync(options.BrowserURL).ConfigureAwait(false);
@@ -423,11 +423,6 @@ namespace PuppeteerSharp
 
         private async Task<IBrowser> ConnectCdpAsync(string browserWSEndpoint, ConnectOptions options)
         {
-            if (options.BlockList != null && options.Allowlist != null)
-            {
-                throw new PuppeteerException("Cannot specify both blocklist and allowlist");
-            }
-
             CdpConnection connection = null;
             try
             {


### PR DESCRIPTION
Ports upstream Puppeteer PR [#14956](https://github.com/puppeteer/puppeteer/pull/14956). URL restrictions (`BlockList`/`Allowlist`) are only enforced by the CDP target/navigation path, so connecting via WebDriver BiDi (or launching Firefox, which defaults to BiDi) with either option set was silently accepting an unenforceable config. Now we throw early with a clear error.

The validation also moved into a shared `UrlRestrictionsValidator` helper, replacing the two duplicated "both blocklist and allowlist" checks in `Launcher.LaunchAsync` and `ConnectCdpAsync`. Validation in `LaunchAsync` now runs after the Firefox -> BiDi protocol coercion so the Firefox case is covered too, matching upstream behavior.

Added tests mirroring the new upstream cases for the connect and Firefox launch paths.