### PR TITLE
fix: do not override user agent when nothing is emulated (#15274)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkManagerTests/NetworkManagerTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkManagerTests/NetworkManagerTests.cs
@@ -810,6 +810,39 @@ public class NetworkManagerTests : PuppeteerPageBaseTest
         Assert.That(responses.Select(response => response.Status), Is.EqualTo(new[] { HttpStatusCode.OK, HttpStatusCode.Found, HttpStatusCode.OK }));
     }
 
+    [Test, PuppeteerTest("NetworkManager.test.ts", "NetworkManager", "should not override the user agent when nothing is emulated")]
+    public async Task ShouldNotOverrideTheUserAgentWhenNothingIsEmulated()
+    {
+        var client = Substitute.For<ICDPSession>();
+
+        using var loggerFactory = new LoggerFactory();
+        var manager = CreateNetworkManager(loggerFactory);
+
+        await manager.AddClientAsync(client);
+        await client.DidNotReceive().SendAsync("Network.setUserAgentOverride", Arg.Any<NetworkSetUserAgentOverrideRequest>(), Arg.Any<bool>(), Arg.Any<CommandOptions>());
+
+        await manager.SetUserAgentAsync("custom-user-agent", null);
+        await client.Received(1).SendAsync("Network.setUserAgentOverride", Arg.Any<NetworkSetUserAgentOverrideRequest>(), Arg.Any<bool>(), Arg.Any<CommandOptions>());
+    }
+
+    [Test, PuppeteerTest("NetworkManager.test.ts", "NetworkManager", "should reset the override when the emulated accept-language is cleared")]
+    public async Task ShouldResetTheOverrideWhenTheEmulatedAcceptLanguageIsCleared()
+    {
+        var client = Substitute.For<ICDPSession>();
+
+        using var loggerFactory = new LoggerFactory();
+        var manager = CreateNetworkManager(loggerFactory);
+
+        await manager.AddClientAsync(client);
+        await client.DidNotReceive().SendAsync("Network.setUserAgentOverride", Arg.Any<NetworkSetUserAgentOverrideRequest>(), Arg.Any<bool>(), Arg.Any<CommandOptions>());
+
+        await manager.SetAcceptLanguageAsync("fr-FR");
+        await client.Received(1).SendAsync("Network.setUserAgentOverride", Arg.Any<NetworkSetUserAgentOverrideRequest>(), Arg.Any<bool>(), Arg.Any<CommandOptions>());
+
+        await manager.SetAcceptLanguageAsync(null);
+        await client.Received(2).SendAsync("Network.setUserAgentOverride", Arg.Any<NetworkSetUserAgentOverrideRequest>(), Arg.Any<bool>(), Arg.Any<CommandOptions>());
+    }
+
     [Test, PuppeteerTest("NetworkManager.test.ts", "NetworkManager error handling", "should not throw on target close error")]
     public async Task ShouldNotThrowOnTargetCloseError()
     {

--- a/lib/PuppeteerSharp/Cdp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/Cdp/NetworkManager.cs
@@ -31,6 +31,7 @@ namespace PuppeteerSharp.Cdp
         private UserAgentMetadata _userAgentMetadata;
         private string _platform;
         private string _acceptLanguage;
+        private bool _userAgentOverrideApplied;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NetworkManager"/> class.
@@ -639,6 +640,17 @@ namespace PuppeteerSharp.Cdp
 
         private async Task ApplyUserAgentAsync(ICDPSession client)
         {
+            var nothingToEmulate = _userAgent == null &&
+                _userAgentMetadata == null &&
+                _acceptLanguage == null &&
+                _platform == null;
+
+            // Still need to send once to reset a previously-applied override.
+            if (nothingToEmulate && !_userAgentOverrideApplied)
+            {
+                return;
+            }
+
             var userAgent = _userAgent ?? await _frameManager.Page.Browser.GetUserAgentAsync().ConfigureAwait(false);
             if (userAgent == null)
             {
@@ -656,6 +668,7 @@ namespace PuppeteerSharp.Cdp
                         UserAgentMetadata = _userAgentMetadata,
                         Platform = _platform,
                     }).ConfigureAwait(false);
+                _userAgentOverrideApplied = !nothingToEmulate;
             }
             catch (Exception ex) when (CanIgnoreError(ex))
             {


### PR DESCRIPTION
## Summary
- Port upstream Puppeteer PR #15274 to Cdp/NetworkManager.
- Do not send Network.setUserAgentOverride when nothing is emulated.
- Keep reset behavior by sending one clearing override when emulated Accept-Language is removed.
- Add upstream-aligned NetworkManager tests for both scenarios.

## Validation
- BROWSER=CHROME PROTOCOL=cdp dotnet build lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
- BROWSER=CHROME PROTOCOL=cdp dotnet test lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj --filter "FullyQualifiedName~PuppeteerSharp.Tests.NetworkManagerTests.NetworkManagerTests.ShouldNotOverrideTheUserAgentWhenNothingIsEmulated|FullyQualifiedName~PuppeteerSharp.Tests.NetworkManagerTests.NetworkManagerTests.ShouldResetTheOverrideWhenTheEmulatedAcceptLanguageIsCleared" --no-build -- NUnit.TestOutputXml=TestResults