### PR TITLE
fix: don't store request on BrowsingContext (upstream #14966)

### DIFF
--- a/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
@@ -39,7 +39,6 @@ internal class BrowsingContext : IDisposable
     private readonly ConcurrentDictionary<string, BrowsingContext> _children = new();
     private readonly List<string> _childrenOrder = new();
     private readonly object _childrenLock = new();
-    private readonly ConcurrentDictionary<string, Request> _requests = new();
     private string _reason;
     private Navigation _navigation;
 
@@ -382,14 +381,6 @@ internal class BrowsingContext : IDisposable
                 return;
             }
 
-            foreach (var entry in _requests)
-            {
-                if (entry.Value.IsDisposed)
-                {
-                    _requests.TryRemove(entry.Key, out _);
-                }
-            }
-
             // Dispose old navigation if exists - a new navigation has started
             _navigation?.Dispose();
 
@@ -421,13 +412,14 @@ internal class BrowsingContext : IDisposable
                 return;
             }
 
-            if (_requests.ContainsKey(args.Request.RequestId))
+            if (args.RedirectCount > 0)
             {
+                // Means the request is a redirect. This is handled in Request.
+                // Or an Auth event was issued
                 return;
             }
 
             var request = Core.Request.From(this, args);
-            _requests.TryAdd(args.Request.RequestId, request);
             Request?.Invoke(this, new RequestEventArgs(request));
         };
 


### PR DESCRIPTION
Mirrors upstream Puppeteer's fix to stop tracking pending requests on the BrowsingContext. We now detect redirect requests by checking `RedirectCount > 0` on the `NetworkBeforeRequestSent` event instead of consulting a per-context request map, which also lets us drop the per-navigation cleanup pass that scrubbed disposed requests.

Upstream: https://github.com/puppeteer/puppeteer/pull/14966