### PR TITLE
Fix Native AOT crash from missing JsonSerializable registrations

### DIFF
--- a/lib/PuppeteerSharp.Tests/UtilitiesTests/SystemTextJsonSerializationContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/UtilitiesTests/SystemTextJsonSerializationContextTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using PuppeteerSharp.Helpers.Json;
+
+namespace PuppeteerSharp.Tests.UtilitiesTests
+{
+    public class SystemTextJsonSerializationContextTests
+    {
+        // Generic method type parameters and BCL/System.Text.Json types that JsonSerializerContext
+        // always knows how to resolve on its own (they don't need a [JsonSerializable] entry).
+        private static readonly HashSet<string> IgnoredTypeNames = new(StringComparer.Ordinal)
+        {
+            "T",
+            "bool", "byte", "sbyte", "short", "ushort", "int", "uint", "long", "ulong",
+            "float", "double", "decimal", "char", "string", "object",
+            "DateTime", "DateTimeOffset", "TimeSpan", "DateOnly", "TimeOnly", "Half", "Int128", "UInt128",
+            "JsonElement", "JsonDocument", "JsonNode", "JsonArray", "JsonObject",
+        };
+
+        private static Type FindTypeByName(Assembly assembly, string typeName, ICollection<string> problems)
+        {
+            var candidates = assembly.GetTypes().Where(candidate => candidate.Name == typeName).ToList();
+
+            if (candidates.Count == 0)
+            {
+                problems.Add($"{typeName}: could not locate a matching type via reflection (update this test if the type was renamed).");
+                return null;
+            }
+
+            if (candidates.Count > 1)
+            {
+                problems.Add($"{typeName}: matches {candidates.Count} types ({string.Join(", ", candidates.Select(c => c.FullName))}) - " +
+                    "make this test's type resolution namespace-aware so it checks the right one.");
+                return null;
+            }
+
+            return candidates[0];
+        }
+
+        private static string GetPuppeteerSharpSourceDirectory()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory != null && !Directory.Exists(Path.Combine(directory.FullName, "PuppeteerSharp")))
+            {
+                directory = directory.Parent;
+            }
+
+            if (directory == null)
+            {
+                throw new InvalidOperationException("Could not locate the PuppeteerSharp source directory from the test output directory.");
+            }
+
+            return Path.Combine(directory.FullName, "PuppeteerSharp");
+        }
+
+        [Test]
+        public void AllTypesDeserializedWithToObjectShouldBeRegisteredInTheSourceGenerationContext()
+        {
+            var libraryDirectory = GetPuppeteerSharpSourceDirectory();
+            var assembly = typeof(JsonHelper).Assembly;
+
+            // JsonHelper.cs is where ToObject<T> itself is *declared* (its own generic type
+            // parameter T would otherwise be picked up as a false positive).
+            var typeNames = Directory
+                .EnumerateFiles(libraryDirectory, "*.cs", SearchOption.AllDirectories)
+                .Where(path => !path.EndsWith("JsonHelper.cs", StringComparison.Ordinal) &&
+                               !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") &&
+                               !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                .SelectMany(path => Regex.Matches(File.ReadAllText(path), @"\.ToObject<\s*([A-Za-z_][A-Za-z0-9_]*)\s*(\[\])?\s*>")
+                    .Select(match => match.Groups[1].Value))
+                .Where(name => !IgnoredTypeNames.Contains(name))
+                .Distinct()
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            // Sanity check: if this ever returns empty, the regex above stopped matching the
+            // calling convention used in the codebase and the test would pass for the wrong reason.
+            Assert.That(typeNames, Is.Not.Empty, "Expected to find at least one .ToObject<T>() call site in the PuppeteerSharp source tree.");
+
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = SystemTextJsonSerializationContext.Default,
+            };
+
+            var problems = new List<string>();
+
+            foreach (var typeName in typeNames)
+            {
+                var type = FindTypeByName(assembly, typeName, problems);
+
+                if (type == null)
+                {
+                    continue;
+                }
+
+                JsonTypeInfo typeInfo;
+
+                try
+                {
+                    typeInfo = ((IJsonTypeInfoResolver)SystemTextJsonSerializationContext.Default).GetTypeInfo(type, options);
+                }
+                catch (Exception ex)
+                {
+                    problems.Add($"{type.FullName}: {ex.GetType().Name} - {ex.Message}");
+                    continue;
+                }
+
+                if (typeInfo == null)
+                {
+                    problems.Add(type.FullName);
+                }
+            }
+
+            Assert.That(
+                problems,
+                Is.Empty,
+                "The following types are deserialized via ToObject<T>() but are not resolvable through " +
+                "SystemTextJsonSerializationContext. Without a [JsonSerializable] entry (or being reachable " +
+                "as a property from an already-registered type), apps that disable reflection-based " +
+                "serialization (e.g. Native AOT) will throw a NotSupportedException at runtime. " +
+                "See https://github.com/hardkoded/puppeteer-sharp/issues/3515. Problems found: " +
+                Environment.NewLine + string.Join(Environment.NewLine, problems));
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpWebMcp.cs
@@ -275,19 +275,19 @@ public class CdpWebMcp
         }
     }
 
