### PR TITLE
Fix #3517: CreateCDPSessionAsync never delivers events for worker targets

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.local.json
@@ -131,5 +131,12 @@
     "platforms": ["linux", "win32"],
     "parameters": ["chrome", "cdp"],
     "expectations": ["SKIP"]
+  },
+  {
+    "comment": "BidiWorkerTarget.CreateCDPSessionAsync always throws PuppeteerException(\"Not supported\") on Firefox, so this CDP-only regression test for #3517 does not apply there",
+    "testIdPattern": "[puppeteer-sharp] CDPSession should receive events on a service worker session created via CreateCDPSessionAsync",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"]
   }
 ]

--- a/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
+++ b/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
@@ -187,7 +187,7 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
             Assert.That(client.Detached, Is.True);
         }
 
-        [Test]
+        [Test, PuppeteerTest("puppeteer-sharp", "CDPSession", "should receive events on a service worker session created via CreateCDPSessionAsync")]
         public async Task ShouldReceiveEventsOnAServiceWorkerSessionCreatedViaCreateCDPSessionAsync()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/serviceworkers/empty/sw.html");

--- a/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
+++ b/lib/PuppeteerSharp.Tests/CDPSessionTests/CreateCDPSessionTests.cs
@@ -187,6 +187,28 @@ namespace PuppeteerSharp.Tests.CDPSessionTests
             Assert.That(client.Detached, Is.True);
         }
 
+        [Test]
+        public async Task ShouldReceiveEventsOnAServiceWorkerSessionCreatedViaCreateCDPSessionAsync()
+        {
+            await Page.GoToAsync(TestConstants.ServerUrl + "/serviceworkers/empty/sw.html");
+            var target = await Context.WaitForTargetAsync(t => t.Type == TargetType.ServiceWorker, new WaitForOptions(3_000));
+
+            var client = await target.CreateCDPSessionAsync();
+            var scriptParsedTaskCompletion = new TaskCompletionSource<bool>();
+            client.MessageReceived += (_, e) =>
+            {
+                if (e.MessageID == "Debugger.scriptParsed")
+                {
+                    scriptParsedTaskCompletion.TrySetResult(true);
+                }
+            };
+
+            await client.SendAsync("Debugger.enable");
+
+            var completed = await Task.WhenAny(scriptParsedTaskCompletion.Task, Task.Delay(5_000));
+            Assert.That(completed, Is.EqualTo(scriptParsedTaskCompletion.Task), "Debugger.scriptParsed was not received for the service worker session.");
+        }
+
         [Test, PuppeteerTest("CDPSession.spec", "Target.createCDPSession", "should handle session callbacks when Chrome sends error without sessionId")]
         public async Task ShouldHandleSessionCallbacksWhenChromeSendsErrorWithoutSessionId()
         {

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -129,7 +129,11 @@ namespace PuppeteerSharp
 
                 while (_bufferedMessages.Count > 0)
                 {
-                    _messageReceived?.Invoke(this, _bufferedMessages.Dequeue());
+                    // Dequeue unconditionally before the null-conditional invoke: `a?.M(Dequeue())` would
+                    // short-circuit the argument evaluation (and never dequeue) when nobody has subscribed
+                    // yet, spinning this loop forever.
+                    var message = _bufferedMessages.Dequeue();
+                    _messageReceived?.Invoke(this, message);
                 }
             }
         }

--- a/lib/PuppeteerSharp/Cdp/CdpTarget.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpTarget.cs
@@ -111,6 +111,15 @@ public class CdpTarget : Target
     {
         var session = await SessionFactory(false).ConfigureAwait(false);
         session.Target = this;
+
+        // Worker-type sessions buffer their early method-events until flushed (see
+        // CDPSession.BufferEarlyMessages), so an internal consumer that subscribes right after
+        // attaching (e.g. CdpWebWorker) doesn't lose Chrome's replayed init events. This public
+        // API returns the session before the caller has a chance to subscribe, so there is no
+        // "internal listener" to protect here; flush immediately so future events (e.g.
+        // Debugger.scriptParsed) reach the caller's MessageReceived handler instead of sitting in
+        // the buffer forever.
+        session.FlushEarlyMessages();
         return session;
     }
 

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.3.3</PackageVersion>
-    <ReleaseVersion>25.3.3</ReleaseVersion>
-    <AssemblyVersion>25.3.3</AssemblyVersion>
-    <FileVersion>25.3.3</FileVersion>
+    <PackageVersion>25.3.4</PackageVersion>
+    <ReleaseVersion>25.3.4</ReleaseVersion>
+    <AssemblyVersion>25.3.4</AssemblyVersion>
+    <FileVersion>25.3.4</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
## Summary

Attaching to a `ServiceWorker` target via `ITarget.CreateCDPSessionAsync()` and calling `Debugger.enable` worked fine, but `Debugger.scriptParsed` (and every other CDP event on that session) never showed up on `MessageReceived`.

Worker-type sessions buffer their early events until `FlushEarlyMessages()` is called, to avoid a race where Chrome's init events beat the internal listener's subscription. That flush was only ever wired up for the two internal consumers (`CdpWebWorker`, blocked service worker registration) — `CreateCDPSessionAsync()`, the public API, never called it, so every event on a manually-created worker session just piled up in the buffer forever.

Wiring the flush into `CreateCDPSessionAsync()` exposed a second, separate bug: `FlushEarlyMessages()` drains the buffer with `_messageReceived?.Invoke(this, _bufferedMessages.Dequeue())`. When nobody has subscribed yet, `?.` short-circuits the *whole* call — including the `Dequeue()` argument — so the queue never actually drains and the loop spins forever. Fixed by dequeuing before the null-conditional invoke.

Fixes #3517

## Verification
- Reproduced with a standalone repro app registering a service worker and reading its source via `Debugger.getScriptSource`; confirmed `Debugger.scriptParsed` now arrives.
- Added `ShouldReceiveEventsOnAServiceWorkerSessionCreatedViaCreateCDPSessionAsync` — verified it fails without the fix and passes with it.
- `CDPSessionTests`, `TargetTests`, `ResponseFromServiceWorkerTests`, `PageSetBypassServiceWorkerTests` (61 tests): passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)