### PR TITLE
New Feature: Add synchronous IDisposable support to IJSHandle (#15027)

### DIFF
--- a/lib/PuppeteerSharp/IJSHandle.cs
+++ b/lib/PuppeteerSharp/IJSHandle.cs
@@ -9,7 +9,7 @@ namespace PuppeteerSharp
     /// <summary>
     /// IJSHandle represents an in-page JavaScript object. JSHandles can be created with the <see cref="IPage.EvaluateExpressionHandleAsync(string)"/> and <see cref="IPage.EvaluateFunctionHandleAsync(string, object[])"/> methods.
     /// </summary>
-    public interface IJSHandle : IAsyncDisposable
+    public interface IJSHandle : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Gets a value indicating whether this <see cref="IJSHandle"/> is disposed.

--- a/lib/PuppeteerSharp/JSHandle.cs
+++ b/lib/PuppeteerSharp/JSHandle.cs
@@ -70,6 +70,13 @@ namespace PuppeteerSharp
         public abstract ValueTask DisposeAsync();
 
         /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
         public Task<IJSHandle> EvaluateFunctionHandleAsync(string pageFunction, params object[] args)
         {
             return Realm.EvaluateFunctionHandleAsync(pageFunction, [this, .. args]);
@@ -87,6 +94,20 @@ namespace PuppeteerSharp
         public Task<T> EvaluateFunctionAsync<T>(string script, params object[] args)
         {
             return Realm.EvaluateFunctionAsync<T>(script, [this, .. args]);
+        }
+
+        /// <summary>
+        /// Disposes the handle. By default, disposal is delegated to <see cref="DisposeAsync"/> without
+        /// waiting for it to complete; any exception raised is swallowed, mirroring the fire-and-forget
+        /// nature of a synchronous <c>Dispose</c> call over an asynchronous resource.
+        /// </summary>
+        /// <param name="disposing">Indicates whether disposal was initiated by <see cref="Dispose()"/> operation.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _ = DisposeAsync().AsTask();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Upstream puppeteer PR https://github.com/puppeteer/puppeteer/pull/15027 promotes `JSHandle`'s `Symbol.dispose`/`Symbol.asyncDispose` from internal to public API, so JS users can do `using handle = ...` / `await using handle = ...` over Puppeteer objects.

Most of our classes already had this covered: `Browser`, `BrowserContext`, and `Page` already expose public `Dispose()`/`DisposeAsync()` via `IDisposable`/`IAsyncDisposable`, so there was nothing to change there. `IJSHandle` (and therefore `IElementHandle`) was the one gap — it only implemented `IAsyncDisposable`, so `await using var handle = ...` worked but plain `using var handle = ...` didn't compile.

Added `IDisposable` to `IJSHandle` and a `Dispose()`/`Dispose(bool)` implementation on the base `JSHandle` class that mirrors upstream's `[disposeSymbol]`: it fires `DisposeAsync()` without waiting on it, matching the fire-and-forget nature of a synchronous dispose over an async resource. `ElementHandle` and all CDP/BiDi handle implementations pick this up for free since they only override `DisposeAsync()`.

I also looked at adding this to the `Realm` class (upstream's `Realm.ts` got the same treatment), but that would force it into the full `IDisposable`/`Dispose(bool)` pattern (Realm isn't sealed) and trips CA2213 on `BidiFrameRealm`/`BidiWorkerRealm` fields that would suddenly need disposing too — a much bigger and riskier change for a class that's barely user-facing (only reachable via `ExtensionRealms()`). Left that alone.

Verified with the JSHandle and ElementHandle test suites (73 tests, all passing).