### PR TITLE
feat: roll to Firefox 153.0 (#15258)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -2239,22 +2239,6 @@
     "comment": "Origin (*) is not supported for setPermission in BiDi"
   },
   {
-    "testIdPattern": "[browsercontext.spec] BrowserContext should fire target events",
-    "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox",
-      "webDriverBiDi"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "In BiDi currently more events than needed are fired (because target is updated more often). We probably need to adjust the test as the behavior is not broken per se"
-  },
-  {
     "testIdPattern": "[browsercontext.spec] BrowserContext should work across sessions",
     "platforms": [
       "darwin",
@@ -2756,22 +2740,6 @@
     "parameters": [
       "cdp",
       "chrome"
-    ],
-    "expectations": [
-      "FAIL"
-    ],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[launcher.spec] Launcher specs Browser target events should work",
-    "platforms": [
-      "darwin",
-      "linux",
-      "win32"
-    ],
-    "parameters": [
-      "firefox",
-      "webDriverBiDi"
     ],
     "expectations": [
       "FAIL"

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_152.0.5";
+        public const string DefaultBuildId = "stable_153.0";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
## Summary
- port upstream puppeteer PR #15258
- bump `Firefox.DefaultBuildId` from `stable_152.0.5` to `stable_153.0`
- remove the two Firefox BiDi upstream expectation failures that were dropped in upstream `TestExpectations.json`

## Superseded check
This is **not** a no-op in this branch. Upstream #15269 only bumps Firefox from `stable_153.0` to `stable_153.0.1` and does not include the expectation removals from #15258.