### PR TITLE
perf: optimize GetPropertiesAsync property iteration (upstream #15094)

### DIFF
--- a/lib/PuppeteerSharp/JSHandle.cs
+++ b/lib/PuppeteerSharp/JSHandle.cs
@@ -36,15 +36,7 @@ namespace PuppeteerSharp
         public virtual async Task<Dictionary<string, IJSHandle>> GetPropertiesAsync()
         {
             var propertyNames = await EvaluateFunctionAsync<string[]>(@"object => {
-                    const enumerableProperties = [];
-                    const descriptors = Object.getOwnPropertyDescriptors(object);
-                    for (const propertyName in descriptors) {
-                        if (descriptors[propertyName]?.enumerable)
-                        {
-                            enumerableProperties.push(propertyName);
-                        }
-                    }
-                    return enumerableProperties;
+                    return Object.keys(object ?? {});
                 }").ConfigureAwait(false);
 
             var dic = new Dictionary<string, IJSHandle>();


### PR DESCRIPTION
`GetPropertiesAsync` was using a `for...in` loop over `Object.getOwnPropertyDescriptors()` to collect enumerable properties. Upstream replaced this with `Object.keys()`, which returns own enumerable properties directly and avoids traversing the prototype chain. Upstream measured ~38% faster execution for this path in browser benchmarks.

Upstream: https://github.com/puppeteer/puppeteer/pull/15094