### PR TITLE
fix: roll to Firefox 152.0.1 (upstream #15134)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_152.0";
+        public const string DefaultBuildId = "stable_152.0.1";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Bumps the default Firefox build from `stable_152.0` to `stable_152.0.1` to match the upstream patch release pin.

Upstream: https://github.com/puppeteer/puppeteer/pull/15134