### PR TITLE
fix: await Worker script execution before evaluate (upstream #15099)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -77,13 +77,6 @@
     "expectations": ["FAIL"]
   },
   {
-    "comment": "This is flaky on CI/CD",
-    "testIdPattern": "[worker.spec] Workers Page.workers",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome"],
-    "expectations": ["FAIL"]
-  },
-  {
     "comment": "This is passing on my machine but failing on CI/CD",
     "testIdPattern": "*should take fullPage screenshots*",
     "platforms": ["linux"],

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -4255,10 +4255,8 @@
       "chrome-headless-shell"
     ],
     "expectations": [
-      "FAIL",
       "PASS"
-    ],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    ]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch throws an error if executable path is not valid with pipe=true",

--- a/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/PageWorkerTests.cs
@@ -21,7 +21,6 @@ namespace PuppeteerSharp.Tests.WorkerTests
         }
 
         [Test, PuppeteerTest("worker.spec", "Workers", "Page.workers")]
-        [Ignore("TODO: Fix me. Too flaky")]
         public async Task PageWorkers()
         {
             var workerCreatedTcs = new TaskCompletionSource<bool>();

--- a/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebWorker.cs
@@ -39,6 +39,7 @@ public class CdpWebWorker : WebWorker
     private readonly Action<EvaluateExceptionResponseDetails> _exceptionThrown;
     private readonly string _id;
     private readonly TargetType _targetType;
+    private readonly TaskCompletionSource<bool> _workerScriptLoaded = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     internal CdpWebWorker(
         CDPSession client,
@@ -132,6 +133,34 @@ public class CdpWebWorker : WebWorker
         }
     }
 
+    /// <inheritdoc/>
+    public override async Task<T> EvaluateFunctionAsync<T>(string script, params object[] args)
+    {
+        await _workerScriptLoaded.Task.ConfigureAwait(false);
+        return await base.EvaluateFunctionAsync<T>(script, args).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public override async Task EvaluateFunctionAsync(string script, params object[] args)
+    {
+        await _workerScriptLoaded.Task.ConfigureAwait(false);
+        await base.EvaluateFunctionAsync(script, args).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<T> EvaluateExpressionAsync<T>(string script)
+    {
+        await _workerScriptLoaded.Task.ConfigureAwait(false);
+        return await base.EvaluateExpressionAsync<T>(script).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IJSHandle> EvaluateExpressionHandleAsync(string script)
+    {
+        await _workerScriptLoaded.Task.ConfigureAwait(false);
+        return await base.EvaluateExpressionHandleAsync(script).ConfigureAwait(false);
+    }
+
     private async void OnMessageReceived(object sender, MessageEventArgs e)
     {
         try
@@ -146,6 +175,9 @@ public class CdpWebWorker : WebWorker
                     break;
                 case "Runtime.exceptionThrown":
                     OnExceptionThrown(e.MessageData.ToObject<RuntimeExceptionThrownResponse>());
+                    break;
+                case "Inspector.workerScriptLoaded":
+                    _workerScriptLoaded.TrySetResult(true);
                     break;
             }
         }

--- a/lib/PuppeteerSharp/WebWorker.cs
+++ b/lib/PuppeteerSharp/WebWorker.cs
@@ -57,7 +57,7 @@ namespace PuppeteerSharp
         /// </remarks>
         /// <seealso cref="ExecutionContext.EvaluateExpressionAsync(string)"/>
         /// <returns>Task which resolves to script return value.</returns>
-        public async Task<T> EvaluateExpressionAsync<T>(string script)
+        public virtual async Task<T> EvaluateExpressionAsync<T>(string script)
             => await World.EvaluateExpressionAsync<T>(script).ConfigureAwait(false);
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace PuppeteerSharp
         /// <see cref="IJSHandle"/> instances can be passed as arguments.
         /// </remarks>
         /// <returns>Task which resolves to script return value.</returns>
-        public async Task EvaluateFunctionAsync(string script, params object[] args)
+        public virtual async Task EvaluateFunctionAsync(string script, params object[] args)
             => await World.EvaluateFunctionAsync(script, args).ConfigureAwait(false);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace PuppeteerSharp
         /// <see cref="IJSHandle"/> instances can be passed as arguments.
         /// </remarks>
         /// <returns>Task which resolves to script return value.</returns>
-        public async Task<T> EvaluateFunctionAsync<T>(string script, params object[] args)
+        public virtual async Task<T> EvaluateFunctionAsync<T>(string script, params object[] args)
             => await World.EvaluateFunctionAsync<T>(script, args).ConfigureAwait(false);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace PuppeteerSharp
         /// </remarks>
         /// <returns>Task which resolves to script return value.</returns>
         /// <seealso cref="ExecutionContext.EvaluateExpressionHandleAsync(string)"/>
-        public async Task<IJSHandle> EvaluateExpressionHandleAsync(string script)
+        public virtual async Task<IJSHandle> EvaluateExpressionHandleAsync(string script)
             => await World.EvaluateExpressionHandleAsync(script).ConfigureAwait(false);
 
         /// <summary>


### PR DESCRIPTION
There was a race condition between `Runtime.evaluate` and the worker's main script execution — if you called `worker.evaluate()` right after getting the worker, globals defined in the worker script might not be set yet. Upstream fixed this by waiting for `Inspector.workerScriptLoaded` before allowing any evaluate call through. This port adds the same gate in `CdpWebWorker` using a `TaskCompletionSource`, makes the relevant `WebWorker` base methods `virtual`, and un-ignores the `PageWorkers` test that was previously marked flaky for exactly this reason.

Upstream: https://github.com/puppeteer/puppeteer/pull/15099