### PR TITLE
fix: apply network allowlist/blocklist to non-auto-attach sessions and workers (upstream #15136)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -88,6 +88,45 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
         Assert.That(fetchError, Does.Contain("Failed to fetch"));
     }
 
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions blocklist validation", "should fail fetch requests from within a service worker to URLs in the blocklist")]
+    public async Task ShouldFailFetchRequestsFromWithinServiceWorkerToUrlsInBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList =
+        [
+            "*://*:*/serviceworkers/fetch/style.css",
+        ];
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        await using var context = await browser.CreateBrowserContextAsync();
+        var page = await context.NewPageAsync();
+
+        var allowedUrl = TestConstants.ServerUrl + "/serviceworkers/fetch/sw.html";
+        var blockedUrl = TestConstants.ServerUrl + "/serviceworkers/fetch/style.css";
+
+        await page.GoToAsync(allowedUrl);
+
+        var target = await context.WaitForTargetAsync(
+            t => t.Type == TargetType.ServiceWorker,
+            new WaitForOptions { Timeout = 3000 });
+
+        var worker = await target.WorkerAsync();
+
+        var fetchError = await worker.EvaluateFunctionAsync<string>(
+            @"async (url) => {
+                try {
+                    await fetch(url);
+                    return null;
+                } catch (e) {
+                    return e.message;
+                }
+            }",
+            blockedUrl);
+
+        Assert.That(fetchError, Is.Not.Null.And.Not.Empty);
+        Assert.That(fetchError, Does.Contain("Failed to fetch"));
+    }
+
     [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions", "should prevent loading of blocklisted subresources (e.g., images)")]
     public async Task ShouldPreventLoadingOfBlocklistedSubresources()
     {

--- a/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
@@ -350,6 +350,7 @@ namespace PuppeteerSharp.Cdp
 
             if (!_connection.IsAutoAttached(targetInfo.TargetId))
             {
+                await MaybeSetupNetworkBlockListAsync(session, targetInfo).ConfigureAwait(false);
                 return;
             }
 
@@ -363,6 +364,14 @@ namespace PuppeteerSharp.Cdp
 
             if (targetInfo.Type == TargetType.ServiceWorker)
             {
+                if (!IsUrlAllowed(targetInfo.Url))
+                {
+                    await Task.WhenAll(
+                        MaybeSetupNetworkBlockListAsync(session, targetInfo),
+                        session.SendAsync("Runtime.runIfWaitingForDebugger")).ConfigureAwait(false);
+                    return;
+                }
+
                 await SilentDetachAsync(session, parentConnection).ConfigureAwait(false);
                 if (_attachedTargetsByTargetId.ContainsKey(targetInfo.TargetId))
                 {
@@ -429,6 +438,7 @@ namespace PuppeteerSharp.Cdp
                 FinishInitializationIfReady(parentTarget.TargetId);
             }
 
+            // The browser might be shutting down here, so we ignore potential errors.
             try
             {
                 await Task.WhenAll(
@@ -438,7 +448,7 @@ namespace PuppeteerSharp.Cdp
                         Flatten = true,
                         AutoAttach = true,
                     }),
-                    MaybeSetupNetworkBlockListAsync(session),
+                    MaybeSetupNetworkBlockListAsync(session, targetInfo),
                     session.SendAsync("Runtime.runIfWaitingForDebugger")).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -502,7 +512,7 @@ namespace PuppeteerSharp.Cdp
             TargetGone?.Invoke(this, new TargetChangedArgs { Target = target });
         }
 
-        private async Task MaybeSetupNetworkBlockListAsync(CDPSession session)
+        private async Task MaybeSetupNetworkBlockListAsync(CDPSession session, TargetInfo targetInfo)
         {
             var hasBlockList = _blockList != null && _blockList.Length > 0;
             var hasAllowList = _allowList != null && _allowList.Length > 0;
@@ -554,7 +564,18 @@ namespace PuppeteerSharp.Cdp
                 });
             }
 
-            await session.SendAsync(
+            // Workers do not have Network enabled by default; enable it before applying rules.
+            var needsNetwork = targetInfo.Type == TargetType.Worker
+                || targetInfo.Type == TargetType.ServiceWorker
+                || targetInfo.Type == TargetType.SharedWorker;
+
+            var tasks = new List<Task>();
+            if (needsNetwork)
+            {
+                tasks.Add(session.SendAsync("Network.enable"));
+            }
+
+            tasks.Add(session.SendAsync(
                 "Network.emulateNetworkConditionsByRule",
                 new NetworkEmulateNetworkConditionsByRuleRequest
                 {
@@ -562,7 +583,16 @@ namespace PuppeteerSharp.Cdp
                     // Only set it when using a blocklist; allowlist mode uses per-rule offline flags instead.
                     Offline = hasBlockList ? true : null,
                     MatchedNetworkConditions = matchedNetworkConditions.ToArray(),
-                }).ConfigureAwait(false);
+                }));
+
+            try
+            {
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to setup network block list");
+            }
         }
     }
 }


### PR DESCRIPTION
Non-auto-attach sessions — including custom CDP sessions and lazily-created worker sessions — were silently bypassing the blocklist/allowlist because the rules were never applied to them. This meant a service worker could fetch a blocked URL even when restrictions were configured.

The fix passes the `targetInfo` through to `MaybeSetupNetworkBlockListAsync` everywhere it's called, and sends `Network.enable` before applying the emulation rules for worker targets (workers don't have Network enabled by default). Service workers whose URL isn't allowed now get the rules applied and stay attached for enforcement, rather than being silently detached.

Upstream: https://github.com/puppeteer/puppeteer/pull/15136