### PR TITLE
fix!: remove Cookie SameParty attribute (upstream #14545)

### DIFF
--- a/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/CookiesTests/SetCookiesTests.cs
@@ -135,9 +135,6 @@ namespace PuppeteerSharp.Tests.CookiesTests
                 Value = "123456",
                 Domain = "localhost",
                 Path = "/",
-#pragma warning disable CS0618 // SameParty is deprecated
-                SameParty = false,
-#pragma warning restore CS0618
                 Expires = -1,
                 HttpOnly = false,
                 Secure = false,

--- a/lib/PuppeteerSharp/Bidi/BidiCookieHelper.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiCookieHelper.cs
@@ -84,13 +84,6 @@ internal static class BidiCookieHelper
         }
 
         // Add CDP-specific properties if needed
-#pragma warning disable CS0618 // SameParty is deprecated
-        if (cookie.SameParty.HasValue)
-        {
-            bidiCookie.AdditionalData["goog:sameParty"] = cookie.SameParty.Value;
-        }
-#pragma warning restore CS0618
-
         if (cookie.SourceScheme.HasValue)
         {
             bidiCookie.AdditionalData["goog:sourceScheme"] = ConvertSourceSchemeEnumToString(cookie.SourceScheme.Value);
@@ -137,13 +130,6 @@ internal static class BidiCookieHelper
         {
             bidiCookie.Expires = DateTimeOffset.FromUnixTimeSeconds((long)cookie.Expires.Value).DateTime;
         }
-
-#pragma warning disable CS0618 // SameParty is deprecated
-        if (cookie.SameParty.HasValue)
-        {
-            bidiCookie.AdditionalData["goog:sameParty"] = cookie.SameParty.Value;
-        }
-#pragma warning restore CS0618
 
         if (cookie.SourceScheme.HasValue)
         {

--- a/lib/PuppeteerSharp/CookieData.cs
+++ b/lib/PuppeteerSharp/CookieData.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json.Serialization;
 using PuppeteerSharp.Helpers.Json;
 
@@ -53,12 +52,6 @@ namespace PuppeteerSharp
         /// Cookie Priority. Supported only in Chrome.
         /// </summary>
         public CookiePriority? Priority { get; set; }
-
-        /// <summary>
-        /// Always set to false. Supported only in Chrome.
-        /// </summary>
-        [Obsolete("SameParty is deprecated and always ignored.")]
-        public bool? SameParty { get; set; }
 
         /// <summary>
         /// Cookie source scheme type. Supported only in Chrome.

--- a/lib/PuppeteerSharp/CookieParam.cs
+++ b/lib/PuppeteerSharp/CookieParam.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json.Serialization;
 using PuppeteerSharp.Helpers.Json;
 
@@ -81,12 +80,6 @@ namespace PuppeteerSharp
         /// Cookie Priority. Supported only in Chrome.
         /// </summary>
         public CookiePriority? Priority { get; set; }
-
-        /// <summary>
-        /// Always set to false. Supported only in Chrome.
-        /// </summary>
-        [Obsolete("SameParty is deprecated and always ignored.")]
-        public bool? SameParty { get; set; }
 
         /// <summary>
         /// Cookie source scheme type. Supported only in Chrome.


### PR DESCRIPTION
Chrome deprecated the `sameParty` cookie attribute years ago and has been setting it to `false` internally ever since. Upstream Puppeteer dropped it in a breaking change, so this removes the matching `[Obsolete]` property from `CookieData` and `CookieParam`, and stops forwarding `goog:sameParty` through the BiDi cookie helpers.

BREAKING: `CookieData.SameParty` and `CookieParam.SameParty` are gone.

Upstream: https://github.com/puppeteer/puppeteer/pull/14545