### PR TITLE
fix: reject PWA access when network restrictions are configured (#15271)

### DIFF
--- a/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkRestrictionTests/NetworkRestrictionsTests.cs
@@ -635,4 +635,66 @@ public class NetworkRestrictionsTests : PuppeteerBaseTest
 
         Assert.That(pageError.Message, Does.Contain("Cannot reset network conditions: rule-based emulation is enabled."));
     }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions PWA validation blocklist", "should throw when calling PWA APIs")]
+    public async Task ShouldThrowWhenCallingPwaApisWithBlocklist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.BlockList = ["*://*:*/empty.html"];
+        options.Pipe = true;
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        var manifestId = $"{TestConstants.ServerUrl}/pwa/";
+
+        var installError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.InstallPWAAsync(new InstallPWAOptions
+            {
+                ManifestId = manifestId,
+                InstallUrlOrBundleUrl = $"{TestConstants.ServerUrl}/pwa/index.html",
+            }));
+        Assert.That(installError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+
+        var launchError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.LaunchPWAAsync(new LaunchPWAOptions { ManifestId = manifestId }));
+        Assert.That(launchError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+
+        var uninstallError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.UninstallPWAAsync(new UninstallPWAOptions { ManifestId = manifestId }));
+        Assert.That(uninstallError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+
+        var stateError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.GetPWAStateAsync(new GetPWAStateOptions { ManifestId = manifestId }));
+        Assert.That(stateError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+    }
+
+    [Test, PuppeteerTest("network_restrictions.spec", "Network Restrictions PWA validation allowlist", "should throw when calling PWA APIs")]
+    public async Task ShouldThrowWhenCallingPwaApisWithAllowlist()
+    {
+        var options = TestConstants.DefaultBrowserOptions();
+        options.Allowlist = ["*://*:*/empty.html"];
+        options.Pipe = true;
+
+        await using var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory);
+        var manifestId = $"{TestConstants.ServerUrl}/pwa/";
+
+        var installError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.InstallPWAAsync(new InstallPWAOptions
+            {
+                ManifestId = manifestId,
+                InstallUrlOrBundleUrl = $"{TestConstants.ServerUrl}/pwa/index.html",
+            }));
+        Assert.That(installError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+
+        var launchError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.LaunchPWAAsync(new LaunchPWAOptions { ManifestId = manifestId }));
+        Assert.That(launchError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+
+        var uninstallError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.UninstallPWAAsync(new UninstallPWAOptions { ManifestId = manifestId }));
+        Assert.That(uninstallError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+
+        var stateError = Assert.ThrowsAsync<PuppeteerException>(async () =>
+            await browser.GetPWAStateAsync(new GetPWAStateOptions { ManifestId = manifestId }));
+        Assert.That(stateError.Message, Does.Contain("PWA APIs are not supported when network restrictions are configured."));
+    }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpBrowser.cs
@@ -37,6 +37,7 @@ public class CdpBrowser : Browser
     private readonly ConcurrentDictionary<string, CdpBrowserContext> _contexts;
     private readonly ILogger<Browser> _logger;
     private readonly bool _handleDevToolsAsPage;
+    private readonly bool _hasNetworkRestrictions;
     private readonly bool _networkEnabled;
     private readonly Dictionary<string, Extension> _extensions = new();
     private readonly bool _issuesEnabled;
@@ -77,7 +78,8 @@ public class CdpBrowser : Browser
             contextIds.Select(contextId =>
                 new KeyValuePair<string, CdpBrowserContext>(contextId, new(Connection, this, contextId))));
 
-        Connection.RejectEmulateNetworkConditionsCalls = (blockList != null && blockList.Length > 0) || (allowList != null && allowList.Length > 0);
+        _hasNetworkRestrictions = (blockList != null && blockList.Length > 0) || (allowList != null && allowList.Length > 0);
+        Connection.RejectEmulateNetworkConditionsCalls = _hasNetworkRestrictions;
 
         if (browser == SupportedBrowser.Firefox)
         {
@@ -269,6 +271,11 @@ public class CdpBrowser : Browser
             throw new ArgumentNullException(nameof(options));
         }
 
+        if (_hasNetworkRestrictions)
+        {
+            throw new PuppeteerException("PWA APIs are not supported when network restrictions are configured.");
+        }
+
         await Connection.SendAsync(
             "PWA.install",
             new PWAInstallRequest { ManifestId = options.ManifestId, InstallUrlOrBundleUrl = options.InstallUrlOrBundleUrl }).ConfigureAwait(false);
@@ -291,6 +298,11 @@ public class CdpBrowser : Browser
             throw new ArgumentNullException(nameof(options));
         }
 
+        if (_hasNetworkRestrictions)
+        {
+            throw new PuppeteerException("PWA APIs are not supported when network restrictions are configured.");
+        }
+
         await Connection.SendAsync("PWA.uninstall", new PWAUninstallRequest { ManifestId = options.ManifestId }).ConfigureAwait(false);
     }
 
@@ -300,6 +312,11 @@ public class CdpBrowser : Browser
         if (options == null)
         {
             throw new ArgumentNullException(nameof(options));
+        }
+
+        if (_hasNetworkRestrictions)
+        {
+            throw new PuppeteerException("PWA APIs are not supported when network restrictions are configured.");
         }
 
         // `PWA.launch` resolves with the id of the launched *tab* target. Tab targets sit above page targets
@@ -355,6 +372,11 @@ public class CdpBrowser : Browser
         if (options == null)
         {
             throw new ArgumentNullException(nameof(options));
+        }
+
+        if (_hasNetworkRestrictions)
+        {
+            throw new PuppeteerException("PWA APIs are not supported when network restrictions are configured.");
         }
 
         var response = await Connection.SendAsync<PWAGetOsAppStateResponse>(


### PR DESCRIPTION
## Summary
- port upstream Puppeteer PR #15271 in `CdpBrowser`
- reject PWA APIs when blocklist/allowlist network restrictions are configured
- add network restriction tests for both blocklist and allowlist PWA rejection paths

## Upstream
- https://github.com/puppeteer/puppeteer/pull/15271