### PR TITLE
chore: bump version to 25.2.1

### DIFF
--- a/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
@@ -548,6 +548,14 @@ namespace PuppeteerSharp.Cdp
 
             session.MessageReceived += OnRequestPaused;
 
+            // Worker sessions buffer their method-events until a consumer flushes them (so a
+            // CdpWebWorker doesn't miss its init events). A blocked worker never becomes a
+            // CdpWebWorker, so nothing would ever flush — and the Fetch.requestPaused event we
+            // rely on here would stay buffered, leaving the worker's script fetch paused forever
+            // (registration hangs). Flush now that our listener is attached so requestPaused is
+            // delivered live.
+            session.FlushEarlyMessages();
+
             try
             {
                 await Task.WhenAll(

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.1.2</PackageVersion>
-    <ReleaseVersion>25.1.2</ReleaseVersion>
-    <AssemblyVersion>25.1.2</AssemblyVersion>
-    <FileVersion>25.1.2</FileVersion>
+    <PackageVersion>25.2.1</PackageVersion>
+    <ReleaseVersion>25.2.1</ReleaseVersion>
+    <AssemblyVersion>25.2.1</AssemblyVersion>
+    <FileVersion>25.2.1</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Bumps the package version to 25.2.1 to line up with the puppeteer-core v25.2.1 release being ported (PRs #15150 and #15153). Version-only change in `PuppeteerSharp.csproj`.

Note: chromium-bidi stays pinned at 14.0.0 — PuppeteerSharp has intentionally held that across the whole 25.x line (upstream is on 16.0.1); rolling it is a separate effort, not part of this bump.