### PR TITLE
Fix: handle swaps without a timer (#15198)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -557,6 +557,21 @@
     "comment": "Firefox does not support --remote-debugging-pipe argument"
   },
   {
+    "testIdPattern": "[prerender.spec] *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "SKIP"
+    ],
+    "comment": "Prerendering is not supported by WebDriver BiDi implementation"
+  },
+  {
     "testIdPattern": "[proxy.spec] *",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.TestServer/wwwroot/prerender/target.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/prerender/target.html
@@ -2,4 +2,17 @@
 <head>
   <script>fetch('target.html?fromPrerendered')</script>
 </head>
-<body>target<input></input></body>
+<body>target<input></input>
+<h1>Is this page prerendered?</h1>
+<script>
+  function pagePrerendered() {
+    return (
+      document.prerendering ||
+      self.performance?.getEntriesByType?.('navigation')[0]?.activationStart > 0
+    );
+  }
+  const div = document.createElement('div');
+  div.innerText = String(pagePrerendered());
+  document.body.append(div);
+</script>
+</body>

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/PrerenderTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/PrerenderTests.cs
@@ -22,7 +22,7 @@ public class PrerenderTests : PuppeteerPageBaseTest
             link.ClickAsync()
         );
 
-        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('div')?.innerText"), Is.EqualTo("true"));
     }
 
     [Test, PuppeteerTest("prerender.spec", "Prerender", "can navigate to a prerendered page via Puppeteer")]
@@ -34,6 +34,6 @@ public class PrerenderTests : PuppeteerPageBaseTest
         await button.ClickAsync();
 
         await Page.GoToAsync(TestConstants.ServerUrl + "/prerender/target.html");
-        Assert.That(await Page.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(await Page.EvaluateExpressionAsync<string>("document.querySelector('div')?.innerText"), Is.EqualTo("false"));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/ViaFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/ViaFrameTests.cs
@@ -24,7 +24,7 @@ public class ViaFrameTests : PuppeteerPageBaseTest
         );
 
         Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
-        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.querySelector('div')?.innerText"), Is.EqualTo("true"));
         Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
     }
 
@@ -39,7 +39,7 @@ public class ViaFrameTests : PuppeteerPageBaseTest
         var mainFrame = Page.MainFrame;
         await mainFrame.GoToAsync(TestConstants.ServerUrl + "/prerender/target.html");
         Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
-        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.querySelector('div')?.innerText"), Is.EqualTo("false"));
         Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
     }
 }

--- a/lib/PuppeteerSharp.Tests/PrerenderTests/WithNetworkRequestsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PrerenderTests/WithNetworkRequestsTests.cs
@@ -27,7 +27,7 @@ public class WithNetworkRequestsTests : PuppeteerPageBaseTest
         );
 
         Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
-        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.body.innerText"), Is.EqualTo("target"));
+        Assert.That(await mainFrame.EvaluateExpressionAsync<string>("document.querySelector('div')?.innerText"), Is.EqualTo("true"));
         Assert.That(Page.MainFrame, Is.SameAs(mainFrame));
 
         Assert.That(urls.Exists(url => url.Contains("prerender/target.html")), Is.True);

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -13,7 +13,6 @@ namespace PuppeteerSharp.Cdp
 {
     internal class FrameManager : IDisposable, IAsyncDisposable, IFrameProvider
     {
-        private const int TimeForWaitingForSwap = 200;
         private const string ChromeExtensionPrefix = "chrome-extension://";
         private static readonly string UtilityWorldName = "__puppeteer_utility_world__" + typeof(FrameManager).Assembly.GetName().Version.ToString();
 
@@ -37,7 +36,7 @@ namespace PuppeteerSharp.Cdp
             IssuesEnabled = issuesEnabled;
 
             Client.MessageReceived += Client_MessageReceived;
-            Client.Disconnected += (sender, e) => _ = OnClientDisconnectAsync();
+            Client.Disconnected += (sender, e) => _ = OnClientDisconnectAsync(client);
         }
 
         internal event EventHandler<FrameEventArgs> FrameAttached;
@@ -280,7 +279,7 @@ namespace PuppeteerSharp.Cdp
             }
 
             Client.MessageReceived += Client_MessageReceived;
-            Client.Disconnected += (sender, e) => _ = OnClientDisconnectAsync();
+            Client.Disconnected += (sender, e) => _ = OnClientDisconnectAsync(client);
 
             await InitializeAsync(client).ConfigureAwait(false);
             await NetworkManager.AddClientAsync(client).ConfigureAwait(false);
@@ -667,7 +666,7 @@ namespace PuppeteerSharp.Cdp
             }
         }
 
-        private async Task OnClientDisconnectAsync()
+        private async Task OnClientDisconnectAsync(CDPSession client)
         {
             try
             {
@@ -677,9 +676,17 @@ namespace PuppeteerSharp.Cdp
                     return;
                 }
 
-                if (Client.Connection.IsClosed)
+                // If the disconnected client is not the current one, it means a swap
+                // has already happened.
+                if (Client != client)
                 {
-                    // On connection disconnected remove all frames
+                    return;
+                }
+
+                if (Client.Connection.IsClosed || Page.IsClosed)
+                {
+                    // On connection disconnected or the page closed, we know
+                    // that activation will not happen.
                     RemoveFramesRecursively(mainFrame);
                     return;
                 }
@@ -689,17 +696,26 @@ namespace PuppeteerSharp.Cdp
                     RemoveFramesRecursively(child as Frame);
                 }
 
-                var swappedTcs = new TaskCompletionSource<bool>();
+                var swappedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                mainFrame.FrameSwappedByActivation += (_, _) => swappedTcs.TrySetResult(true);
+                void OnFrameSwapped(object sender, EventArgs e) => swappedTcs.TrySetResult(true);
+                void OnPageClosed(object sender, EventArgs e) => swappedTcs.TrySetException(new PuppeteerException("Page closed"));
+
+                mainFrame.FrameSwappedByActivation += OnFrameSwapped;
+                Page.Close += OnPageClosed;
 
                 try
                 {
-                    await swappedTcs.Task.WithTimeout(TimeForWaitingForSwap).ConfigureAwait(false);
+                    await swappedTcs.Task.ConfigureAwait(false);
                 }
                 catch
                 {
                     RemoveFramesRecursively(mainFrame);
+                }
+                finally
+                {
+                    mainFrame.FrameSwappedByActivation -= OnFrameSwapped;
+                    Page.Close -= OnPageClosed;
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
FrameManager used to race a 200ms timer against the frame swap event when a CDP session disconnected. If a prerender activation took longer than that (slow machine, heavy page), we'd give up waiting and tear down frames that were actually about to be swapped in correctly. It also never checked *which* session had disconnected, so a stale disconnect event firing after a swap had already happened could wipe out the new session's frames.

Now the wait has no timer: it waits for either the swap event or the page closing, and bails out immediately if the disconnected client isn't the current one. A closed page is also treated the same as a disconnected browser, since activation can't happen in either case.

Also updated the prerender test target page to actually report whether it was served from the prerender cache, instead of just asserting on body text (which was identical either way and couldn't catch this race).

Upstream: https://github.com/puppeteer/puppeteer/pull/15198