### PR TITLE
Make ICdpHandle interface public

### DIFF
--- a/lib/PuppeteerSharp/Cdp/ICdpHandle.cs
+++ b/lib/PuppeteerSharp/Cdp/ICdpHandle.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.Cdp;
 /// <summary>
 /// CDP Specific handle info.
 /// </summary>
-internal interface ICdpHandle : IJSHandle
+public interface ICdpHandle : IJSHandle
 {
     /// <summary>
     /// CDP remote object.


### PR DESCRIPTION
Would it be ok to change `ICdpHandle` access modifier from `Internal` to `Public`?

I was going to upgrade [PuppeteerSharp.Dom](https://github.com/ChromiumDotNet/PuppeteerSharp.Dom) to support the latest version and having access to the interface would make that easier. 

Previously I used `IJSHandle.RemoteObject` to determine details about the object, since that's been moved to moved to `ICdpHandle` using that interface instead would make the transition easy.

Thanks, for the fantastic project 👍 

