### PR TITLE
fix: unblock service-worker registration block after worker-buffer change

### DIFF
--- a/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
+++ b/lib/PuppeteerSharp/Cdp/ChromeTargetManager.cs
@@ -548,6 +548,14 @@ namespace PuppeteerSharp.Cdp
 
             session.MessageReceived += OnRequestPaused;
 
+            // Worker sessions buffer their method-events until a consumer flushes them (so a
+            // CdpWebWorker doesn't miss its init events). A blocked worker never becomes a
+            // CdpWebWorker, so nothing would ever flush — and the Fetch.requestPaused event we
+            // rely on here would stay buffered, leaving the worker's script fetch paused forever
+            // (registration hangs). Flush now that our listener is attached so requestPaused is
+            // delivered live.
+            session.FlushEarlyMessages();
+
             try
             {
                 await Task.WhenAll(


### PR DESCRIPTION
A regression from merging #3487 and #3490 together. #3487 made worker `CDPSession`s buffer their method-events until a consumer flushes them; #3490 blocks a disallowed service worker via Fetch interception on its session. A blocked worker never becomes a `CdpWebWorker`, so nothing flushed the buffer — the `Fetch.requestPaused` event stayed buffered, the script fetch stayed paused, and `register()` hung until the 180s protocol timeout (both `ShouldFailServiceWorkerRegistration*` tests timed out on master).

Fix flushes the session right after attaching the Fetch listener. Verified locally: both tests pass in ~1s (were hanging).