### PR TITLE
feat: add page locale emulation (upstream #15075)

### DIFF
--- a/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateLocaleTests.cs
+++ b/lib/PuppeteerSharp.Tests/EmulationTests/PageEmulateLocaleTests.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.EmulationTests
+{
+    public class PageEmulateLocaleTests : PuppeteerPageBaseTest
+    {
+        public PageEmulateLocaleTests() : base()
+        {
+        }
+
+        [Test, PuppeteerTest("emulation.spec", "Emulation Page.emulateLocale", "should work")]
+        public async Task ShouldWork()
+        {
+            var defaultLocale = await Page.EvaluateFunctionAsync<string>("() => Intl.NumberFormat().resolvedOptions().locale");
+            var defaultLanguage = await Page.EvaluateFunctionAsync<string>("() => navigator.language");
+
+            await Page.EmulateLocaleAsync("de-DE");
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => Intl.NumberFormat().resolvedOptions().locale"),
+                Is.EqualTo("de-DE"));
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => new Intl.NumberFormat().format(123456.78)"),
+                Is.EqualTo("123.456,78"));
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => navigator.language"),
+                Is.EqualTo("de-DE"));
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => navigator.languages[0]"),
+                Is.EqualTo("de-DE"));
+
+            await Page.EmulateLocaleAsync("fr-FR");
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => Intl.DateTimeFormat().resolvedOptions().locale"),
+                Is.EqualTo("fr-FR"));
+
+            await Page.EmulateLocaleAsync();
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => Intl.NumberFormat().resolvedOptions().locale"),
+                Is.EqualTo(defaultLocale));
+            Assert.That(
+                await Page.EvaluateFunctionAsync<string>("() => navigator.language"),
+                Is.EqualTo(defaultLanguage));
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -239,6 +239,18 @@ public class BidiPage : Page
         => Task.FromResult(BidiMainFrame.BrowsingContext.WindowId);
 
     /// <inheritdoc />
