### PR TITLE
chore: bump version to 25.3.0

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.2.1</PackageVersion>
-    <ReleaseVersion>25.2.1</ReleaseVersion>
-    <AssemblyVersion>25.2.1</AssemblyVersion>
-    <FileVersion>25.2.1</FileVersion>
+    <PackageVersion>25.3.0</PackageVersion>
+    <ReleaseVersion>25.3.0</ReleaseVersion>
+    <AssemblyVersion>25.3.0</AssemblyVersion>
+    <FileVersion>25.3.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Bumps the package version to 25.3.0 to line up with the puppeteer-core 25.3.0 release being ported (#3507, #3508, #3509, #3510).

chromium-bidi stays pinned at 14.0.0 — upstream is now on 16.0.1 at this tag, but rolling it is a separate effort, not part of this bump.