### PR TITLE
fix: block emulateNetworkConditions when block/allowlist is active (upstream #14976)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -469,4 +469,39 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
 
         Assert.That(error.Message, Does.Contain("blocklist and allowlist are only supported with the CDP protocol"));
     }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block standard emulation reset when blocklist/allowlist is active")]
+    public async Task ShouldBlockStandardEmulationResetWhenBlocklistAllowlistIsActive()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/empty.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        var session = await page.CreateCDPSessionAsync();
+
+        var sessionError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await session.SendAsync(
+                "Network.emulateNetworkConditions",
+                new
+                {
+                    offline = false,
+                    latency = 0,
+                    downloadThroughput = 0,
+                    uploadThroughput = 0,
+                }));
+
+        Assert.That(sessionError.Message, Does.Contain("Cannot reset network conditions: rule-based emulation is enabled."));
+
+        var pageError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await page.EmulateNetworkConditionsAsync(new NetworkConditions
+            {
+                Latency = 0,
+                Download = 0,
+                Upload = 0,
+            }));
+
+        Assert.That(pageError.Message, Does.Contain("Cannot reset network conditions: rule-based emulation is enabled."));
+    }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -76,6 +76,8 @@ public class CdpBrowser : Browser
             contextIds.Select(contextId =>
                 new KeyValuePair<string, CdpBrowserContext>(contextId, new(Connection, this, contextId))));
 
+        Connection.RejectEmulateNetworkConditionsCalls = (blockList != null && blockList.Length > 0) || (allowList != null && allowList.Length > 0);
+
         if (browser == SupportedBrowser.Firefox)
         {
             TargetManager = new FirefoxTargetManager(

--- a/lib/PuppeteerSharp/Cdp/CdpCDPSession.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpCDPSession.cs
@@ -86,6 +86,11 @@ public class CdpCDPSession : CDPSession
                 CloseReason);
         }
 
+        if (method == "Network.emulateNetworkConditions" && Connection.RejectEmulateNetworkConditionsCalls)
+        {
+            throw new PuppeteerException("Cannot reset network conditions: rule-based emulation is enabled.");
+        }
+
         var id = GetMessageId();
         var message = Connection.GetMessage(id, method, args, Id);
 

--- a/lib/PuppeteerSharp/Cdp/Connection.cs
+++ b/lib/PuppeteerSharp/Cdp/Connection.cs
@@ -99,6 +99,8 @@ namespace PuppeteerSharp.Cdp
 
         internal int ProtocolTimeout { get; }
 
+        internal bool RejectEmulateNetworkConditionsCalls { get; set; }
+
         /// <inheritdoc />
         public void Dispose()
         {
@@ -112,6 +114,11 @@ namespace PuppeteerSharp.Cdp
             if (IsClosed)
             {
                 throw new TargetClosedException($"Protocol error({method}): Target closed.", CloseReason);
+            }
+
+            if (method == "Network.emulateNetworkConditions" && RejectEmulateNetworkConditionsCalls)
+            {
+                throw new PuppeteerException("Cannot reset network conditions: rule-based emulation is enabled.");
             }
 
             var id = GetMessageId();


### PR DESCRIPTION
Block standard `Network.emulateNetworkConditions` from `Connection.SendAsync` and `CdpCDPSession.SendAsync` whenever a blocklist or allowlist is in effect. Resetting network conditions while rule-based emulation is enabled would silently clobber those restrictions, so the calls now throw a clear "Cannot reset network conditions: rule-based emulation is enabled." error instead.

Upstream: https://github.com/puppeteer/puppeteer/pull/14976