-    private class WebMcpToolsAddedProtocolEvent
+    internal class WebMcpToolsAddedProtocolEvent
     {
         [JsonPropertyName("tools")]
         public WebMcpProtocolTool[] Tools { get; set; }
     }
 
-    private class WebMcpToolsRemovedProtocolEvent
+    internal class WebMcpToolsRemovedProtocolEvent
     {
         [JsonPropertyName("tools")]
         public WebMcpProtocolRemovedTool[] Tools { get; set; }
     }
 
-    private class WebMcpToolInvokedProtocolEvent
+    internal class WebMcpToolInvokedProtocolEvent
     {
         [JsonPropertyName("frameId")]
         public string FrameId { get; set; }
@@ -302,7 +302,7 @@ public class CdpWebMcp
         public string ToolName { get; set; }
     }
 
-    private class WebMcpToolRespondedProtocolEvent
+    internal class WebMcpToolRespondedProtocolEvent
     {
         [JsonPropertyName("errorText")]
         public string ErrorText { get; set; }
@@ -320,7 +320,7 @@ public class CdpWebMcp
         public string Status { get; set; }
     }
 
-    private class WebMcpProtocolAnnotation
+    internal class WebMcpProtocolAnnotation
     {
         [JsonPropertyName("autosubmit")]
         public bool? Autosubmit { get; set; }
@@ -332,7 +332,7 @@ public class CdpWebMcp
         public bool? UntrustedContent { get; set; }
     }
 
-    private class WebMcpProtocolRemovedTool
+    internal class WebMcpProtocolRemovedTool
     {
         [JsonPropertyName("frameId")]
         public string FrameId { get; set; }
@@ -341,7 +341,7 @@ public class CdpWebMcp
         public string Name { get; set; }
     }
 
-    private class WebMcpProtocolTool
+    internal class WebMcpProtocolTool
     {
         [JsonPropertyName("annotations")]
         public WebMcpProtocolAnnotation Annotations { get; set; }

--- a/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
@@ -26,6 +26,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using PuppeteerSharp.BrowserData;
+using PuppeteerSharp.Cdp;
 using PuppeteerSharp.Cdp.Messaging;
 
 namespace PuppeteerSharp.Helpers.Json;
@@ -39,6 +40,7 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(AccessibilityGetFullAXTreeResponse))]
 [JsonSerializable(typeof(AccessibilityQueryAXTreeRequest))]
 [JsonSerializable(typeof(AccessibilityQueryAXTreeResponse))]
+[JsonSerializable(typeof(AuditsIssueAddedResponse))]
 [JsonSerializable(typeof(BasicFrameResponse))]
 [JsonSerializable(typeof(BindingCalledResponse))]
 [JsonSerializable(typeof(BrowserGetVersionResponse))]
@@ -245,6 +247,10 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(TargetInfo))]
 [JsonSerializable(typeof(WaitForFunctionPollingOption))]
 [JsonSerializable(typeof(WaitForOptions))]
+[JsonSerializable(typeof(CdpWebMcp.WebMcpToolsAddedProtocolEvent))]
+[JsonSerializable(typeof(CdpWebMcp.WebMcpToolsRemovedProtocolEvent))]
+[JsonSerializable(typeof(CdpWebMcp.WebMcpToolInvokedProtocolEvent))]
+[JsonSerializable(typeof(CdpWebMcp.WebMcpToolRespondedProtocolEvent))]
 [JsonSerializable(typeof(GeolocationOption))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(string))]

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.3.2</PackageVersion>
-    <ReleaseVersion>25.3.2</ReleaseVersion>
-    <AssemblyVersion>25.3.2</AssemblyVersion>
-    <FileVersion>25.3.2</FileVersion>
+    <PackageVersion>25.3.3</PackageVersion>
+    <ReleaseVersion>25.3.3</ReleaseVersion>
+    <AssemblyVersion>25.3.3</AssemblyVersion>
+    <FileVersion>25.3.3</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Someone hit a `NotSupportedException` under Native AOT because `AuditsIssueAddedResponse` was never wired up in `SystemTextJsonSerializationContext` — the `Audits.issueAdded` CDP event just isn't reachable through the reflection-free source-gen resolver we use when reflection-based serialization is disabled.

While tracking that down I went looking for every other type deserialized the same way (`.ToObject<T>()`) and found four more with the same gap: the WebMcp tool protocol events (`WebMcpToolsAddedProtocolEvent`, `WebMcpToolsRemovedProtocolEvent`, `WebMcpToolInvokedProtocolEvent`, `WebMcpToolRespondedProtocolEvent`). They were private nested classes in `CdpWebMcp`, so registering them also meant bumping them to `internal` — the source-gen context lives in a different file and can't see `private` nested types even within the same assembly.

To stop this from silently regressing again, I added a test that scans every `.ToObject<T>()` call site in the library and checks the type actually resolves through the source-gen context. It fails loudly in CI now instead of only surfacing when someone publishes with AOT.

Fixes #3515. Also bumping the patch version to 25.3.3.