+    public override async Task EmulateLocaleAsync(string locale = null)
+    {
+        var commandParameters = new WebDriverBiDi.Emulation.SetLocaleOverrideCommandParameters()
+        {
+            Locale = locale,
+            Contexts = [BidiMainFrame.BrowsingContext.Id],
+        };
+
+        await BidiMainFrame.BrowsingContext.Session.Driver.Emulation.SetLocaleOverrideAsync(commandParameters).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public override Task EmulateIdleStateAsync(EmulateIdleOverrides idleOverrides = null)
         => _cdpEmulationManager.EmulateIdleStateAsync(idleOverrides);
 

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -58,7 +58,8 @@ public class CdpPage : Page
     private CdpPage(
         CdpCDPSession client,
         CdpTarget target,
-        TaskQueue screenshotTaskQueue) : base(screenshotTaskQueue)
+        TaskQueue screenshotTaskQueue,
+        string defaultUserAgent = null) : base(screenshotTaskQueue)
     {
         PrimaryTargetClient = client;
         TabTargetClient = (CdpCDPSession)client.ParentSession;
@@ -74,7 +75,7 @@ public class CdpPage : Page
 
         _emulationManager = new CdpEmulationManager(client);
         _logger = Client.Connection.LoggerFactory.CreateLogger<Page>();
-        FrameManager = new FrameManager(client, this, TimeoutSettings, target.Browser.IsNetworkEnabled(), target.Browser.IsIssuesEnabled());
+        FrameManager = new FrameManager(client, this, TimeoutSettings, target.Browser.IsNetworkEnabled(), target.Browser.IsIssuesEnabled(), defaultUserAgent);
         _webMcp = new CdpWebMcp(client, FrameManager);
         Accessibility = new Accessibility(client, () => MainFrame?.Id, () => (FrameManager.MainFrame as Frame)?.MainRealm);
 
@@ -693,6 +694,13 @@ public class CdpPage : Page
         => _emulationManager.EmulateTimezoneAsync(timezoneId);
 
     /// <inheritdoc/>
+    public override async Task EmulateLocaleAsync(string locale = null)
+    {
+        await _emulationManager.EmulateLocaleAsync(locale).ConfigureAwait(false);
+        await FrameManager.NetworkManager.SetAcceptLanguageAsync(locale).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
     public override Task EmulateIdleStateAsync(EmulateIdleOverrides overrides = null)
         => _emulationManager.EmulateIdleStateAsync(overrides);
 
@@ -839,7 +847,8 @@ public class CdpPage : Page
         ViewPortOptions defaultViewPort,
         TaskQueue screenshotTaskQueue)
     {
-        var page = new CdpPage(client, target, screenshotTaskQueue);
+        var defaultUserAgent = await target.Browser.GetUserAgentAsync().ConfigureAwait(false);
+        var page = new CdpPage(client, target, screenshotTaskQueue, defaultUserAgent);
 
         try
         {

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -27,12 +27,12 @@ namespace PuppeteerSharp.Cdp
         private readonly HashSet<Binding> _bindings = new();
         private TaskCompletionSource<bool> _frameTreeHandled = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        internal FrameManager(CDPSession client, Page page, TimeoutSettings timeoutSettings, bool networkEnabled = true, bool issuesEnabled = true)
+        internal FrameManager(CDPSession client, Page page, TimeoutSettings timeoutSettings, bool networkEnabled = true, bool issuesEnabled = true, string defaultUserAgent = null)
         {
             Client = client;
             Page = page;
             _logger = Client.Connection.LoggerFactory.CreateLogger<FrameManager>();
-            NetworkManager = new NetworkManager(this, client.Connection.LoggerFactory, networkEnabled);
+            NetworkManager = new NetworkManager(this, client.Connection.LoggerFactory, networkEnabled, defaultUserAgent);
             TimeoutSettings = timeoutSettings;
             IssuesEnabled = issuesEnabled;
 

--- a/lib/PuppeteerSharp/Cdp/Messaging/EmulationSetLocaleOverrideRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/EmulationSetLocaleOverrideRequest.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class EmulationSetLocaleOverrideRequest
+    {
+        public string Locale { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/NetworkSetUserAgentOverrideRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/NetworkSetUserAgentOverrideRequest.cs
@@ -4,6 +4,8 @@ namespace PuppeteerSharp.Cdp.Messaging
     {
         public string UserAgent { get; set; }
 
+        public string AcceptLanguage { get; set; }
+
         public UserAgentMetadata UserAgentMetadata { get; set; }
 
         public string Platform { get; set; }

--- a/lib/PuppeteerSharp/Cdp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/Cdp/NetworkManager.cs
@@ -20,6 +20,7 @@ namespace PuppeteerSharp.Cdp
         private readonly IFrameProvider _frameManager;
         private readonly ILoggerFactory _loggerFactory;
         private readonly bool _networkEnabled;
+        private readonly string _defaultUserAgent;
 
         private InternalNetworkConditions _emulatedNetworkConditions;
         private Dictionary<string, string> _extraHTTPHeaders;
@@ -30,6 +31,7 @@ namespace PuppeteerSharp.Cdp
         private string _userAgent;
         private UserAgentMetadata _userAgentMetadata;
         private string _platform;
+        private string _acceptLanguage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NetworkManager"/> class.
@@ -37,12 +39,14 @@ namespace PuppeteerSharp.Cdp
         /// <param name="frameManager">Frame manager.</param>
         /// <param name="loggerFactory">Logger factory.</param>
         /// <param name="networkEnabled">Whether network events are enabled.</param>
-        internal NetworkManager(IFrameProvider frameManager, ILoggerFactory loggerFactory, bool networkEnabled = true)
+        /// <param name="defaultUserAgent">Default user agent to use when no explicit user agent has been set.</param>
+        internal NetworkManager(IFrameProvider frameManager, ILoggerFactory loggerFactory, bool networkEnabled = true, string defaultUserAgent = null)
         {
             _frameManager = frameManager;
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<NetworkManager>();
             _networkEnabled = networkEnabled;
+            _defaultUserAgent = defaultUserAgent;
         }
 
         internal event EventHandler<ResponseCreatedEventArgs> Response;
@@ -128,6 +132,12 @@ namespace PuppeteerSharp.Cdp
             _userAgent = userAgent;
             _userAgentMetadata = userAgentMetadata;
             _platform = platform;
+            return ApplyToAllClientsAsync(ApplyUserAgentAsync);
+        }
+
+        internal Task SetAcceptLanguageAsync(string acceptLanguage)
+        {
+            _acceptLanguage = acceptLanguage;
             return ApplyToAllClientsAsync(ApplyUserAgentAsync);
         }
 
@@ -632,7 +642,8 @@ namespace PuppeteerSharp.Cdp
 
         private async Task ApplyUserAgentAsync(ICDPSession client)
         {
-            if (_userAgent == null)
+            var userAgent = _userAgent ?? _defaultUserAgent;
+            if (userAgent == null)
             {
                 return;
             }
@@ -643,7 +654,8 @@ namespace PuppeteerSharp.Cdp
                     "Network.setUserAgentOverride",
                     new NetworkSetUserAgentOverrideRequest
                     {
-                        UserAgent = _userAgent,
+                        UserAgent = userAgent,
+                        AcceptLanguage = _acceptLanguage,
                         UserAgentMetadata = _userAgentMetadata,
                         Platform = _platform,
                     }).ConfigureAwait(false);

--- a/lib/PuppeteerSharp/CdpEmulationManager.cs
+++ b/lib/PuppeteerSharp/CdpEmulationManager.cs
@@ -108,6 +108,11 @@ namespace PuppeteerSharp
             return reloadNeeded;
         }
 
+        internal Task EmulateLocaleAsync(string locale)
+            => _client.SendAsync(
+                "Emulation.setLocaleOverride",
+                new EmulationSetLocaleOverrideRequest { Locale = locale });
+
         internal Task EmulateMediaTypeAsync(MediaType type)
             => _client.SendAsync(
                 "Emulation.setEmulatedMedia",

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -535,6 +535,13 @@ namespace PuppeteerSharp
         Task EmulateTimezoneAsync(string timezoneId);
 
         /// <summary>
+        /// Emulates the locale of the page.
+        /// </summary>
+        /// <param name="locale">Locale to emulate on the page (e.g., "en-US", "de-DE"). Passing <c>null</c> disables locale emulation.</param>
+        /// <returns>A task that resolves when the locale has been set.</returns>
+        Task EmulateLocaleAsync(string locale = null);
+
+        /// <summary>
         /// Simulates the given vision deficiency on the page.
         /// </summary>
         /// <example>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -871,6 +871,9 @@ namespace PuppeteerSharp
         public abstract Task EmulateTimezoneAsync(string timezoneId);
 
         /// <inheritdoc/>
+        public abstract Task EmulateLocaleAsync(string locale = null);
+
+        /// <inheritdoc/>
         public abstract Task EmulateIdleStateAsync(EmulateIdleOverrides idleOverrides = null);
 
         /// <inheritdoc/>


### PR DESCRIPTION
`Page.EmulateLocaleAsync(locale?)` was missing from PuppeteerSharp. On CDP, it sets `Emulation.setLocaleOverride` for `Intl` behavior and also passes `acceptLanguage` through `Network.setUserAgentOverride` so `navigator.language` and `navigator.languages` reflect the emulated locale. On BiDi, it delegates to `emulation.setLocaleOverride`. Calling with no argument clears the override.

Upstream: https://github.com/puppeteer/puppeteer/pull/15075