### PR TITLE
Roll browsers: Chrome 151.0.7922.77, Firefox 153.0.3

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Chrome.cs
+++ b/lib/PuppeteerSharp/BrowserData/Chrome.cs
@@ -14,7 +14,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default chrome build.
         /// </summary>
-        public static string DefaultBuildId => "151.0.7922.71";
+        public static string DefaultBuildId => "151.0.7922.77";
 
         internal static async Task<string> ResolveBuildIdAsync(ChromeReleaseChannel channel)
             => (await GetLastKnownGoodReleaseForChannel(channel).ConfigureAwait(false)).Version;

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_153.0.1";
+        public const string DefaultBuildId = "stable_153.0.3";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
Rolls the pinned browser versions to match Puppeteer v25.6.0.

## Changes

| Browser | Before | After |
| --- | --- | --- |
| Chrome (`BrowserData/Chrome.cs`) | 151.0.7922.60 | **151.0.7922.77** |
| Firefox (`BrowserData/Firefox.cs`) | stable_153.0.2 | **stable_153.0.3** |

The chromium-bidi mapper version (`lib/PuppeteerSharp/Bidi/chromium-bidi.version`) was checked against upstream `packages/puppeteer-core/package.json` and is unchanged (14.0.0).

## Upstream

- puppeteer/puppeteer#15295 — roll to Chrome 151.0.7922.76
- puppeteer/puppeteer#15308 — roll to Chrome 151.0.7922.77 (supersedes #15295)
- puppeteer/puppeteer#15294 — roll to Firefox 153.0.3

## Verification

- Build passes
- `LaunchTests` on Chrome/CDP: 33 passed, 3 skipped, 0 failed
