### PR TITLE
fix: support WebDriverBiDi 0.0.54+ (fixes #3479)

### DIFF
--- a/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
+++ b/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
@@ -108,7 +108,7 @@ internal class PuppeteerConnection : BidiConnection
     {
         try
         {
-            await OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(e.Message)).ConfigureAwait(false);
+            await InvocableConnectionDataReceivedObservableEvent.InvokeNotifyObserversAsync(new ConnectionDataReceivedEventArgs(e.Message)).ConfigureAwait(false);
         }
         catch
         {

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -46,11 +46,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="WebDriverBiDi" Version="0.0.49" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
+    <PackageReference Include="WebDriverBiDi" Version="0.0.54" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.1.1</PackageVersion>
-    <ReleaseVersion>25.1.1</ReleaseVersion>
-    <AssemblyVersion>25.1.1</AssemblyVersion>
-    <FileVersion>25.1.1</FileVersion>
+    <PackageVersion>25.1.2</PackageVersion>
+    <ReleaseVersion>25.1.2</ReleaseVersion>
+    <AssemblyVersion>25.1.2</AssemblyVersion>
+    <FileVersion>25.1.2</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
WebDriverBiDi made breaking API changes across versions 0.0.53–0.0.54:

- **0.0.53**: `NotifyObserversAsync` was removed from the public `ObservableEvent<T>` and moved to the protected `ObservableEventInvocable<T>` class
- **0.0.54**: `NotifyObserversAsync` on `ObservableEventInvocable<T>` was renamed to `InvokeNotifyObserversAsync`

PuppeteerSharp's `PuppeteerConnection` was calling `OnDataReceived.NotifyObserversAsync(...)` which no longer existed at runtime when users installed WebDriverBiDi >= 0.0.53, causing a `MissingMethodException`.

Fixed by bumping the WebDriverBiDi dependency to 0.0.54 and updating `PuppeteerConnection` to use the new protected `InvocableConnectionDataReceivedObservableEvent.InvokeNotifyObserversAsync(...)`. Also bumped the transitive `Microsoft.Bcl.AsyncInterfaces` and `System.Text.Json` pins (netstandard2.0 only) from 10.0.3 to 10.0.7 to match WebDriverBiDi 0.0.54's requirements.

Fixes #3479

🤖 Generated with [Claude Code](https://claude.com/claude-code)