### PR TITLE
fix: normalize newline-separated headers to comma-separated (upstream #14492)

### DIFF
--- a/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
+++ b/lib/PuppeteerSharp.Tests/RequestInterceptionTests/RequestRespondTests.cs
@@ -231,17 +231,7 @@ namespace PuppeteerSharp.Tests.RequestInterceptionTests
 
             Assert.That(response.Status, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(response.Headers["foo"], Is.EqualTo("bar"));
-
-            // The separator used to handle headers with multiple values is browser
-            // specific. Chrome uses newline, Firefox uses comma-separated values.
-            if (!TestConstants.IsChrome)
-            {
-                Assert.That(response.Headers["arr"], Is.EqualTo("1, 2"));
-            }
-            else
-            {
-                Assert.That(response.Headers["arr"], Is.EqualTo("1\n2"));
-            }
+            Assert.That(response.Headers["arr"], Is.EqualTo("1, 2"));
 
             Assert.That(firstCookie?.Value, Is.EqualTo("1"));
             Assert.That(secondCookie?.Value, Is.EqualTo("2"));

--- a/lib/PuppeteerSharp.Tests/UtilitiesTests/HttpUtilsTests.cs
+++ b/lib/PuppeteerSharp.Tests/UtilitiesTests/HttpUtilsTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using PuppeteerSharp.Helpers;
+
+namespace PuppeteerSharp.Tests.UtilitiesTests
+{
+    public class HttpUtilsTests
+    {
+        [Test]
+        public void ShouldGiveSingleLineHeaderValueUnchanged()
+        {
+            var header = "application/json; charset=utf-8";
+
+            Assert.That(HttpUtils.NormalizeHeaderValue(header), Is.EqualTo(header));
+        }
+
+        [Test]
+        public void ShouldNormalizeMultilineHeaderWithNewlines()
+        {
+            var header = "text/html;\n charset=utf-8;\n boundary=something";
+
+            Assert.That(
+                HttpUtils.NormalizeHeaderValue(header),
+                Is.EqualTo("text/html;, charset=utf-8;, boundary=something"));
+        }
+
+        [Test]
+        public void ShouldTrimWhitespaceFromEachLine()
+        {
+            var header = "text/html; \n  charset=utf-8  \n   boundary=something   ";
+
+            Assert.That(
+                HttpUtils.NormalizeHeaderValue(header),
+                Is.EqualTo("text/html;, charset=utf-8, boundary=something"));
+        }
+
+        [Test]
+        public void ShouldFilterOutEmptyLines()
+        {
+            var header = "text/html;\n\n charset=utf-8;\n\n\n boundary=something";
+
+            Assert.That(
+                HttpUtils.NormalizeHeaderValue(header),
+                Is.EqualTo("text/html;, charset=utf-8;, boundary=something"));
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.Bidi;
 
@@ -77,7 +78,7 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var header in data.Headers)
         {
-            Headers[header.Name] = header.Value.Value;
+            Headers[header.Name] = HttpUtils.NormalizeHeaderValue(header.Value.Value);
         }
     }
 
@@ -106,7 +107,7 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var header in data.Headers)
         {
-            Headers[header.Name] = header.Value.Value;
+            Headers[header.Name] = HttpUtils.NormalizeHeaderValue(header.Value.Value);
         }
     }
 

--- a/lib/PuppeteerSharp/Cdp/CdpHttpResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpResponse.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.Cdp;
 
@@ -34,7 +35,7 @@ public partial class CdpHttpResponse : Response<CdpHttpRequest>
         {
             foreach (var keyValue in headers)
             {
-                Headers[keyValue.Key] = keyValue.Value;
+                Headers[keyValue.Key] = HttpUtils.NormalizeHeaderValue(keyValue.Value);
             }
         }
 

--- a/lib/PuppeteerSharp/Helpers/HttpUtils.cs
+++ b/lib/PuppeteerSharp/Helpers/HttpUtils.cs
@@ -1,0 +1,46 @@
+using System.Text;
+
+namespace PuppeteerSharp.Helpers;
+
+/// <summary>
+/// Helpers for normalizing HTTP-related values.
+/// </summary>
+internal static class HttpUtils
+{
+    /// <summary>
+    /// Normalizes HTTP header values by handling multiline values.
+    /// Multiline header values are joined with commas according to
+    /// <see href="https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2">RFC 9110 Section 5.2</see>.
+    /// </summary>
+    /// <param name="header">The header value to normalize.</param>
+    /// <returns>The normalized header value.</returns>
+    public static string NormalizeHeaderValue(string header)
+    {
+        if (header == null || header.IndexOf('\n') == -1)
+        {
+            return header;
+        }
+
+        var parts = header.Split('\n');
+        var builder = new StringBuilder(header.Length);
+        var first = true;
+        foreach (var part in parts)
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            if (!first)
+            {
+                builder.Append(", ");
+            }
+
+            builder.Append(trimmed);
+            first = false;
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
CDP returns duplicate HTTP response headers joined with `\n`, which is invalid per RFC 9110 and made `Response.Headers` values unusable for some sites. Added `HttpUtils.NormalizeHeaderValue` and route both `CdpHttpResponse` and `BidiHttpResponse` header parsing through it so consumers always get a single comma-separated value.

BREAKING CHANGE: response headers that previously came back as `"a\nb"` are now `"a, b"`.

Upstream: https://github.com/puppeteer/puppeteer/pull/14492