### PR TITLE
New Feature: support installing extensions for browser contexts (#15164)

### DIFF
--- a/lib/PuppeteerSharp.Tests/ExtensionsTests/ExtensionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/ExtensionsTests/ExtensionsTests.cs
@@ -18,6 +18,12 @@ namespace PuppeteerSharp.Tests.ExtensionsTests
             EnableExtensions = true,
         };
 
+        private static void AssertNoServiceWorkerReported(ITarget[] targets, string id)
+        {
+            var target = targets.FirstOrDefault(t => t.Url.Contains(id) && t.Type == TargetType.ServiceWorker);
+            Assert.That(target, Is.Null);
+        }
+
         [Test, PuppeteerTest("extensions.spec", "extensions", "service_worker target type should be available")]
         public async Task ServiceWorkerTargetTypeShouldBeAvailable()
         {
@@ -202,6 +208,49 @@ namespace PuppeteerSharp.Tests.ExtensionsTests
 
             extensions = await browserWithExtension.ExtensionsAsync();
             Assert.That(extensions.ContainsKey(id), Is.False);
+        }
+
+        [Test, PuppeteerTest("extensions.spec", "extensions", "should be available in Incognito profiles if enabledInIncognito is true")]
+        public async Task ShouldBeAvailableInIncognitoProfilesIfEnabledInIncognitoIsTrue()
+        {
+            await using var browserWithExtension = await Puppeteer.LaunchAsync(
+                BrowserWithExtensionOptions(),
+                TestConstants.LoggerFactory);
+
+            var extensionId = await browserWithExtension.InstallExtensionAsync(
+                _extensionPath,
+                new ExtensionInstallOptions { EnabledInIncognito = true });
+
+            var context = await browserWithExtension.CreateBrowserContextAsync();
+            var page = await context.NewPageAsync();
+            await page.GoToAsync(TestConstants.EmptyPage);
+
+            var target = await browserWithExtension.WaitForTargetAsync(t =>
+                t.Url.Contains(extensionId) && t.Type == TargetType.ServiceWorker);
+            Assert.That(target, Is.Not.Null);
+
+            var realms = page.ExtensionRealms();
+
+            Realm contentScriptRealm = null;
+            foreach (var realm in realms)
+            {
+                var extension = await realm.ExtensionAsync();
+                if (extension != null && extension.Id == extensionId)
+                {
+                    contentScriptRealm = realm;
+                    break;
+                }
+            }
+
+            Assert.That(contentScriptRealm, Is.Not.Null, "realm should be defined");
+
+            var isContentScript = await contentScriptRealm.EvaluateFunctionAsync<bool>("() => globalThis.thisIsTheContentScript");
+            Assert.That(isContentScript, Is.True);
+
+            await browserWithExtension.UninstallExtensionAsync(extensionId);
+            await context.CloseAsync();
+            var targets = browserWithExtension.Targets();
+            AssertNoServiceWorkerReported(targets, extensionId);
         }
     }
 }

--- a/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
@@ -189,7 +189,7 @@ public class BidiBrowser : Browser
         => throw new NotSupportedException("RemoveScreen is not supported in WebDriver BiDi.");
 
     /// <inheritdoc/>
-    public override async Task<string> InstallExtensionAsync(string path)
+    public override async Task<string> InstallExtensionAsync(string path, ExtensionInstallOptions options = null)
     {
         var result = await Driver.WebExtension.InstallAsync(
             new WebDriverBiDi.WebExtension.InstallCommandParameters(

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -100,7 +100,7 @@ namespace PuppeteerSharp
         public abstract Task RemoveScreenAsync(string screenId);
 
         /// <inheritdoc/>
-        public abstract Task<string> InstallExtensionAsync(string path);
+        public abstract Task<string> InstallExtensionAsync(string path, ExtensionInstallOptions options = null);
 
         /// <inheritdoc/>
         public abstract Task UninstallExtensionAsync(string id);

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -216,11 +216,11 @@ public class CdpBrowser : Browser
     }
 
     /// <inheritdoc/>
-    public override async Task<string> InstallExtensionAsync(string path)
+    public override async Task<string> InstallExtensionAsync(string path, ExtensionInstallOptions options = null)
     {
         var response = await Connection.SendAsync<ExtensionsLoadUnpackedResponse>(
             "Extensions.loadUnpacked",
-            new ExtensionsLoadUnpackedRequest { Path = path }).ConfigureAwait(false);
+            new ExtensionsLoadUnpackedRequest { Path = path, EnableInIncognito = options?.EnabledInIncognito ?? false }).ConfigureAwait(false);
         _extensions.Remove(response.Id);
         return response.Id;
     }

--- a/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsLoadUnpackedRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/ExtensionsLoadUnpackedRequest.cs
@@ -3,5 +3,7 @@ namespace PuppeteerSharp.Cdp.Messaging
     internal class ExtensionsLoadUnpackedRequest
     {
         public string Path { get; set; }
+
+        public bool EnableInIncognito { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/ExtensionInstallOptions.cs
+++ b/lib/PuppeteerSharp/ExtensionInstallOptions.cs
@@ -1,0 +1,13 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Options for <see cref="IBrowser.InstallExtensionAsync(string, ExtensionInstallOptions)"/>.
+    /// </summary>
+    public class ExtensionInstallOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable the extension in Incognito or OTR profiles in Chrome.
+        /// </summary>
+        public bool EnabledInIncognito { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/IBrowser.cs
+++ b/lib/PuppeteerSharp/IBrowser.cs
@@ -317,8 +317,9 @@ namespace PuppeteerSharp
         /// Installs an unpacked extension and returns the extension ID.
         /// </summary>
         /// <param name="path">The path to the unpacked extension directory.</param>
+        /// <param name="options">Options for installing the extension.</param>
         /// <returns>A task that resolves to the extension ID.</returns>
-        Task<string> InstallExtensionAsync(string path);
+        Task<string> InstallExtensionAsync(string path, ExtensionInstallOptions options = null);
 
         /// <summary>
         /// Uninstalls a previously installed extension by its ID.

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -230,6 +230,11 @@ namespace PuppeteerSharp
         public EnableExtensionsOption EnableExtensions { get; set; }
 
         /// <summary>
+        /// Gets or sets the list of extension paths that will be enabled in Incognito and off-the-record profiles.
+        /// </summary>
+        public string[] ExtensionsEnabledInIncognito { get; set; }
+
+        /// <summary>
         /// Whether to handle the DevTools windows as pages in Puppeteer. Supported only in Chrome with CDP.
         /// </summary>
         public bool HandleDevToolsAsPage { get; set; }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -199,8 +199,11 @@ namespace PuppeteerSharp
 
                     if (options.EnableExtensions is { Paths: { } extensionPaths })
                     {
+                        var extensionsEnabledInIncognito = options.ExtensionsEnabledInIncognito ?? [];
                         await Task.WhenAll(
-                            extensionPaths.Select(path => browser.InstallExtensionAsync(path))).ConfigureAwait(false);
+                            extensionPaths.Select(path => browser.InstallExtensionAsync(
+                                path,
+                                new ExtensionInstallOptions { EnabledInIncognito = extensionsEnabledInIncognito.Contains(path) }))).ConfigureAwait(false);
                     }
 
                     if (options.WaitForInitialPage)


### PR DESCRIPTION
Previously extensions would only apply to the default browser context. This adds an `EnabledInIncognito` option to `InstallExtensionAsync`, plus a matching `ExtensionsEnabledInIncognito` launch option, so extensions can be enabled in Puppeteer's incognito/OTR browser contexts too.

Upstream: https://github.com/puppeteer/puppeteer/pull/15164