### PR TITLE
Implement upstream PR #14430 - dispose sub-classes correctly

### DIFF
--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -576,9 +576,12 @@ namespace PuppeteerSharp.Cdp
                 RemoveFramesRecursively(frame.ChildFrames.First() as Frame);
             }
 
-            frame.Detach();
             FrameTree.RemoveFrame(frame);
             FrameDetached?.Invoke(this, new FrameEventArgs(frame));
+
+            // Needs to be last to ensure events are dispatched before
+            // any per-frame cleanup runs. Mirrors upstream PR #14430.
+            frame.Detach();
         }
 
         private void OnFrameAttached(CDPSession session, PageFrameAttachedResponse frameAttached)


### PR DESCRIPTION
Ports the spirit of upstream Puppeteer PR [#14430](https://github.com/puppeteer/puppeteer/pull/14430) ("perf: dispose sub-classes correctly").

Upstream's fix is mostly about TypeScript's `disposeSymbol` / `asyncDisposeSymbol` pattern and an internal `EventEmitter` that removes all subscribers on dispose. PuppeteerSharp uses standard C# events whose delegate list is not cleared by `Dispose`, so the listener-removed-before-event-fires bug doesn't manifest the same way for us — most of the upstream diff is a no-op in C#.

The one place where the ordering actually matters in our code is `FrameManager.RemoveFramesRecursively`. `Frame.Detach()` does internal cleanup (world detachment, raising the per-frame `FrameDetached`) and used to run before the manager-level `FrameDetached` event. Now we mirror upstream: remove from the tree, fire `FrameDetached` on the manager, and only then call `frame.Detach()`. This keeps observability consistent if anything ever subscribes to manager-level detach events expecting the frame state hasn't been torn down yet.

Verified with the Frame, Navigation, Lifecycle, and Page test suites on Chrome + CDP — all green.