### PR TITLE
Implement upstream PR #14945 - optimize url blocking on navigation

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -34,7 +34,7 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
         });
 
         Assert.That(error, Is.Not.Null);
-        Assert.That(error.Message, Does.Contain("net::ERR_INTERNET_DISCONNECTED"));
+        Assert.That(error.Message, Does.Contain("is blocked by blocklist/allowlist rules"));
     }
 
     [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block window.location.href navigation to URLs in the blocklist")]
@@ -156,20 +156,29 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
         }
     }
 
-    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should not block chrome://version/ even if it matches blocklist")]
-    public async Task ShouldNotBlockChromeVersionEvenIfItMatchesBlocklist()
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block chrome://version/ when it matches blocklist")]
+    public async Task ShouldBlockChromeVersionWhenItMatchesBlocklist()
     {
-        const string chromeUrl = "chrome://version/";
+        const string blockedUrl = "chrome://version/";
         var options = TestConstants.DefaultBrowserOptions();
-        options.BlockList = [chromeUrl];
+        options.BlockList = [blockedUrl];
 
         await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
         await using var page = await browser.NewPageAsync();
 
-        await page.GoToAsync(chromeUrl);
+        Exception error = null;
+        await page.GoToAsync(blockedUrl).ContinueWith(t =>
+        {
+            if (t.IsFaulted)
+            {
+                error = t.Exception?.InnerException ?? t.Exception;
+            }
 
-        // Navigation should succeed as chrome:// URLs usually bypass the network
-        Assert.That(page.Url, Is.EqualTo(chromeUrl));
+            return t;
+        });
+
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error.Message, Does.Contain("is blocked by blocklist/allowlist rules"));
     }
 
     [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should only allow navigation to URLs in the allowlist")]
@@ -199,7 +208,7 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
 
         Assert.That(page.Url, Is.Not.EqualTo(blockedUrl));
         Assert.That(error, Is.Not.Null);
-        Assert.That(error.Message, Does.Contain("net::ERR_INTERNET_DISCONNECTED"));
+        Assert.That(error.Message, Does.Contain("is blocked by blocklist/allowlist rules"));
     }
 
     [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block window.location.href navigation to URLs not in the allowlist")]
@@ -381,5 +390,34 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
         }
 
         Assert.That(error, Is.Not.Null);
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block frame.goto when the destination is in the blocklist")]
+    public async Task ShouldBlockFrameGotoWhenDestinationIsInBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        await page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
+        var frame = Array.Find(page.Frames, f => f != page.MainFrame);
+        Assert.That(frame, Is.Not.Null);
+
+        var blockedUrl = TestConstants.ServerUrl + "/empty.html";
+        Exception error = null;
+        await frame.GoToAsync(blockedUrl).ContinueWith(t =>
+        {
+            if (t.IsFaulted)
+            {
+                error = t.Exception?.InnerException ?? t.Exception;
+            }
+
+            return t;
+        });
+
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error.Message, Does.Contain("is blocked by blocklist/allowlist rules"));
     }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -88,6 +88,13 @@ public class CdpFrame : Frame
             throw new ArgumentNullException(nameof(options));
         }
 
+        if (CdpPage != null && !CdpPage.IsUrlAllowed(url))
+        {
+            throw new NavigationException(
+                $"Navigation to {url} is blocked by blocklist/allowlist rules",
+                url);
+        }
+
         var referrer = string.IsNullOrEmpty(options.Referer)
             ? FrameManager.NetworkManager.ExtraHTTPHeaders?.GetValue(RefererHeaderName)
             : options.Referer;

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -901,6 +901,8 @@ public class CdpPage : Page
         return pixels / 96;
     }
 
