### PR TITLE
fix: route CDP responses by callback id when sessionId missing (upstream #14975)

### DIFF
--- a/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
+++ b/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using PuppeteerSharp.Cdp;
 using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Nunit;
 
 namespace PuppeteerSharp.Tests.CDPSessionTests
@@ -182,6 +185,24 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
             Assert.That(client.Detached, Is.False);
             await client.DetachAsync();
             Assert.That(client.Detached, Is.True);
+        }
+
+        [Test, PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should handle session callbacks when Chrome sends error without sessionId")]
+        public async Task ShouldHandleSessionCallbacksWhenChromeSendsErrorWithoutSessionId()
+        {
+            var client = (CDPSession)await Page.CreateCDPSessionAsync();
+            var connection = client.Connection;
+
+            var fakeSession = new CdpCDPSession(connection, TargetType.Other, "fake-session-id", null);
+
+            var sessionsField = typeof(Connection).GetField("_sessions", BindingFlags.Instance | BindingFlags.NonPublic);
+            var sessions = (AsyncDictionaryHelper<string, CdpCDPSession>)sessionsField!.GetValue(connection);
+            sessions!.AddItem("fake-session-id", fakeSession);
+
+            var exception = Assert.ThrowsAsync<MessageException>(() => fakeSession.SendAsync(
+                "Runtime.evaluate",
+                new RuntimeEvaluateRequest { Expression = "1 + 1" }));
+            Assert.That(exception!.Message, Does.Contain("Session with given id not found"));
         }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpCDPSession.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpCDPSession.cs
@@ -144,6 +144,8 @@ public class CdpCDPSession : CDPSession
 
     internal bool HasPendingCallbacks() => !_callbacks.IsEmpty;
 
+    internal bool HasCallback(int id) => _callbacks.ContainsKey(id);
+
     internal List<string> GetPendingProtocolErrors()
     {
         var result = new List<string>();

--- a/lib/PuppeteerSharp/Cdp/Connection.cs
+++ b/lib/PuppeteerSharp/Cdp/Connection.cs
@@ -368,6 +368,20 @@ namespace PuppeteerSharp.Cdp
                 {
                     MessageQueue.Enqueue(callback, obj);
                 }
+                else
+                {
+                    // Chrome can occasionally omit the sessionId on responses. Fall back
+                    // to a per-session callback lookup so the response is routed to the
+                    // session that originally issued the command (upstream #14975).
+                    foreach (var session in _sessions.Values)
+                    {
+                        if (session.HasCallback(obj.Id.Value))
+                        {
+                            session.OnMessage(obj);
+                            break;
+                        }
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
Chrome occasionally sends CDP responses without a sessionId, which caused the response to be dropped because the message id was not registered in the connection-level callback table. We now fall back to scanning per-session callbacks so the response reaches the session that actually issued the command.

Upstream: https://github.com/puppeteer/puppeteer/pull/14975