### PR TITLE
fix: PWA launch returning a page with an empty URL on Windows

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -322,6 +322,12 @@ public class CdpBrowser : Browser
             },
             new WaitForOptions { Timeout = options.Timeout }).ConfigureAwait(false);
 
+        // The child page target can be discovered (and match the predicate above) before CDP has reported
+        // its real navigated URL, which would otherwise be picked up here with page.Url still empty. Wait
+        // for the target to be fully initialized (i.e. its URL populated) before creating the Page for it,
+        // matching the pattern used by CreateTargetInPageAsync/GetDevToolsTargetPageAsync.
+        await target.InitializedTask.ConfigureAwait(false);
+
         var page = await target.PageAsync().ConfigureAwait(false);
         if (page == null)
         {


### PR DESCRIPTION
On Windows CDP CI, `LaunchesAnInstalledPwaAndReturnsItsPage` and `LaunchesAnInstalledPwaAtAnExplicitUrl` failed on every run with `page.Url` coming back empty instead of the start URL.

Turns out `LaunchPWAAsync` was waiting for the launched page's *target* to show up in the right spot of the target hierarchy, but never checking whether that target had actually finished initializing (i.e. had its real URL reported by CDP yet). On Windows the child target apparently shows up in the target dictionary before its URL populates, so `WaitForTargetAsync` would resolve on the very first hierarchy match and we'd build a `Page` from a target that was still blank. Linux happened to not hit this timing window, so it looked Windows-specific.

The fix is a two-line addition: await `target.InitializedTask` before creating the page, same as `CreateTargetInPageAsync` and `GetDevToolsTargetPageAsync` already do for newly created targets elsewhere in this file.

Ran the full `PWATests` suite locally (macOS, Chrome/CDP) and all 4 tests pass, including `InstallsAPwaWithAStandaloneDisplayMode` which has a separate, unrelated `PWA.uninstall` flake reported on Windows CI — didn't chase that one since it's a distinct protocol-level error, not a URL race.