### PR TITLE
chore: roll Firefox to 152.0.4 (upstream #15158, #15195)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_152.0.2";
+        public const string DefaultBuildId = "stable_152.0.4";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -237,6 +237,30 @@ namespace PuppeteerSharp
             process.WaitForExit();
         }
 
+        // On Windows, an installer .exe can stay briefly locked (e.g. by antivirus scanning)
+        // right after WaitForExit() returns, so deleting it immediately can fail transiently.
+        private static async Task DeleteFileWithRetryAsync(string path)
+        {
+            const int maxAttempts = 5;
+            const int minDelayInMillis = 200;
+            const int maxDelayInMillis = 2000;
+
+            var retryDelay = minDelayInMillis;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    new FileInfo(path).Delete();
+                    return;
+                }
+                catch (IOException) when (attempt < maxAttempts)
+                {
+                    await Task.Delay(retryDelay).ConfigureAwait(false);
+                    retryDelay = Math.Min(retryDelay * 2, maxDelayInMillis);
+                }
+            }
+        }
+
         private async Task<InstalledBrowser> DownloadAsync(SupportedBrowser browser, string buildId)
         {
             var url = GetDownloadURL(browser, Platform, BaseUrl, buildId);
@@ -285,7 +309,7 @@ namespace PuppeteerSharp
             }
 
             await UnpackArchiveAsync(archivePath, outputPath, fileName).ConfigureAwait(false);
-            new FileInfo(archivePath).Delete();
+            await DeleteFileWithRetryAsync(archivePath).ConfigureAwait(false);
 
             var installedBrowser = new InstalledBrowser(cache, browser, buildId, Platform);
             installedBrowser.PermissionsFixed = RunSetup(installedBrowser);


### PR DESCRIPTION
Rolls the pinned Firefox build from 152.0.2 to 152.0.4. Upstream shipped this as two separate rolls (152.0.3 in #15158, then 152.0.4 in #15195) within the same release; since the intermediate version is immediately superseded, this lands as a single bump straight to 152.0.4.

Upstream: https://github.com/puppeteer/puppeteer/pull/15158
Upstream: https://github.com/puppeteer/puppeteer/pull/15195