### PR TITLE
Fix: don't throw in checkVisibility for a detached text node

### DIFF
--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/IsVisibleIsHiddenTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/IsVisibleIsHiddenTests.cs
@@ -22,5 +22,15 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             Assert.That(await element.IsVisibleAsync(), Is.True);
             Assert.That(await element.IsHiddenAsync(), Is.False);
         }
+
+        [Test, PuppeteerTest("elementhandle.spec", "ElementHandle specs ElementHandle.isVisible and ElementHandle.isHidden", "should not throw for a detached text node with no parent element")]
+        public async Task ShouldNotThrowForADetachedTextNodeWithNoParentElement()
+        {
+            await Page.SetContentAsync("<div>x</div>");
+            var handle = await Page.EvaluateFunctionHandleAsync("() => document.createTextNode('orphan')");
+            var textHandle = (IElementHandle)handle;
+            Assert.That(await textHandle.IsHiddenAsync(), Is.True);
+            Assert.That(await textHandle.IsVisibleAsync(), Is.False);
+        }
     }
 }

--- a/lib/PuppeteerSharp/Injected/injected.js
+++ b/lib/PuppeteerSharp/Injected/injected.js
@@ -513,6 +513,9 @@ var checkVisibility = (node, visible) => {
     }
     const element =
         node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+    if (!element) {
+        return visible === false;
+    }
     const style = window.getComputedStyle(element);
     const isVisible =
         style &&


### PR DESCRIPTION
Calling `isHidden()`/`isVisible()` on an `ElementHandle` wrapping a text node that was never attached to the DOM (e.g. `document.createTextNode('x')` with no parent) threw a `TypeError` instead of returning `true` for hidden. `checkVisibility` resolves a text node to its `parentElement` before calling `getComputedStyle`, and a detached text node has `parentElement === null`, so `getComputedStyle(null)` blew up.

Ports the fix from https://github.com/puppeteer/puppeteer/pull/15197: same guard as the existing `if (!node) return visible === false;` check, just one level down after the parent lookup. Added a regression test in `IsVisibleIsHiddenTests` using an orphan text node created via `document.createTextNode`.