### PR TITLE
fix: normalize duplicate set-cookie headers using newline (upstream #15173)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkTests/CdpHttpResponseTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/CdpHttpResponseTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using PuppeteerSharp.Cdp;
+using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.NetworkTests;
+
+[TestFixture]
+public class CdpHttpResponseTests
+{
+    [Test, PuppeteerTest("HTTPResponse.test.ts", "CdpHTTPResponse", "should normalize set-cookie using \\n")]
+    public void ShouldNormalizeSetCookieUsingNewline()
+    {
+        var request = CreateRequest();
+        var responsePayload = new ResponsePayload
+        {
+            RemoteIPAddress = "127.0.0.1",
+            RemotePort = 80,
+            Status = HttpStatusCode.OK,
+            StatusText = "OK",
+            Headers = new Dictionary<string, string>
+            {
+                ["set-cookie"] = "a=b\n  c=d",
+            },
+        };
+
+        var response = new CdpHttpResponse(request, responsePayload, null);
+
+        Assert.That(response.Headers["set-cookie"], Is.EqualTo("a=b\n c=d"));
+    }
+
+    [Test, PuppeteerTest("HTTPResponse.test.ts", "CdpHTTPResponse", "should normalize other headers using ,")]
+    public void ShouldNormalizeOtherHeadersUsingComma()
+    {
+        var request = CreateRequest();
+        var responsePayload = new ResponsePayload
+        {
+            RemoteIPAddress = "127.0.0.1",
+            RemotePort = 80,
+            Status = HttpStatusCode.OK,
+            StatusText = "OK",
+            Headers = new Dictionary<string, string>
+            {
+                ["content-type"] = "text/html\n  charset=utf-8",
+                ["accept-language"] = "en-US\n en",
+            },
+        };
+
+        var response = new CdpHttpResponse(request, responsePayload, null);
+
+        Assert.That(response.Headers["content-type"], Is.EqualTo("text/html, charset=utf-8"));
+        Assert.That(response.Headers["accept-language"], Is.EqualTo("en-US, en"));
+    }
+
+    private static CdpHttpRequest CreateRequest()
+    {
+        var client = Substitute.For<CDPSession>();
+        var frame = Substitute.For<IFrame>();
+        using var loggerFactory = new LoggerFactory();
+
+        return new CdpHttpRequest(
+            client,
+            frame,
+            "interceptionId",
+            true,
+            new RequestWillBeSentResponse
+            {
+                RequestId = "requestId",
+                Request = new Request
+                {
+                    Url = "http://example.com",
+                    Method = HttpMethod.Get,
+                    Headers = new Dictionary<string, string>(),
+                },
+                Initiator = new Initiator { Type = InitiatorType.Other },
+            },
+            [],
+            loggerFactory);
+    }
+}

--- a/lib/PuppeteerSharp.Tests/UtilitiesTests/HttpUtilsTests.cs
+++ b/lib/PuppeteerSharp.Tests/UtilitiesTests/HttpUtilsTests.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Tests.UtilitiesTests
         {
             var header = "application/json; charset=utf-8";
 
-            Assert.That(HttpUtils.NormalizeHeaderValue(header), Is.EqualTo(header));
+            Assert.That(HttpUtils.NormalizeHeaderValue("content-type", header), Is.EqualTo(header));
         }
 
         [Test]
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Tests.UtilitiesTests
             var header = "text/html;\n charset=utf-8;\n boundary=something";
 
             Assert.That(
-                HttpUtils.NormalizeHeaderValue(header),
+                HttpUtils.NormalizeHeaderValue("content-type", header),
                 Is.EqualTo("text/html;, charset=utf-8;, boundary=something"));
         }
 
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.UtilitiesTests
             var header = "text/html; \n  charset=utf-8  \n   boundary=something   ";
 
             Assert.That(
-                HttpUtils.NormalizeHeaderValue(header),
+                HttpUtils.NormalizeHeaderValue("content-type", header),
                 Is.EqualTo("text/html;, charset=utf-8, boundary=something"));
         }
 
@@ -39,8 +39,18 @@ namespace PuppeteerSharp.Tests.UtilitiesTests
             var header = "text/html;\n\n charset=utf-8;\n\n\n boundary=something";
 
             Assert.That(
-                HttpUtils.NormalizeHeaderValue(header),
+                HttpUtils.NormalizeHeaderValue("content-type", header),
                 Is.EqualTo("text/html;, charset=utf-8;, boundary=something"));
+        }
+
+        [Test]
+        public void ShouldNormalizeSetCookieWithNewlines()
+        {
+            var header = "a=b\n c=d";
+
+            Assert.That(
+                HttpUtils.NormalizeHeaderValue("set-cookie", header),
+                Is.EqualTo("a=b\n c=d"));
         }
     }
 }

