### PR TITLE
chore: roll Firefox to 151.0 (upstream #15013)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -32,21 +32,6 @@
   {
     "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should get and set browser window bounds",
     "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "Not supported by Firefox"
-  },
-  {
-    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should get and set browser window bounds",
-    "platforms": [
       "win32"
     ],
     "parameters": [
@@ -1566,21 +1551,6 @@
       "FAIL"
     ],
     "comment": "In headless shell all pages are in foreground"
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.newPage should open pages in a new window at the specified position",
-    "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "Not supported by WebDriver BiDi"
   },
   {
     "testIdPattern": "[page.spec] Page Page.newPage should open pages in a new window at the specified position",
@@ -4058,6 +4028,21 @@
     "expectations": [
       "PASS"
     ]
+  },
+  {
+    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should get and set browser window bounds",
+    "platforms": [
+      "darwin"
+    ],
+    "parameters": [
+      "firefox",
+      "headful",
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Different dimensions on Mac for headful"
   },
   {
     "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should get and set browser window bounds",

--- a/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpRequest.cs
@@ -109,6 +109,11 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
 
     internal BidiPage BidiPage => (BidiPage)Frame.Page;
 
+    // True only for the canonical request that actually emitted the Request event.
+    // Firefox sends duplicate (phantom) BeforeRequestSent events for the same URL during navigation;
+    // those phantoms are deduplicated and must not drive page-level events like RequestServedFromCache.
+    internal bool RequestEventEmitted { get; private set; }
+
     internal WebDriverBiDi.Network.FetchTimingInfo Timings => _request.Timings;
 
     internal ConcurrentDictionary<string, string> ExtraHttpHeaders => BidiPage.ExtraHttpHeaders;
@@ -613,6 +618,7 @@ public class BidiHttpRequest : Request<BidiHttpResponse>
         // (in GoToAsync) so that subsequent fetch/XHR calls to the same URLs work correctly.
         if (BidiPage.TryMarkRequestEventFired(Url))
         {
+            RequestEventEmitted = true;
             BidiPage.OnRequest(this);
         }
 

--- a/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
@@ -160,10 +160,12 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         {
             _request.FromMemoryCache = true;
 
-            // Only fire RequestServedFromCache if this URL hasn't already been reported.
-            // Firefox BiDi can send duplicate BeforeRequestSent events with different request IDs,
-            // each getting its own BidiHttpRequest, but we should only report the cache event once per URL.
-            if (_request.BidiPage.TryMarkCacheEventFired(_request.Url))
+            // Only fire RequestServedFromCache for the canonical request that actually emitted the
+            // Request event. Firefox BiDi sends duplicate BeforeRequestSent events with different
+            // request IDs for the same URL during navigation; on a cold load the phantom duplicate
+            // can report fromCache=true even though the real request was served from the network.
+            // Reporting that phantom would wrongly mark the resource as served from cache.
+            if (_request.RequestEventEmitted && _request.BidiPage.TryMarkCacheEventFired(_request.Url))
             {
                 ((Page)_request.Frame.Page).OnRequestServedFromCache(new RequestEventArgs(_request));
             }

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_150.0.3";
+        public const string DefaultBuildId = "stable_151.0";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Rolls the pinned Firefox build from stable_150.0.3 to stable_151.0 to match upstream, and syncs the Firefox window-bounds / new-window-position test expectations: drops the two "not supported" Firefox expectations that now pass, and adds a headful macOS expectation for the window-bounds test.

The roll surfaced a latent BiDi bug. On a cold navigation, Firefox 151 sends a duplicate (phantom) `BeforeRequestSent` for cached sub-resources with a different request ID. The real request is served from the network (`fromCache=false`), but the phantom reports `fromCache=true`. We already dedup the phantom's `Request` event by URL, but its cache event still fired through an independent tracker, so a cold load wrongly reported the stylesheet as served from cache (`RequestServedFromCache for stylesheet` failed on Firefox). Fixed by only firing `RequestServedFromCache` for the canonical request that actually emitted its `Request` event, so phantom duplicates can't drive the cache event.

Upstream: https://github.com/puppeteer/puppeteer/pull/15013