### PR TITLE
Fix #3501: pin Microsoft.Extensions.Logging to the v8 floor

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -45,7 +45,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="WebDriverBiDi" Version="0.0.54" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Fixes #3501.

We were pulling in `Microsoft.Extensions.Logging` v10 on every target, including net8.0 and netstandard2.0. On .NET 8 apps that sit on the v8 extensions stack, that v10 transitive reference tripped NuGet's "Detected package downgrade" error and broke restore.

Dropping the floor to 8.0.0 fixes it: v8 consumers restore cleanly, and v10 consumers still resolve to v10 through a normal transitive upgrade.

I kept the full `Microsoft.Extensions.Logging` package on purpose. Switching to `Microsoft.Extensions.Logging.Abstractions` would have shaved the graph, but it also drops `Microsoft.Extensions.Logging.dll` from the published dependencies — which would break the documented `new LoggerFactory()` / `LoggerFactory.Create(...)` setup in `LogCDPCommunication.md` for anyone relying on the transitive reference. Not worth a breaking change in a fix release.

## Verification
- Library builds clean for netstandard2.0, net8.0, net10.0.
- Inspected the generated `.nupkg`: all three dependency groups now reference `Microsoft.Extensions.Logging` 8.0.0.
- `LauncherTests` (Chrome/CDP): 56 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)