### PR TITLE
fix: disable WebUIOmniboxPopup and WebUIOmniboxAimPopup (#15278)

### DIFF
--- a/lib/PuppeteerSharp.Tests/ChromeLauncherTests/DefaultArgsTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromeLauncherTests/DefaultArgsTests.cs
@@ -6,6 +6,18 @@ namespace PuppeteerSharp.Tests.ChromeLauncherTests
 {
     public class DefaultArgsTests : PuppeteerPageBaseTest
     {
+        [Test, PuppeteerTest("ChromeLauncher.test.ts", "ChromeLauncher", "disables WebUIOmniboxPopup and WebUIOmniboxAimPopup by default")]
+        public void DisablesWebUIOmniboxPopupAndWebUIOmniboxAimPopupByDefault()
+        {
+            var args = ChromeLauncher.GetDefaultArgs(new LaunchOptions());
+            var disableFeaturesFlag = args.FirstOrDefault(arg => arg.StartsWith("--disable-features=", System.StringComparison.Ordinal));
+            Assert.That(disableFeaturesFlag, Is.Not.Null);
+
+            var disabledFeatures = disableFeaturesFlag.Split('=')[1].Split(',');
+            Assert.That(disabledFeatures, Does.Contain("WebUIOmniboxPopup"));
+            Assert.That(disabledFeatures, Does.Contain("WebUIOmniboxAimPopup"));
+        }
+
         [Test, PuppeteerTest("ChromeLauncher.test.ts", "ChromeLauncher", "removes disabled features if they are enabled explicitly")]
         public void RemovesDisabledFeaturesIfTheyAreEnabledExplicitly()
         {

--- a/lib/PuppeteerSharp/ChromeLauncher.cs
+++ b/lib/PuppeteerSharp/ChromeLauncher.cs
@@ -80,6 +80,8 @@ namespace PuppeteerSharp
                 "MediaRouter",
                 "OptimizationHints",
                 "WebUIReloadButton",
+                "WebUIOmniboxPopup",
+                "WebUIOmniboxAimPopup",
                 "IPH_ReadingModePageActionLabel",
                 "ReadAnythingOmniboxChip",
                 "ProcessPerSiteUpToMainFrameThreshold",


### PR DESCRIPTION
## Summary
- Port upstream Puppeteer PR #15278.
- Disable `WebUIOmniboxPopup` and `WebUIOmniboxAimPopup` in PuppeteerSharp default Chrome launch args (`ChromeLauncher.GetDefaultArgs`).
- Add a directly related launcher test asserting both features are disabled by default.

## Changes
- `lib/PuppeteerSharp/ChromeLauncher.cs`
  - Added `WebUIOmniboxPopup` and `WebUIOmniboxAimPopup` to the default `--disable-features` list.
- `lib/PuppeteerSharp.Tests/ChromeLauncherTests/DefaultArgsTests.cs`
  - Added `DisablesWebUIOmniboxPopupAndWebUIOmniboxAimPopupByDefault`.

## Validation
- `BROWSER=CHROME PROTOCOL=cdp dotnet test lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj --filter "FullyQualifiedName~PuppeteerSharp.Tests.ChromeLauncherTests.DefaultArgsTests" --no-build -- NUnit.TestOutputXml=TestResults`

Upstream reference: https://github.com/puppeteer/puppeteer/pull/15278