### PR TITLE
Avoid leaking TargetChangedArgs event handlers

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
@@ -450,9 +450,9 @@ public class BidiBrowser : Browser
 
         foreach (var context in _browserContexts.Values)
         {
-            context.TargetCreated -= (sender, args) => OnTargetCreated(args);
-            context.TargetChanged -= (sender, args) => OnTargetChanged(args);
-            context.TargetDestroyed -= (sender, args) => OnTargetDestroyed(args);
+            context.TargetCreated -= OnTargetCreated;
+            context.TargetChanged -= OnTargetChanged;
+            context.TargetDestroyed -= OnTargetDestroyed;
         }
     }
 
@@ -465,12 +465,18 @@ public class BidiBrowser : Browser
 
         _browserContexts.TryAdd(userContext, browserContext);
 
-        browserContext.TargetCreated += (sender, args) => OnTargetCreated(args);
-        browserContext.TargetChanged += (sender, args) => OnTargetChanged(args);
-        browserContext.TargetDestroyed += (sender, args) => OnTargetDestroyed(args);
+        browserContext.TargetCreated += OnTargetCreated;
+        browserContext.TargetChanged += OnTargetChanged;
+        browserContext.TargetDestroyed += OnTargetDestroyed;
 
         return browserContext;
     }
+
+    private void OnTargetCreated(object sender, TargetChangedArgs args) => OnTargetCreated(args);
+
+    private void OnTargetChanged(object sender, TargetChangedArgs args) => OnTargetChanged(args);
+
+    private void OnTargetDestroyed(object sender, TargetChangedArgs args) => OnTargetDestroyed(args);
 }
 
 #endif


### PR DESCRIPTION
Deregistering events via an anonymous delegate can be problematic.

See e.g.
https://www.jetbrains.com/help/rider/EventUnsubscriptionViaAnonymousDelegate.html
https://pvs-studio.com/en/docs/warnings/v3084/

Used the code below to verify that the memory dump diff after the fix no longer contained instances of `TargetChangedArgs`.

```cs
using System;
using System.Threading.Tasks;
using NUnit.Framework;

namespace PuppeteerSharp.Tests.BrowserContextTests;

public class EventHandlerLeaks
{
    [Test]
    public async Task Event_Handler_leaks()
    {
        GC.Collect(4, GCCollectionMode.Forced, true, true);
        GC.WaitForPendingFinalizers();

        ; // Take memory dump
        {
            var launcher = new Launcher();
            await using var browser = await launcher.LaunchAsync(new()
            {
                Protocol = ProtocolType.WebdriverBiDi,
                Browser = SupportedBrowser.ChromeHeadlessShell
            });
            for (var i = 0; i < 500; i++)
            {
                await using var context = await browser.CreateBrowserContextAsync();
            }

            browser.Disconnect();
            await browser.CloseAsync();
        }

        GC.Collect(4, GCCollectionMode.Forced, true, true);
        GC.WaitForPendingFinalizers();
        ; // Take memory dump and compare
    }
}
```