### PR TITLE
chore: bump version to 25.0.4

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>24.42.0</PackageVersion>
-    <ReleaseVersion>24.42.0</ReleaseVersion>
-    <AssemblyVersion>24.42.0</AssemblyVersion>
-    <FileVersion>24.42.0</FileVersion>
+    <PackageVersion>25.0.4</PackageVersion>
+    <ReleaseVersion>25.0.4</ReleaseVersion>
+    <AssemblyVersion>25.0.4</AssemblyVersion>
+    <FileVersion>25.0.4</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Aligns the PuppeteerSharp package version with upstream puppeteer-core v25.0.x. Bumps `PackageVersion`, `ReleaseVersion`, `AssemblyVersion`, and `FileVersion` in `PuppeteerSharp.csproj` from 24.42.0 to 25.0.4.