### PR TITLE
Fix: combine duplicate BiDi response headers instead of overwriting (#15203)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkTests/BidiHttpResponseTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/BidiHttpResponseTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using System.Text.Json;
+using NUnit.Framework;
+using PuppeteerSharp.Bidi;
+using PuppeteerSharp.Nunit;
+using WebDriverBiDi.JsonConverters;
+
+namespace PuppeteerSharp.Tests.NetworkTests;
+
+[TestFixture]
+public class BidiHttpResponseTests
+{
+    [Test, PuppeteerTest("HTTPResponse.test.ts", "BidiHTTPResponse", "should combine duplicate set-cookie headers using \\n")]
+    public void ShouldCombineDuplicateSetCookieHeadersUsingNewline()
+    {
+        var data = CreateResponseData(("set-cookie", "a=b"), ("set-cookie", "c=d"));
+
+        var response = BidiHttpResponse.FromResponseData(data);
+
+        Assert.That(response.Headers["set-cookie"], Is.EqualTo("a=b\n c=d"));
+    }
+
+    [Test, PuppeteerTest("HTTPResponse.test.ts", "BidiHTTPResponse", "should combine other duplicate headers using ,")]
+    public void ShouldCombineOtherDuplicateHeadersUsingComma()
+    {
+        var data = CreateResponseData(("cache-control", "no-cache"), ("cache-control", "no-store"));
+
+        var response = BidiHttpResponse.FromResponseData(data);
+
+        Assert.That(response.Headers["cache-control"], Is.EqualTo("no-cache, no-store"));
+    }
+
+    private static WebDriverBiDi.Network.ResponseData CreateResponseData(params (string Name, string Value)[] headers)
+    {
+        var headersJson = string.Join(
+            ",",
+            headers.Select(header => $"{{\"name\":\"{header.Name}\",\"value\":{{\"type\":\"string\",\"value\":\"{header.Value}\"}}}}"));
+
+        var json = "{"
+            + "\"url\":\"http://localhost/\","
+            + "\"protocol\":\"http/1.1\","
+            + "\"status\":200,"
+            + "\"statusText\":\"OK\","
+            + "\"fromCache\":false,"
+            + "\"mimeType\":\"text/plain\","
+            + "\"bytesReceived\":0,"
+            + "\"headersSize\":0,"
+            + "\"bodySize\":0,"
+            + "\"content\":{\"size\":0},"
+            + $"\"headers\":[{headersJson}]"
+            + "}";
+
+        return JsonSerializer.Deserialize(json, WebDriverBiDiJsonSerializerContext.Default.ResponseData);
+    }
+}

--- a/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiHttpResponse.cs
@@ -75,12 +75,7 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         };
 
         // Convert headers
-        Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var header in data.Headers)
-        {
-            var headerName = header.Name.ToLowerInvariant();
-            Headers[headerName] = HttpUtils.NormalizeHeaderValue(headerName, header.Value.Value);
-        }
+        Headers = BuildHeaders(data.Headers);
     }
 
     // Internal constructor for synthetic responses (e.g., cached history navigation)
@@ -105,12 +100,7 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
         FromCache = data.FromCache;
         RemoteAddress = new RemoteAddress { IP = string.Empty, Port = -1 };
 
-        Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var header in data.Headers)
-        {
-            var headerName = header.Name.ToLowerInvariant();
-            Headers[headerName] = HttpUtils.NormalizeHeaderValue(headerName, header.Value.Value);
-        }
+        Headers = BuildHeaders(data.Headers);
     }
 
     /// <inheritdoc />
@@ -154,6 +144,24 @@ public class BidiHttpResponse : Response<BidiHttpRequest>
     internal static BidiHttpResponse FromResponseData(WebDriverBiDi.Network.ResponseData data)
     {
         return new BidiHttpResponse(data);
+    }
+
+    // Combines duplicate header values with a newline before normalizing, so repeated
+    // headers (e.g. multiple Set-Cookie entries) are preserved instead of the last one
+    // silently overwriting the earlier ones.
+    private static Dictionary<string, string> BuildHeaders(IEnumerable<WebDriverBiDi.Network.ReadOnlyHeader> headers)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in headers)
+        {
+            var headerName = header.Name.ToLowerInvariant();
+            var value = result.TryGetValue(headerName, out var existingValue)
+                ? $"{existingValue}\n{header.Value.Value}"
+                : header.Value.Value;
+            result[headerName] = HttpUtils.NormalizeHeaderValue(headerName, value);
+        }
+
+        return result;
     }
 
     private void Initialize()


### PR DESCRIPTION
When a server sends multiple headers with the same name over BiDi (Set-Cookie being the common case), `BidiHttpResponse.Headers` kept only the last one, silently dropping the rest. CDP never showed this bug because Chrome pre-merges duplicates into a single newline-joined string before we see them; BiDi hands us each duplicate as a separate entry.

Now duplicate values are combined with a newline before normalizing, same as the existing CDP path: comma-joined for regular headers, newline-joined for Set-Cookie.

Port of https://github.com/puppeteer/puppeteer/pull/15203.