### PR TITLE
Roll Chrome to 151.0.7922.47 (#15237)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "150.0.7871.24";
+        public static string DefaultBuildId => "151.0.7922.47";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
Rolls the default Chrome build to 151.0.7922.47, matching upstream Puppeteer PR https://github.com/puppeteer/puppeteer/pull/15237.

This is the final Chrome-roll PR in that Puppeteer release — the intermediate roll PRs got superseded, so only this version matters. Chrome-Headless-Shell reuses Chrome's `DefaultBuildId` in PuppeteerSharp, so nothing else needed to change there.