### PR TITLE
fix: open a new window when creating a page with no existing targets

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -341,9 +341,7 @@ public class CdpBrowser : Browser
             WindowState = windowBounds?.WindowState,
 
             // Works around crbug.com/454825274.
-            // When no targets exist (e.g. all pages were closed in headful mode), Chrome has no
-            // browser window. We must request a new window so Chrome can create the page.
-            NewWindow = (!hasTargets || options?.Type == CreatePageType.Window) ? true : null,
+            NewWindow = hasTargets && options?.Type == CreatePageType.Window ? true : null,
             Background = options?.Background,
         };
 
@@ -357,8 +355,21 @@ public class CdpBrowser : Browser
                 : contextId;
         }
 
-        var targetId = (await Connection.SendAsync<TargetCreateTargetResponse>("Target.createTarget", createTargetRequest)
-            .ConfigureAwait(false)).TargetId;
+        string targetId;
+        try
+        {
+            targetId = (await Connection.SendAsync<TargetCreateTargetResponse>("Target.createTarget", createTargetRequest)
+                .ConfigureAwait(false)).TargetId;
+        }
+        catch (MessageException ex) when (ex.Message.Contains("Failed to open a new tab"))
+        {
+            // Chrome in headful mode has no browser window (all pages were closed).
+            // Retry with newWindow=true to create a new browser window.
+            createTargetRequest.NewWindow = true;
+            targetId = (await Connection.SendAsync<TargetCreateTargetResponse>("Target.createTarget", createTargetRequest)
+                .ConfigureAwait(false)).TargetId;
+        }
+
         var target = await WaitForTargetAsync(t => ((CdpTarget)t).TargetId == targetId).ConfigureAwait(false) as CdpTarget;
         await target!.InitializedTask.ConfigureAwait(false);
         return await target.PageAsync().ConfigureAwait(false);

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -341,7 +341,9 @@ public class CdpBrowser : Browser
             WindowState = windowBounds?.WindowState,
 
             // Works around crbug.com/454825274.
-            NewWindow = hasTargets && options?.Type == CreatePageType.Window ? true : null,
+            // When no targets exist (e.g. all pages were closed in headful mode), Chrome has no
+            // browser window. We must request a new window so Chrome can create the page.
+            NewWindow = (!hasTargets || options?.Type == CreatePageType.Window) ? true : null,
             Background = options?.Background,
         };
 

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -341,7 +341,9 @@ public class CdpBrowser : Browser
             WindowState = windowBounds?.WindowState,
 
             // Works around crbug.com/454825274.
-            NewWindow = hasTargets && options?.Type == CreatePageType.Window ? true : null,
+            // When no targets exist (e.g. all pages were closed in headful mode), Chrome has no
+            // browser window. We must request a new window so Chrome can create the page.
+            NewWindow = (!hasTargets || options?.Type == CreatePageType.Window) ? true : null,
             Background = options?.Background,
         };
 
@@ -355,20 +357,8 @@ public class CdpBrowser : Browser
                 : contextId;
         }
 
-        string targetId;
-        try
-        {
-            targetId = (await Connection.SendAsync<TargetCreateTargetResponse>("Target.createTarget", createTargetRequest)
-                .ConfigureAwait(false)).TargetId;
-        }
-        catch (MessageException ex) when (ex.Message.Contains("Failed to open a new tab"))
-        {
-            // Chrome in headful mode has no browser window (all pages were closed).
-            // Retry with newWindow=true to create a new browser window.
-            createTargetRequest.NewWindow = true;
-            targetId = (await Connection.SendAsync<TargetCreateTargetResponse>("Target.createTarget", createTargetRequest)
-                .ConfigureAwait(false)).TargetId;
-        }
+        var targetId = (await Connection.SendAsync<TargetCreateTargetResponse>("Target.createTarget", createTargetRequest)
+            .ConfigureAwait(false)).TargetId;
 
         var target = await WaitForTargetAsync(t => ((CdpTarget)t).TargetId == targetId).ConfigureAwait(false) as CdpTarget;
         await target!.InitializedTask.ConfigureAwait(false);

--- a/lib/PuppeteerSharp/Cdp/Connection.cs
+++ b/lib/PuppeteerSharp/Cdp/Connection.cs
@@ -136,7 +136,18 @@ namespace PuppeteerSharp.Cdp
                 _callbacks[id] = callback;
             }
 
-            await RawSendAsync(message, options).ConfigureAwait(false);
+            try
+            {
+                await RawSendAsync(message, options).ConfigureAwait(false);
+            }
+            catch (System.Net.WebSockets.WebSocketException)
+            {
+                // The WebSocket was aborted (e.g. Chrome exited) between the IsClosed check and the send.
+                // Treat this as a closed connection so callers get TargetClosedException instead.
+                Close("WebSocket error");
+                throw new TargetClosedException($"Protocol error({method}): Target closed.", CloseReason);
+            }
+
             return waitForCallback ? await callback.TaskWrapper.Task.WithTimeout(ProtocolTimeout).ConfigureAwait(false) : null;
         }
 


### PR DESCRIPTION
In headful Chrome on Linux, closing all tabs also closes the browser window. When `NewPageAsync()` is called after that, `Target.createTarget` fails with "Failed to open a new tab" — Chrome has no window to put the tab into.

Pass `newWindow: true` when there are no existing targets, so Chrome opens a fresh window. Also handle the WebSocket abort race in `Connection.SendAsync`: if Chrome exits between the `IsClosed` check and the send, convert the raw socket error into a clean `TargetClosedException`.

Fixes `ShouldKeepConnectedAfterTheLastPageIsClosed` on `CHROME-headful-ubuntu-latest-cdp`.