### PR TITLE
fix: roll Chrome to 148.0.7778.178 + bump to 25.1.0 (upstream #15014)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "148.0.7778.167";
+        public static string DefaultBuildId => "148.0.7778.178";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.0.4</PackageVersion>
-    <ReleaseVersion>25.0.4</ReleaseVersion>
-    <AssemblyVersion>25.0.4</AssemblyVersion>
-    <FileVersion>25.0.4</FileVersion>
+    <PackageVersion>25.1.0</PackageVersion>
+    <ReleaseVersion>25.1.0</ReleaseVersion>
+    <AssemblyVersion>25.1.0</AssemblyVersion>
+    <FileVersion>25.1.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Rolls the pinned Chrome build to `148.0.7778.178` (`Chrome.DefaultBuildId`) and bumps the project version to `25.1.0` for the release.

Upstream: https://github.com/puppeteer/puppeteer/pull/15014