### PR TITLE
Bump version to 25.4.0

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.3.4</PackageVersion>
-    <ReleaseVersion>25.3.4</ReleaseVersion>
-    <AssemblyVersion>25.3.4</AssemblyVersion>
-    <FileVersion>25.3.4</FileVersion>
+    <PackageVersion>25.4.0</PackageVersion>
+    <ReleaseVersion>25.4.0</ReleaseVersion>
+    <AssemblyVersion>25.4.0</AssemblyVersion>
+    <FileVersion>25.4.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Bumps PuppeteerSharp to 25.4.0 to match the puppeteer-core-v25.4.0 release, now that all the corresponding upstream changes (PWA install/launch APIs, Dialog.Handled, IJSHandle disposal, BiDi header fix, checkVisibility fix, and the Chrome/Firefox rolls) are on master.