### PR TITLE
fix: CDP-only netstandard2.0 build failure with System.Threading.Channels

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,6 +19,21 @@ env:
   DOTNET_VERSION: '10.0.x' # The .NET SDK version to use
 
 jobs:
+  build-cdp-only:
+    name: build (CDP only)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Restore (CDP only)
+      run: |
+        dotnet restore lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY
+    - name: Build (CDP only)
+      run: |
+        dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY --configuration Release --no-restore --no-incremental
   build:
     name: ${{ matrix.browser }}-${{ matrix.mode }}-${{ matrix.os }}-${{ matrix.protocol }}${{ matrix.pipe && '-pipe' || '' }}
     runs-on: ${{ matrix.os }}

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -51,6 +51,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageReference Include="System.Text.Json" Version="10.0.7" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.3.0</PackageVersion>
-    <ReleaseVersion>25.3.0</ReleaseVersion>
-    <AssemblyVersion>25.3.0</AssemblyVersion>
-    <FileVersion>25.3.0</FileVersion>
+    <PackageVersion>25.3.1</PackageVersion>
+    <ReleaseVersion>25.3.1</ReleaseVersion>
+    <AssemblyVersion>25.3.1</AssemblyVersion>
+    <FileVersion>25.3.1</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
The v25.3.0 nuget publish run failed while packing the CDP-only build: `ScreenRecorder.cs` uses `System.Threading.Channels`, which isn't in the netstandard2.0 BCL. It only compiled in the normal build because `WebDriverBiDi`'s netstandard2.0 dependency group transitively pulls in `System.Threading.Channels` — and that package reference gets excluded when `CDP_ONLY` is defined, so the CDP-only netstandard2.0 target lost the package with it.

Fixed by adding an explicit reference to the netstandard2.0 item group so it doesn't ride on WebDriverBiDi's coattails.

The reason CI never caught this: the CDP-only build path is only exercised by the release-tag publish workflow, never by the regular PR/push CI. Added a `build-cdp-only` job to `dotnet.yml` so this is caught before a release, not after. Also bumped the patch version to 25.3.1.

## Test plan
- [x] `dotnet build lib/PuppeteerSharp/PuppeteerSharp.csproj /p:DefineConstants=CDP_ONLY --configuration Release --no-incremental` succeeds
- [x] `dotnet build lib/PuppeteerSharp.sln --configuration Release` succeeds
- [x] `dotnet format ./lib/PuppeteerSharp.sln --verify-no-changes --exclude-diagnostics CA1865` clean