### PR TITLE
fix: roll to Firefox 153.0.1 (#15269)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_153.0";
+        public const string DefaultBuildId = "stable_153.0.1";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Ports upstream Puppeteer PR #15269 by rolling Firefox browser data revision to stable_153.0.1 in PuppeteerSharp.

## Changes
- Updated `PuppeteerSharp.BrowserData.Firefox.DefaultBuildId` from `stable_152.0.5` to `stable_153.0.1`.

No unrelated release changes included.