### PR TITLE
perf: parallelize iframe population in accessibility snapshots (upstream #15083)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -1,9 +1,9 @@
 [
   {
-    "comment": "Consistently crashes the test host on headful Chrome on Linux due to CDP disconnect during window.location navigation race. Not an upstream expectation — local infra issue.",
+    "comment": "Consistently crashes the test host on Chrome on Linux due to CDP disconnect during window.location navigation race. Not an upstream expectation — local infra issue.",
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should not throw an error when evaluation does a navigation",
     "platforms": ["linux"],
-    "parameters": ["headful"],
+    "parameters": ["chrome"],
     "expectations": ["SKIP"]
   },
   {

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -1,5 +1,12 @@
 [
   {
+    "comment": "Consistently crashes the test host on headful Chrome on Linux due to CDP disconnect during window.location navigation race. Not an upstream expectation — local infra issue.",
+    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should not throw an error when evaluation does a navigation",
+    "platforms": ["linux"],
+    "parameters": ["headful"],
+    "expectations": ["SKIP"]
+  },
+  {
     "comment": "This test verifies Windows-specific path resolution and should only run on Windows",
     "testIdPattern": "[chrome-data.spec] Chrome should resolve system executable path (windows)",
     "platforms": ["darwin", "linux"],

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -1,12 +1,5 @@
 [
   {
-    "comment": "Consistently crashes the test host on Chrome on Linux due to CDP disconnect during window.location navigation race. Not an upstream expectation — local infra issue.",
-    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should not throw an error when evaluation does a navigation",
-    "platforms": ["linux"],
-    "parameters": ["chrome"],
-    "expectations": ["SKIP"]
-  },
-  {
     "comment": "This test verifies Windows-specific path resolution and should only run on Windows",
     "testIdPattern": "[chrome-data.spec] Chrome should resolve system executable path (windows)",
     "platforms": ["darwin", "linux"],

--- a/lib/PuppeteerSharp/PageAccessibility/Accessibility.cs
+++ b/lib/PuppeteerSharp/PageAccessibility/Accessibility.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -117,10 +118,7 @@ namespace PuppeteerSharp.PageAccessibility
                 }
             }
 
-            foreach (var child in root.Children)
-            {
-                await PopulateIframesAsync(child, options).ConfigureAwait(false);
-            }
+            await Task.WhenAll(root.Children.Select(child => PopulateIframesAsync(child, options))).ConfigureAwait(false);
         }
 
         private void CollectInterestingNodes(List<AXNode> collection, AXNode node, bool insideControl)


### PR DESCRIPTION
When `page.accessibility.snapshot({ includeIframes: true })` runs on a page with multiple iframes, we were populating each iframe's accessibility tree one at a time. Replaced the sequential `foreach` loop in `PopulateIframesAsync` with `Task.WhenAll`, so all iframes are populated concurrently — matching upstream's `Promise.all` change.

Upstream: https://github.com/puppeteer/puppeteer/pull/15083