--- a/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
@@ -78,7 +78,8 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var header in data.Headers)
         {
-            Headers[header.Name] = HttpUtils.NormalizeHeaderValue(header.Value.Value);
+            var headerName = header.Name.ToLowerInvariant();
+            Headers[headerName] = HttpUtils.NormalizeHeaderValue(headerName, header.Value.Value);
         }
     }
 
@@ -107,7 +108,8 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var header in data.Headers)
         {
-            Headers[header.Name] = HttpUtils.NormalizeHeaderValue(header.Value.Value);
+            var headerName = header.Name.ToLowerInvariant();
+            Headers[headerName] = HttpUtils.NormalizeHeaderValue(headerName, header.Value.Value);
         }
     }
 

--- a/lib/PuppeteerSharp/Cdp/CdpHttpResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpResponse.cs
@@ -35,7 +35,11 @@ public partial class CdpHttpResponse : Response<CdpHttpRequest>
         {
             foreach (var keyValue in headers)
             {
-                Headers[keyValue.Key] = HttpUtils.NormalizeHeaderValue(keyValue.Value);
+                var headerName = keyValue.Key.ToLowerInvariant();
+
+                // See https://www.rfc-editor.org/rfc/rfc9110.html#name-field-order for
+                // the set-cookie exception.
+                Headers[headerName] = HttpUtils.NormalizeHeaderValue(headerName, keyValue.Value);
             }
         }
 

--- a/lib/PuppeteerSharp/Helpers/HttpUtils.cs
+++ b/lib/PuppeteerSharp/Helpers/HttpUtils.cs
@@ -10,19 +10,24 @@ internal static class HttpUtils
     /// <summary>
     /// Normalizes HTTP header values by handling multiline values.
     /// Multiline header values are joined with commas according to
-    /// <see href="https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2">RFC 9110 Section 5.2</see>.
+    /// <see href="https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2">RFC 9110 Section 5.2</see>,
+    /// except for <c>Set-Cookie</c>, which is joined with newlines. See
+    /// <see href="https://www.rfc-editor.org/rfc/rfc9110.html#name-field-order">RFC 9110 Section 5.3</see>
+    /// for the <c>Set-Cookie</c> exception.
     /// </summary>
-    /// <param name="header">The header value to normalize.</param>
+    /// <param name="name">The lower-cased header name.</param>
+    /// <param name="value">The header value to normalize.</param>
     /// <returns>The normalized header value.</returns>
-    public static string NormalizeHeaderValue(string header)
+    public static string NormalizeHeaderValue(string name, string value)
     {
-        if (header == null || header.IndexOf('\n') == -1)
+        if (value == null || value.IndexOf('\n') == -1)
         {
-            return header;
+            return value;
         }
 
-        var parts = header.Split('\n');
-        var builder = new StringBuilder(header.Length);
+        var separator = name == "set-cookie" ? "\n " : ", ";
+        var parts = value.Split('\n');
+        var builder = new StringBuilder(value.Length);
         var first = true;
         foreach (var part in parts)
         {
@@ -34,7 +39,7 @@ internal static class HttpUtils
 
             if (!first)
             {
-                builder.Append(", ");
+                builder.Append(separator);
             }
 
             builder.Append(trimmed);

--- a/lib/PuppeteerSharp/IResponse.cs
+++ b/lib/PuppeteerSharp/IResponse.cs
@@ -22,6 +22,8 @@ namespace PuppeteerSharp
 
         /// <summary>
         /// An object with HTTP headers associated with the response. All header names are lower-case.
+        /// Duplicate header values are combined into a single comma-separated list except for
+        /// <c>Set-Cookie</c> that is separated by <c>\n</c>.
         /// </summary>
         /// <value>The headers.</value>
         Dictionary<string, string> Headers { get; }


### PR DESCRIPTION
Set-Cookie can appear multiple times on a response, and our header normalization was joining duplicates with `, ` like any other header. That's wrong for Set-Cookie: cookie values can legitimately contain commas, so merging them that way corrupts the result and makes it unparseable.

Now Set-Cookie duplicates are joined with `\n ` instead, matching RFC 9110's field-order exception for Set-Cookie. Other headers keep the comma-separated behavior. `HttpUtils.NormalizeHeaderValue` now takes the header name so it can special-case `set-cookie`, and both `CdpHttpResponse` and `BidiHttpResponse` lower-case header names before storing them (BiDi wasn't doing this consistently before, which the fix also needed to work correctly).

Upstream: https://github.com/puppeteer/puppeteer/pull/15173