### PR TITLE
feat: track dialog status (#15266)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -148,6 +148,38 @@
     "comment": "No DevTools in shell"
   },
   {
+    "testIdPattern": "[dialog.spec] Page.Events.Dialog should see dialogs handled by other connections",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "chrome",
+      "pipe"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Chrome can't connect when run with pipe"
+  },
+  {
+    "testIdPattern": "[dialog.spec] Page.Events.Dialog should see dialogs handled by other connections",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "firefox",
+      "webDriverBiDi"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Firefox does not support multiple active BiDi sessions."
+  },
+  {
     "testIdPattern": "[drag-and-drop.spec] *",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/DialogTests/DialogTests.cs
+++ b/lib/PuppeteerSharp.Tests/DialogTests/DialogTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Nunit;
@@ -47,6 +49,51 @@ namespace PuppeteerSharp.Tests.DialogTests
 
             var result = await Page.EvaluateExpressionAsync<string>("prompt('question?')");
             Assert.That(result, Is.Null);
+        }
+
+        [Test, PuppeteerTest("dialog.spec", "Page.Events.Dialog", "should see dialogs handled by other connections")]
+        public async Task ShouldSeeDialogsHandledByOtherConnections()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            await using var browser2 = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserWSEndpoint = Browser.WebSocketEndpoint,
+                Protocol = ((Browser)Browser).Protocol,
+            });
+
+            var page2 = (await browser2.PagesAsync()).FirstOrDefault(page => page.Url == TestConstants.EmptyPage);
+            Assert.That(page2, Is.Not.Null, "Could not find page2");
+
+            var dialog1Task = WaitForDialogAsync(Page);
+            var dialog2Task = WaitForDialogAsync(page2);
+            var evaluateTask = page2.EvaluateExpressionAsync<string>("prompt('question?', 'yes.')");
+
+            var dialog1 = await dialog1Task;
+            var dialog2 = await dialog2Task;
+            await dialog2.Accept("answer!");
+
+            var result = await evaluateTask;
+            Assert.That(result, Is.EqualTo("answer!"));
+
+            // Wait for the event to be processed by the first connection.
+            await Page.EvaluateExpressionAsync<int>("1");
+
+            Assert.That(dialog1.Handled, Is.True);
+            Assert.That(dialog2.Handled, Is.True);
+
+            static Task<Dialog> WaitForDialogAsync(IPage page)
+            {
+                var dialogTask = new TaskCompletionSource<Dialog>(TaskCreationOptions.RunContinuationsAsynchronously);
+                EventHandler<DialogEventArgs> handler = null;
+                handler = (_, e) =>
+                {
+                    page.Dialog -= handler;
+                    dialogTask.TrySetResult(e.Dialog);
+                };
+                page.Dialog += handler;
+                return dialogTask.Task;
+            }
         }
 
         [Test, PuppeteerTest("dialog.spec", "Page.Events.Dialog", "should expose handled getter")]

--- a/lib/PuppeteerSharp/Bidi/BidiDialog.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiDialog.cs
@@ -22,6 +22,7 @@
 
 #if !CDP_ONLY
 
+using System;
 using System.Threading.Tasks;
 using PuppeteerSharp.Bidi.Core;
 
@@ -38,6 +39,14 @@ public class BidiDialog : Dialog
         : base(ConvertDialogType(prompt.Info.PromptType), prompt.Info.Message, prompt.Info.DefaultValue ?? string.Empty)
     {
         _prompt = prompt;
+
+        if (_prompt.Handled)
+        {
+            IsHandled = true;
+            return;
+        }
+
+        _prompt.HandledChanged += OnPromptHandled;
     }
 
     internal static BidiDialog From(UserPrompt prompt)
@@ -60,6 +69,12 @@ public class BidiDialog : Dialog
             WebDriverBiDi.BrowsingContext.UserPromptType.BeforeUnload => DialogType.BeforeUnload,
             _ => DialogType.Alert,
         };
+    }
+
+    private void OnPromptHandled(object sender, EventArgs e)
+    {
+        IsHandled = true;
+        _prompt.HandledChanged -= OnPromptHandled;
     }
 }
 

