### PR TITLE
feat: roll to Chrome 150.0.7871.24 (upstream #15126)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -451,6 +451,22 @@
     "comment": "PASS in Chrome >= 149; FAIL in older revisions"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should block out-of-process iframe (OOPIF) content from loading if the iframe URL is in the blocklist",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "cdp",
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Bug in CDP crbug.com/469591372"
+  },
+  {
     "testIdPattern": "[network.spec] network Page.setBypassServiceWorker *",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -470,6 +470,40 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
         Assert.That(error.Message, Does.Contain("blocklist and allowlist are only supported with the CDP protocol"));
     }
 
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block iframe content from loading if the iframe URL is in the blocklist")]
+    public async Task ShouldBlockIframeContentFromLoadingIfTheIframeUrlIsInTheBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/frames/frame.html"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        await page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
+        var frame = Array.Find(page.Frames, f => f != page.MainFrame);
+        Assert.That(frame, Is.Not.Null);
+
+        var content = await frame.GetContentAsync();
+        Assert.That(content, Does.Not.Contain("Hi, I'm frame"));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block out-of-process iframe (OOPIF) content from loading if the iframe URL is in the blocklist")]
+    public async Task ShouldBlockOopifContentFromLoadingIfTheIframeUrlIsInTheBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/frames/frame.html"];
+        options.Args = ["--site-per-process"];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var page = await browser.NewPageAsync();
+
+        await page.GoToAsync(TestConstants.EmptyPage);
+        var frame = await FrameUtils.AttachFrameAsync(page, "frame1", TestConstants.CrossProcessHttpPrefix + "/frames/frame.html");
+        var content = await frame.GetContentAsync();
+        Assert.That(content, Does.Not.Contain("Hi, I'm frame"));
+        Assert.That(content, Does.Contain("ERR_INTERNET_DISCONNECTED"));
+    }
+
     [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should block standard emulation reset when blocklist/allowlist is active")]
     public async Task ShouldBlockStandardEmulationResetWhenBlocklistAllowlistIsActive()
     {

--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "148.0.7778.178";
+        public static string DefaultBuildId => "150.0.7871.24";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
Chrome 150.0.7871.24 is now the default build. Along with the version bump, I've ported the two iframe network-restriction tests that upstream added: the same-origin iframe blocking test (which now passes in Chrome 150), and the OOPIF variant (still broken in CDP — crbug.com/469591372 — so marked FAIL in test expectations).

Upstream: https://github.com/puppeteer/puppeteer/pull/15126