### PR TITLE
New Feature: Expose Handled getter on Dialog (#15225)

### DIFF
--- a/lib/PuppeteerSharp.Tests/DialogTests/DialogTests.cs
+++ b/lib/PuppeteerSharp.Tests/DialogTests/DialogTests.cs
@@ -48,5 +48,18 @@ namespace PuppeteerSharp.Tests.DialogTests
             var result = await Page.EvaluateExpressionAsync<string>("prompt('question?')");
             Assert.That(result, Is.Null);
         }
+
+        [Test, PuppeteerTest("dialog.spec", "Page.Events.Dialog", "should expose handled getter")]
+        public async Task ShouldExposeHandledGetter()
+        {
+            Page.Dialog += async (_, e) =>
+            {
+                Assert.That(e.Dialog.Handled, Is.False);
+                await e.Dialog.Accept();
+                Assert.That(e.Dialog.Handled, Is.True);
+            };
+
+            await Page.EvaluateExpressionAsync("alert('yo');");
+        }
     }
 }

--- a/lib/PuppeteerSharp/Dialog.cs
+++ b/lib/PuppeteerSharp/Dialog.cs
@@ -54,6 +54,12 @@ namespace PuppeteerSharp
         public string Message { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the dialog has been handled.
+        /// </summary>
+        /// <value><c>true</c> if the dialog has already been accepted or dismissed; otherwise, <c>false</c>.</value>
+        public bool Handled => _handled;
+
+        /// <summary>
         /// Accept the Dialog.
         /// </summary>
         /// <returns>Task which resolves when the dialog has been accepted.</returns>


### PR DESCRIPTION
Upstream added a `handled` getter to the `Dialog` class so listeners racing to accept/dismiss the same dialog can check its state without wrapping calls in try/catch. This ports that over as a `Handled` property on `PuppeteerSharp.Dialog`, backed by the existing internal `_handled` flag that `Accept`/`Dismiss` already set.

Implements https://github.com/puppeteer/puppeteer/pull/15225