+    internal bool IsUrlAllowed(string url) => _targetManager.IsUrlAllowed(url);
+
     /// <inheritdoc />
     protected override async Task ExposeFunctionAsync(string name, Delegate puppeteerFunction)
     {

--- a/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
@@ -112,6 +112,49 @@ namespace PuppeteerSharp.Cdp
 
         public IEnumerable<ITarget> GetChildTargets(ITarget target) => target.ChildTargets;
 
+        public bool IsUrlAllowed(string url)
+        {
+            var hasBlockList = _blockList != null && _blockList.Length > 0;
+            var hasAllowList = _allowList != null && _allowList.Length > 0;
+
+            if (!hasBlockList && !hasAllowList)
+            {
+                return true;
+            }
+
+            // Always allow internal or setup pages
+            if (string.IsNullOrEmpty(url) || url == "about:blank")
+            {
+                return true;
+            }
+
+            if (hasBlockList)
+            {
+                foreach (var pattern in _blockList)
+                {
+                    if (MatchesUrlPattern(url, pattern))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (hasAllowList)
+            {
+                foreach (var pattern in _allowList)
+                {
+                    if (MatchesUrlPattern(url, pattern))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
         private static void ValidateUrlPatterns(string[] patterns)
         {
             if (patterns == null)
@@ -457,49 +500,6 @@ namespace PuppeteerSharp.Cdp
 
             _attachedTargetsByTargetId.TryRemove(target.TargetId, out _);
             TargetGone?.Invoke(this, new TargetChangedArgs { Target = target });
-        }
-
-        private bool IsUrlAllowed(string url)
-        {
-            var hasBlockList = _blockList != null && _blockList.Length > 0;
-            var hasAllowList = _allowList != null && _allowList.Length > 0;
-
-            if (!hasBlockList && !hasAllowList)
-            {
-                return true;
-            }
-
-            // Always allow internal or setup pages
-            if (string.IsNullOrEmpty(url) || url == "about:blank")
-            {
-                return true;
-            }
-
-            if (hasBlockList)
-            {
-                foreach (var pattern in _blockList)
-                {
-                    if (MatchesUrlPattern(url, pattern))
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            if (hasAllowList)
-            {
-                foreach (var pattern in _allowList)
-                {
-                    if (MatchesUrlPattern(url, pattern))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            return true;
         }
 
         private async Task MaybeSetupNetworkBlockListAsync(CDPSession session)

--- a/lib/PuppeteerSharp/Cdp/FirefoxTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FirefoxTargetManager.cs
@@ -62,6 +62,8 @@ namespace PuppeteerSharp.Cdp
 
         public IEnumerable<ITarget> GetChildTargets(ITarget target) => [];
 
+        public bool IsUrlAllowed(string url) => true;
+
         private void OnMessageReceived(object sender, MessageEventArgs e)
         {
             try

--- a/lib/PuppeteerSharp/Cdp/ITargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ITargetManager.cs
@@ -49,5 +49,12 @@ namespace PuppeteerSharp
         /// <param name="target">Target to evaluate.</param>
         /// <returns>A list of targets.</returns>
         IEnumerable<ITarget> GetChildTargets(ITarget target);
+
+        /// <summary>
+        /// Validates a URL against the configured blocklist/allowlist patterns.
+        /// </summary>
+        /// <param name="url">URL to validate.</param>
+        /// <returns><c>true</c> if the URL is allowed, otherwise <c>false</c>.</returns>
+        bool IsUrlAllowed(string url);
     }
 }

--- a/lib/PuppeteerSharp/IFrame.cs
+++ b/lib/PuppeteerSharp/IFrame.cs
@@ -243,6 +243,7 @@ namespace PuppeteerSharp
         /// - the `timeout` is exceeded during navigation.
         /// - the remote server does not respond or is unreachable.
         /// - the main resource failed to load.
+        /// - the URL is blocked by blocklist/allowlist rules.
         ///
         /// <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> will not throw an error when any valid HTTP status code is returned by the remote server,
         /// including 404 "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling <see cref="IResponse.Status"/>


### PR DESCRIPTION
Mirrors upstream Puppeteer [#14945](https://github.com/puppeteer/puppeteer/pull/14945). Instead of waiting for the browser to fail a blocked navigation with `net::ERR_INTERNET_DISCONNECTED`, we now short-circuit `Frame.GoToAsync` and throw immediately when the destination URL doesn't pass the blocklist/allowlist check. Saves a round-trip and gives callers a clearer error message.

`IsUrlAllowed` was lifted out of `ChromeTargetManager` onto `ITargetManager` so `CdpPage` can ask the target manager before issuing `Page.navigate`. `FirefoxTargetManager` returns `true` since the feature is CDP-only.

Tests updated to match the new error string, and the `chrome://version/` test was renamed/inverted in line with upstream (it's now expected to be blocked too).