### PR TITLE
Fix Locator.SetVisibility(Hidden).WaitAsync() resolving immediately

### DIFF
--- a/lib/PuppeteerSharp.Tests/LocatorTests/LocatorTests.cs
+++ b/lib/PuppeteerSharp.Tests/LocatorTests/LocatorTests.cs
@@ -44,5 +44,26 @@ namespace PuppeteerSharp.Tests.LocatorTests
             var text = await button.EvaluateFunctionAsync<string>("el => el.innerText");
             Assert.That(text, Is.EqualTo("clicked"));
         }
+
+        [TestCase("() => { document.querySelector('#target').style.display = 'none'; }")]
+        [TestCase("() => { document.querySelector('#target').remove(); }")]
+        public async Task SetVisibilityHiddenShouldWaitForElementToBecomeHidden(string hideElement)
+        {
+            await Page.SetContentAsync("<div id=\"target\">Visible element</div>");
+
+            var waitTask = Page
+                .Locator("#target")
+                .SetVisibility(VisibilityOption.Hidden)
+                .SetTimeout(5000)
+                .WaitAsync();
+
+            await Task.Delay(500);
+            Assert.That(waitTask.IsCompleted, Is.False, "Locator should not resolve while the element is still visible.");
+
+            await Page.EvaluateFunctionAsync(hideElement);
+
+            await waitTask;
+            Assert.That(waitTask.IsCompletedSuccessfully, Is.True);
+        }
     }
 }

--- a/lib/PuppeteerSharp/Locators/Locator.cs
+++ b/lib/PuppeteerSharp/Locators/Locator.cs
@@ -193,6 +193,11 @@ namespace PuppeteerSharp.Locators
         {
             var handle = await WaitHandleAsync(options).ConfigureAwait(false);
 
+            if (handle == null)
+            {
+                return default;
+            }
+
             try
             {
                 return await handle.JsonValueAsync<T>().ConfigureAwait(false);
@@ -212,7 +217,10 @@ namespace PuppeteerSharp.Locators
         {
             var handle = await WaitHandleAsync(options).ConfigureAwait(false);
 
-            await handle.DisposeAsync().ConfigureAwait(false);
+            if (handle != null)
+            {
+                await handle.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -422,7 +430,11 @@ namespace PuppeteerSharp.Locators
 
                     if (elementHandle == null)
                     {
-                        await handle.DisposeAsync().ConfigureAwait(false);
+                        if (handle != null)
+                        {
+                            await handle.DisposeAsync().ConfigureAwait(false);
+                        }
+
                         throw new PuppeteerException("Locator did not resolve to an element.");
                     }
 

--- a/lib/PuppeteerSharp/Locators/NodeLocator.cs
+++ b/lib/PuppeteerSharp/Locators/NodeLocator.cs
@@ -40,7 +40,8 @@ namespace PuppeteerSharp.Locators
             var waitOptions = new WaitForSelectorOptions
             {
                 Timeout = Timeout,
-                Visible = Visibility == VisibilityOption.Visible ? true : Visibility == VisibilityOption.Hidden ? false : null,
+                Visible = Visibility == VisibilityOption.Visible ? true : (bool?)null,
+                Hidden = Visibility == VisibilityOption.Hidden ? true : (bool?)null,
             };
 
             IElementHandle handle;
@@ -54,7 +55,9 @@ namespace PuppeteerSharp.Locators
                 handle = await _frame.WaitForSelectorAsync(_selector, waitOptions).ConfigureAwait(false);
             }
 
-            if (handle == null)
+            // When waiting for Hidden, a null handle means the element is no longer in the DOM,
+            // which is a valid resolution (see WaitForSelectorOptions.Hidden docs), not a failure.
+            if (handle == null && Visibility != VisibilityOption.Hidden)
             {
                 throw new PuppeteerException($"Could not find element matching selector: {_selector}");
             }

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.3.1</PackageVersion>
-    <ReleaseVersion>25.3.1</ReleaseVersion>
-    <AssemblyVersion>25.3.1</AssemblyVersion>
-    <FileVersion>25.3.1</FileVersion>
+    <PackageVersion>25.3.2</PackageVersion>
+    <ReleaseVersion>25.3.2</ReleaseVersion>
+    <AssemblyVersion>25.3.2</AssemblyVersion>
+    <FileVersion>25.3.2</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Fixes #3513. `NodeLocator` was setting `Visible = false` for `VisibilityOption.Hidden` instead of the separate `Hidden = true` flag on `WaitForSelectorOptions`. Since the underlying `QueryHandler.WaitForAsync` only checks visibility when `Visible || Hidden` is true, that flag never got set for the Hidden case, so the wait resolved as soon as the element existed in the DOM — regardless of whether it was actually visible.

Fixed by routing `Hidden` through the correct flag. That also exposed a second bug: waiting for Hidden can legitimately resolve to a `null` handle when the element is removed from the DOM entirely (documented behavior of `WaitForSelectorAsync`), but `NodeLocator` and a few call sites in `Locator` treated that as an error/NRE instead of success. Handled that too, since it's the same feature area and would've broken the moment someone waited for an element to disappear rather than just go `display: none`.

Added regression tests covering both the CSS-hide and DOM-removal flavors of "hidden."

## Test plan
- `BROWSER=CHROME PROTOCOL=cdp dotnet test --filter "FullyQualifiedName~LocatorTests"` — 39/39 passed
- Full suite run: 1357/1359 passed, the only 2 failures are pre-existing/unrelated (a retina-display screenshot pixel-diff test and a flaky incognito service-worker test)