--- a/lib/PuppeteerSharp/Bidi/Core/UserPrompt.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/UserPrompt.cs
@@ -37,6 +37,8 @@ internal class UserPrompt(BrowsingContext browsingContext, UserPromptOpenedEvent
     private string _reason;
     private UserPromptClosedEventArgs _result;
 
+    internal event EventHandler HandledChanged;
+
     /// <summary>
     /// Gets the information about the user prompt when it was opened.
     /// </summary>
@@ -133,6 +135,7 @@ internal class UserPrompt(BrowsingContext browsingContext, UserPromptOpenedEvent
         }
 
         _result = e;
+        HandledChanged?.Invoke(this, EventArgs.Empty);
         Dispose("User prompt already handled.");
     }
 

--- a/lib/PuppeteerSharp/Cdp/CdpDialog.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpDialog.cs
@@ -40,12 +40,28 @@ public class CdpDialog : Dialog
     public CdpDialog(CDPSession client, DialogType type, string message, string defaultValue) : base(type, message, defaultValue)
     {
         _client = client;
+        _client.MessageReceived += OnClientMessageReceived;
     }
 
-    internal override Task HandleAsync(bool accept, string text)
-        => _client.SendAsync("Page.handleJavaScriptDialog", new PageHandleJavaScriptDialogRequest
+    internal override async Task HandleAsync(bool accept, string text)
+    {
+        await _client.SendAsync("Page.handleJavaScriptDialog", new PageHandleJavaScriptDialogRequest
         {
             Accept = accept,
             PromptText = text,
-        });
+        }).ConfigureAwait(false);
+
+        _client.MessageReceived -= OnClientMessageReceived;
+    }
+
+    private void OnClientMessageReceived(object sender, MessageEventArgs e)
+    {
+        if (e.MessageID != "Page.javascriptDialogClosed")
+        {
+            return;
+        }
+
+        IsHandled = true;
+        _client.MessageReceived -= OnClientMessageReceived;
+    }
 }

--- a/lib/PuppeteerSharp/Dialog.cs
+++ b/lib/PuppeteerSharp/Dialog.cs
@@ -59,6 +59,12 @@ namespace PuppeteerSharp
         /// <value><c>true</c> if the dialog has already been accepted or dismissed; otherwise, <c>false</c>.</value>
         public bool Handled => _handled;
 
+        private protected bool IsHandled
+        {
+            get => _handled;
+            set => _handled = value;
+        }
+
         /// <summary>
         /// Accept the Dialog.
         /// </summary>
@@ -66,12 +72,12 @@ namespace PuppeteerSharp
         /// <param name="promptText">A text to enter in prompt. Does not cause any effects if the dialog's type is not prompt.</param>
         public Task Accept(string promptText = "")
         {
-            if (_handled)
+            if (IsHandled)
             {
                 throw new InvalidOperationException("Cannot accept dialog which is already handled!");
             }
 
-            _handled = true;
+            IsHandled = true;
             return HandleAsync(true, promptText);
         }
 
@@ -81,12 +87,12 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves when the dialog has been dismissed.</returns>
         public Task Dismiss()
         {
-            if (_handled)
+            if (IsHandled)
             {
                 throw new InvalidOperationException("Cannot dismiss dialog which is already handled!");
             }
 
-            _handled = true;
+            IsHandled = true;
             return HandleAsync(false, null);
         }
 


### PR DESCRIPTION
## Summary
- port upstream puppeteer/puppeteer#15266 to keep dialog handled state synchronized across multiple connections
- update CDP dialog tracking when the javascript dialog closed event is received
- update BiDi dialog tracking when the underlying user prompt is handled
- add upstream-equivalent dialog test and scoped upstream expectations

## Validation
- BROWSER=CHROME PROTOCOL=cdp dotnet test lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj --filter FullyQualifiedName~DialogTests --no-build
- BROWSER=FIREFOX PROTOCOL=bidi dotnet test lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj --filter FullyQualifiedName~DialogTests --no-build