### PR TITLE
fix: close remaining race in PWA launch where page.Url could still be empty

### DIFF
--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -334,6 +334,18 @@ public class CdpBrowser : Browser
             throw new PuppeteerException($"Failed to create a page for the launched PWA (manifestId = {options.ManifestId})");
         }
 
+        // target.InitializedTask only guarantees the Target domain reported a URL. page.Url is populated by
+        // a separate, independently-timed pathway: target.PageAsync() above triggers a Page.getFrameTree
+        // call whose response can still carry an empty URL for the main frame even after InitializedTask
+        // resolved. If that happens, wait for the main frame to report its navigated URL via the
+        // FrameNavigated event before handing the page back, so callers never observe page.Url empty.
+        if (string.IsNullOrEmpty(page.Url))
+        {
+            await page.WaitForFrameAsync(
+                frame => frame == page.MainFrame && !string.IsNullOrEmpty(frame.Url),
+                new WaitForOptions { Timeout = options.Timeout }).ConfigureAwait(false);
+        }
+
         return page;
     }
 


### PR DESCRIPTION
#3529 fixed the common case of this Windows-only flake by waiting for the CDP Target domain to report a URL before creating the page. Turns out that wasn't the full story: `page.Url` is populated by a completely separate pathway (`Page.getFrameTree` over the Page domain, inside `target.PageAsync()`), and that can still lag behind even after the target itself is "initialized." Under the slower Windows CI runners this showed up again as `page.Url` being empty right after `LaunchPWAAsync` returned.

Now, if `page.Url` is still empty after the page is created, we wait for the main frame to actually report its navigated URL before handing the page back.