### PR TITLE
fix: roll to Chrome 151.0.7922.71 (#15272)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "151.0.7922.47";
+        public static string DefaultBuildId => "151.0.7922.71";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;


### PR DESCRIPTION
## Summary
- port upstream Puppeteer PR #15272
- roll PuppeteerSharp Chrome default build revision from 151.0.7922.47 to 151.0.7922.71 in browser data
- keep scope limited to the direct revision update only

## Upstream reference
- https://github.com/puppeteer/puppeteer/pull/15272