### PR TITLE
fix: ensure CDP-only package is compiled without WebDriverBiDi references

### DIFF
--- a/.github/workflows/PushNugetPackageToIntNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToIntNugetOrg.yml
@@ -32,9 +32,12 @@ jobs:
     - name: Restore (CDP only)
       run: |
         dotnet restore lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY
-    - name: Build and Pack (CDP only)
+    - name: Build (CDP only)
       run: |
-        dotnet pack lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
+        dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY --configuration Release --no-restore --no-incremental
+    - name: Pack (CDP only)
+      run: |
+        dotnet pack lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore --no-build
         ls ./lib/PuppeteerSharp/bin/Release
     - name: NugetPush to int.nuget.org (CDP only)
       env:

--- a/.github/workflows/PushNugetPackageToNugetOrg.yml
+++ b/.github/workflows/PushNugetPackageToNugetOrg.yml
@@ -35,9 +35,12 @@ jobs:
     - name: Restore (CDP only)
       run: |
         dotnet restore lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY
-    - name: Build and Pack (CDP only)
+    - name: Build (CDP only)
       run: |
-        dotnet pack lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore
+        dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY --configuration Release --no-restore --no-incremental
+    - name: Pack (CDP only)
+      run: |
+        dotnet pack lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY /p:Title=PuppeteerSharp.Cdp /p:PackageId=PuppeteerSharp.Cdp /p:Description="Headless Browser .NET API with CDP support only (no WebDriverBiDi)" --configuration Release --no-restore --no-build
         ls ./lib/PuppeteerSharp/bin/Release
     - name: NugetPush to nuget.org (CDP only)
       env:

--- a/lib/Common/CommonProps.props
+++ b/lib/Common/CommonProps.props
@@ -10,7 +10,8 @@
       <Link>keypair.snk</Link>
     </None>
   </ItemGroup>
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent"
+          Condition=" !$(DefineConstants.Contains('CDP_ONLY')) ">
     <Exec Command="dotnet format $(ProjectPath) --exclude-diagnostics CA1865" />
   </Target>
 </Project>

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.1.0</PackageVersion>
-    <ReleaseVersion>25.1.0</ReleaseVersion>
-    <AssemblyVersion>25.1.0</AssemblyVersion>
-    <FileVersion>25.1.0</FileVersion>
+    <PackageVersion>25.1.1</PackageVersion>
+    <ReleaseVersion>25.1.1</ReleaseVersion>
+    <AssemblyVersion>25.1.1</AssemblyVersion>
+    <FileVersion>25.1.1</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Fixes #3477

The `PuppeteerSharp.Cdp` package was shipping a DLL that still referenced WebDriverBiDi types, even though the nuspec correctly excluded the dependency. At runtime the CLR would try to load WebDriverBiDi, fail, and throw `FileNotFoundException`.

Root cause: MSBuild's incremental build skipped recompilation when the CI workflow switched from the normal build to a `CDP_ONLY` pack. The normal-build DLL (with BiDi IL) was considered up-to-date by timestamp, so it was bundled as-is into the CDP package.

The fix is two-pronged:
- Split "Build and Pack" into two steps: `dotnet build --no-incremental` (forces a fresh CDP_ONLY compile) followed by `dotnet pack --no-build` (packages the correct DLL without rebuilding again).
- Skip the `dotnet format` pre-build hook for CDP_ONLY builds — `dotnet format` was doing an implicit restore that put WebDriverBiDi back into `project.assets.json`, which would corrupt the nuspec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)