### PR TITLE
fix: don't set newWindow=true when no targets exist

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -341,9 +341,7 @@ public class CdpBrowser : Browser
             WindowState = windowBounds?.WindowState,
 
             // Works around crbug.com/454825274.
-            // When no targets exist (e.g. all pages were closed in headful mode), Chrome has no
-            // browser window. We must request a new window so Chrome can create the page.
-            NewWindow = (!hasTargets || options?.Type == CreatePageType.Window) ? true : null,
+            NewWindow = hasTargets && options?.Type == CreatePageType.Window ? true : null,
             Background = options?.Background,
         };
 


### PR DESCRIPTION
Sending `newWindow=true` with no existing browser windows causes Chrome to crash and close the WebSocket mid-command. Modern Chrome handles `Target.createTarget` without that flag in a windowless state — it creates the window itself.

Reverts the no-targets logic back to upstream: only set `newWindow=true` when `hasTargets && type === window` (the original crbug.com/454825274 workaround). Fixes `ShouldKeepConnectedAfterTheLastPageIsClosed` on headful Chrome.