### PR TITLE
fix: forward headers to browserURL discovery and WebSocket connection (#15238)

### DIFF
--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Nunit;
@@ -73,6 +76,38 @@ namespace PuppeteerSharp.Tests.LauncherTests
             Assert.That(response.SecurityDetails, Is.Not.Null);
             Assert.That(TestUtils.CurateProtocol(response.SecurityDetails.Protocol),
                 Is.EqualTo(TestUtils.CurateProtocol(requestTask.Result.ToString())));
+        }
+
+        [Test, PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.connect", "should forward headers when connecting with browserURL")]
+        public async Task ShouldForwardHeadersWhenConnectingWithBrowserURL()
+        {
+            const string authorizationHeader = "Bearer forwarded-token";
+            string webSocketAuthorizationHeader = null;
+            Server.SetRoute("/json/version", async context =>
+            {
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(
+                    JsonSerializer.Serialize(new { webSocketDebuggerUrl = Browser.WebSocketEndpoint })).ConfigureAwait(false);
+            });
+            var requestHeaderTask = Server.WaitForRequest("/json/version", request => request.Headers["Authorization"].ToString());
+
+            await using var connectedBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserURL = TestConstants.ServerUrl,
+                Headers = new Dictionary<string, string>
+                {
+                    ["Authorization"] = authorizationHeader,
+                },
+                WebSocketFactory = async (uri, socketOptions, cancellationToken) =>
+                {
+                    webSocketAuthorizationHeader = socketOptions.Headers["Authorization"];
+                    return await WebSocketTransport.DefaultWebSocketFactory(uri, socketOptions, cancellationToken).ConfigureAwait(false);
+                },
+                Protocol = ((Browser)Browser).Protocol,
+            });
+
+            Assert.That(await requestHeaderTask, Is.EqualTo(authorizationHeader));
+            Assert.That(webSocketAuthorizationHeader, Is.EqualTo(authorizationHeader));
         }
 
         [Test, PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.connect", "should support targetFilter option")]

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.WebSockets;
 using PuppeteerSharp.Cdp;
 using PuppeteerSharp.Transport;
@@ -36,6 +37,11 @@ namespace PuppeteerSharp
         /// If <see cref="Transport"/> is set this property will be ignored.
         /// </summary>
         public WebSocketFactory WebSocketFactory { get; set; }
+
+        /// <summary>
+        /// Headers that should be sent with connection-related HTTP and WebSocket requests.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// Experimental setting to disable monitoring network events by default. When

--- a/lib/PuppeteerSharp/IConnectionOptions.cs
+++ b/lib/PuppeteerSharp/IConnectionOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.WebSockets;
 using PuppeteerSharp.Cdp;
 using PuppeteerSharp.Transport;
@@ -46,5 +47,10 @@ namespace PuppeteerSharp
         /// Defaults to 180_000.
         /// </summary>
         public int ProtocolTimeout { get; set; }
+
+        /// <summary>
+        /// Headers that should be sent with connection-related HTTP and WebSocket requests.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -150,6 +150,11 @@ namespace PuppeteerSharp
         public WebSocketFactory WebSocketFactory { get; set; }
 
         /// <summary>
+        /// Headers that should be sent with connection-related HTTP and WebSocket requests.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; }
+
+        /// <summary>
         /// Optional factory for <see cref="IConnectionTransport"/> implementations.
         /// </summary>
         public TransportFactory TransportFactory { get; set; }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -275,7 +276,7 @@ namespace PuppeteerSharp
 
             var browserWSEndpoint = string.IsNullOrEmpty(options.BrowserURL)
                 ? options.BrowserWSEndpoint
-                : await GetWSEndpointAsync(options.BrowserURL).ConfigureAwait(false);
+                : await GetWSEndpointAsync(options.BrowserURL, options.Headers).ConfigureAwait(false);
 
             if (options.Protocol == ProtocolType.WebdriverBiDi)
             {
@@ -457,7 +458,7 @@ namespace PuppeteerSharp
             }
         }
 
-        private async Task<string> GetWSEndpointAsync(string browserURL)
+        private async Task<string> GetWSEndpointAsync(string browserURL, Dictionary<string, string> headers)
         {
             try
             {
@@ -466,7 +467,18 @@ namespace PuppeteerSharp
                     string data;
                     using (var client = new HttpClient())
                     {
-                        data = await client.GetStringAsync(endpointURL).ConfigureAwait(false);
+                        using var request = new HttpRequestMessage(HttpMethod.Get, endpointURL);
+                        if (headers != null)
+                        {
+                            foreach (var header in headers)
+                            {
+                                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                            }
+                        }
+
+                        using var response = await client.SendAsync(request).ConfigureAwait(false);
+                        response.EnsureSuccessStatusCode();
+                        data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     }
 
                     return JsonSerializer.Deserialize<WSEndpointResponse>(data, JsonHelper.DefaultJsonSerializerSettings.Value).WebSocketDebuggerUrl;

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -118,6 +118,14 @@ namespace PuppeteerSharp.Transport
         {
             var result = new ClientWebSocket();
             result.Options.KeepAliveInterval = TimeSpan.Zero;
+            if (options.Headers != null)
+            {
+                foreach (var header in options.Headers)
+                {
+                    result.Options.SetRequestHeader(header.Key, header.Value);
+                }
+            }
+
             await result.ConnectAsync(url, cancellationToken).ConfigureAwait(false);
             return result;
         }


### PR DESCRIPTION
## Summary
- port upstream Puppeteer #15238 to forward `ConnectOptions.Headers` through `browserURL` discovery (`/json/version`)
- forward connection headers to the default WebSocket handshake via `ClientWebSocket.Options.SetRequestHeader`
- add a launcher connect test covering both browserURL HTTP header forwarding and WebSocket factory header propagation

## Testing
- BROWSER=CHROME PROTOCOL=cdp dotnet build lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
- BROWSER=CHROME PROTOCOL=cdp dotnet test lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj --filter "FullyQualifiedName~PuppeteerConnectTests.ShouldForwardHeadersWhenConnectingWithBrowserURL|FullyQualifiedName~ConnectTests.ShouldBeAbleToConnectUsingBrowserURLWithAndWithoutTrailingSlash" --no-build -- NUnit.TestOutputXml=TestResults