### PR TITLE
Fix: Roll to Firefox 152.0.5 (#15219)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_152.0.4";
+        public const string DefaultBuildId = "stable_152.0.5";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Bumps the default Firefox build id from `stable_152.0.4` to `stable_152.0.5`, matching upstream's automated browser-pin update.

Implements https://github.com/puppeteer/puppeteer/pull/15219