### PR TITLE
fix: bound CdpPage.CloseAsync's wait for target close confirmation

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -832,7 +832,27 @@ public class CdpPage : Page
 
             // Puppeteer waits for Target.CloseTask. But I found some race condition where IsClose didn't get set to true.
             // So I'm waiting for the task that set IsClose to true.
-            await _closedFinishedTask.ConfigureAwait(false);
+            //
+            // Target.closeTarget can race an in-flight, client-initiated navigation (e.g. window.location = ...
+            // from an evaluate call): Chrome acknowledges the close (success: true) but keeps loading the new
+            // document to completion first, and has been observed (headful Chrome for Testing) to then never
+            // send the follow-up Target.detachedFromTarget/Target.targetDestroyed events at all, which would
+            // leave this await pending forever. Every other protocol round-trip in this codebase is bounded by
+            // ProtocolTimeout (see CdpCDPSession.SendAsync/Connection.SendAsync); mirror that here instead of
+            // hanging indefinitely. The close request was already accepted by Chrome, so on timeout we log and
+            // move on rather than fail the caller - if the events do arrive later, IsClosed will still flip.
+            await _closedFinishedTask.WithTimeout(
+                () =>
+                {
+                    _logger.LogWarning(
+                        "Timed out waiting for confirmation that target {TargetId} was closed. Target.closeTarget " +
+                        "was acknowledged but no Target.detachedFromTarget/targetDestroyed event followed within " +
+                        "{Timeout}ms; this can happen when the close races an in-flight navigation. Continuing.",
+                        PrimaryTarget.TargetId,
+                        PrimaryTargetClient.Connection.ProtocolTimeout);
+                    return Task.CompletedTask;
+                },
+                PrimaryTargetClient.Connection.ProtocolTimeout).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
## Summary

`ShouldNotThrowAnErrorWhenEvaluationDoesANavigation` has been intermittently hanging the whole test host on the `CHROME-headful-ubuntu-latest-cdp` CI job (Blame collector killing it after 5 minutes of inactivity, repeatedly, always mid-test).

Turns out the hang isn't in the evaluate call at all — it's in the test's teardown, in `Page.CloseAsync()`. Reproduced it locally (headful Chrome CDP) by capturing raw CDP traffic: when a navigation is still in flight and `Target.closeTarget` races it, Chrome accepts the close (`success: true`) but finishes loading the new document first, and in that window can simply go silent on the target — no `Target.detachedFromTarget`, no `Target.targetDestroyed`, ever. `CloseAsync` was waiting on that event with zero timeout, so it just hung forever.

Every other protocol call in this codebase already has a bounded wait via `ProtocolTimeout` (180s by default). This one didn't. Now it does — same timeout, and since Chrome already accepted the close request, a timeout here just logs a warning and returns instead of throwing.

Locally this turned a reliably-forever hang into a bounded ~3 minute wait, test still passes. Ran the full `EvaluationTests`, `PageTests/CloseTests`, `PageEventsCloseTests`, and `TargetTests` suites afterward with no regressions.

## Test plan
- [x] `dotnet build` clean (net8.0/net10.0/netstandard2.0), no StyleCop warnings
- [x] `dotnet format --verify-no-changes` clean
- [x] Reproduced the hang locally with headful Chrome CDP, confirmed root cause via raw CDP message capture
- [x] Verified the fix resolves the hang (bounded wait, test still passes) across multiple repro attempts
- [x] Ran EvaluationTests, PageTests/CloseTests, PageEventsCloseTests, TargetTests — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K92eapPm8e7mX7puT4cF4s