### PR TITLE
chore: roll Chrome to 148.0.7778.167 (upstream #14980)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "148.0.7778.97";
+        public static string DefaultBuildId => "148.0.7778.167";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
Bumps the bundled Chrome build from 148.0.7778.97 to 148.0.7778.167 to keep us in sync with the latest upstream pin.

Upstream: https://github.com/puppeteer/puppeteer/pull/14980