### PR TITLE
chore: roll Firefox to 150.0.3 (upstream #14983)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_150.0.2";
+        public const string DefaultBuildId = "stable_150.0.3";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Bump the default Firefox build to stable_150.0.3 to match upstream.

Upstream: https://github.com/puppeteer/puppeteer/pull/14983