### PR TITLE
fix(webmcp): invalidate webmcp tools on context destruction (upstream #15068)

### DIFF
--- a/lib/PuppeteerSharp.Tests/WebMcpTests/PageWebMcpTests.cs
+++ b/lib/PuppeteerSharp.Tests/WebMcpTests/PageWebMcpTests.cs
@@ -162,6 +162,90 @@ namespace PuppeteerSharp.Tests.WebMcpTests
             Assert.That(response.Exception, Is.Null);
         }
 
+        [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should handle multiple navigations and report tools correctly")]
+        public async Task ShouldHandleMultipleNavigationsAndReportToolsCorrectly()
+        {
+            await using var browser = await Puppeteer.LaunchAsync(WebMcpOptions(), TestConstants.LoggerFactory);
+            var page = (CdpPage)await browser.NewPageAsync();
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+
+            // 1. Register tool on first context
+            var toolsAddedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsAdded += (_, _) => toolsAddedTcs.TrySetResult(true);
+
+            await page.EvaluateFunctionAsync(@"() => {
+                const form = document.createElement('form');
+                form.setAttribute('toolname', 'tool-1');
+                form.setAttribute('tooldescription', 'desc-1');
+                document.body.appendChild(form);
+            }");
+            await toolsAddedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(page.WebMcp.Tools().Length, Is.EqualTo(1));
+            Assert.That(page.WebMcp.Tools()[0].Name, Is.EqualTo("tool-1"));
+
+            // 2. Navigate to new page - tools should be removed
+            var toolsRemovedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsRemoved += (_, _) => toolsRemovedTcs.TrySetResult(true);
+
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+            await toolsRemovedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(page.WebMcp.Tools(), Is.Empty);
+
+            // 3. Register tool on second context
+            toolsAddedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsAdded += (_, _) => toolsAddedTcs.TrySetResult(true);
+
+            await page.EvaluateFunctionAsync(@"() => {
+                const form = document.createElement('form');
+                form.setAttribute('toolname', 'tool-2');
+                form.setAttribute('tooldescription', 'desc-2');
+                document.body.appendChild(form);
+            }");
+            await toolsAddedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(page.WebMcp.Tools().Length, Is.EqualTo(1));
+            Assert.That(page.WebMcp.Tools()[0].Name, Is.EqualTo("tool-2"));
+
+            // 4. Navigate again - tools should be removed again
+            toolsRemovedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsRemoved += (_, _) => toolsRemovedTcs.TrySetResult(true);
+
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+            await toolsRemovedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(page.WebMcp.Tools(), Is.Empty);
+        }
+
+        [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should not reset tools on same-document navigation")]
+        public async Task ShouldNotResetToolsOnSameDocumentNavigation()
+        {
+            await using var browser = await Puppeteer.LaunchAsync(WebMcpOptions(), TestConstants.LoggerFactory);
+            var page = (CdpPage)await browser.NewPageAsync();
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html");
+
+            var toolsAddedTcs = new TaskCompletionSource<bool>();
+            page.WebMcp.ToolsAdded += (_, _) => toolsAddedTcs.TrySetResult(true);
+
+            await page.EvaluateFunctionAsync(@"() => {
+                const form = document.createElement('form');
+                form.setAttribute('toolname', 'declarative tool name');
+                form.setAttribute('tooldescription', 'tool description');
+                document.body.appendChild(form);
+            }");
+            await toolsAddedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(page.WebMcp.Tools().Length, Is.EqualTo(1));
+
+            // Same-document (hash) navigation should not reset tools.
+            await page.GoToAsync(TestConstants.HttpsPrefix + "/empty.html#hash");
+
+            // Tools should still be present because context was not destroyed.
+            Assert.That(page.WebMcp.Tools().Length, Is.EqualTo(1));
+            Assert.That(page.WebMcp.Tools()[0].Name, Is.EqualTo("declarative tool name"));
+        }
+
         [Test, PuppeteerTest("webmcp.spec", "Page.webmcp", "should remove tools on frame navigation")]
         public async Task ShouldRemoveToolsOnFrameNavigation()
         {

--- a/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
@@ -47,7 +47,6 @@ public class CdpWebMcp
     {
         _client = client;
         _frameManager = frameManager;
-        _frameManager.FrameNavigated += OnFrameNavigated;
         BindListeners();
     }
 
@@ -142,7 +141,12 @@ public class CdpWebMcp
                 continue;
             }
 
+            var isNewFrame = !_tools.ContainsKey(tool.FrameId);
             var frameTools = _tools.GetOrAdd(tool.FrameId, _ => new ConcurrentDictionary<string, WebMcpTool>());
+            if (isNewFrame)
+            {
+                ListenToContextCleared(frame as CdpFrame);
+            }
 
             ConsoleMessageLocation location = null;
             if (tool.StackTrace?.CallFrames?.Length > 0)
@@ -238,9 +242,25 @@ public class CdpWebMcp
         ToolResponded?.Invoke(this, result);
     }
 
-    private void OnFrameNavigated(object sender, FrameNavigatedEventArgs e)
+    private void ListenToContextCleared(CdpFrame frame)
     {
-        var frameId = e.Frame?.Id;
+        var mainWorld = frame?.MainWorld;
+        if (mainWorld == null)
+        {
+            return;
+        }
+
+        EventHandler handler = null;
+        handler = (_, _) =>
+        {
+            mainWorld.ContextCleared -= handler;
+            OnContextCleared(frame.Id);
+        };
+        mainWorld.ContextCleared += handler;
+    }
+
+    private void OnContextCleared(string frameId)
+    {
         if (string.IsNullOrEmpty(frameId) || !_tools.TryGetValue(frameId, out var frameTools))
         {
             return;

--- a/lib/PuppeteerSharp/IsolatedWorld.cs
+++ b/lib/PuppeteerSharp/IsolatedWorld.cs
@@ -49,6 +49,8 @@ namespace PuppeteerSharp
             FrameUpdated();
         }
 
+        internal event EventHandler ContextCleared;
+
         /// <inheritdoc/>
         public override string Origin => _origin;
 
@@ -269,6 +271,7 @@ namespace PuppeteerSharp
             _context?.Dispose();
             _context = null;
             Frame?.ClearDocumentHandle();
+            ContextCleared?.Invoke(this, EventArgs.Empty);
         }
 
         internal void SetNewContext(


### PR DESCRIPTION
The previous implementation listened to `FrameNavigated` on the `FrameManager` to invalidate tools, which fired on every navigation including same-document ones (hash changes). This incorrectly removed tools when the execution context was still alive.

The fix mirrors upstream: instead of the global navigation event, `IsolatedWorld` now exposes a `ContextCleared` event that fires only when the execution context is actually destroyed. `CdpWebMcp` subscribes to it once per tracked frame, so tools are only invalidated when the context truly goes away.

Upstream: https://github.com/puppeteer/puppeteer/pull/15068