### PR TITLE
feat: roll to Firefox 152.0 (upstream #15125)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_151.0";
+        public const string DefaultBuildId = "stable_152.0";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Bumps the default Firefox build ID from `stable_151.0` to `stable_152.0` to match the upstream browser pin.

Upstream: https://github.com/puppeteer/puppeteer/pull/15125