### PR TITLE
Don't fail per-frame CDP fan-out when an OOP iframe goes away

### DIFF
--- a/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
+++ b/lib/PuppeteerSharp.Tests/OOPIFTests/OOPIFTests.cs
@@ -478,6 +478,36 @@ namespace PuppeteerSharp.Tests.OOPIFTests
             }
         }
 
+        [Test, PuppeteerTest("oopif.spec", "OOPIF", "should exposeFunction when an OOP iframe goes away mid-call")]
+        public async Task ShouldExposeFunctionWhenAnOopIframeGoesAwayMidCall()
+        {
+            const int FrameCount = 8;
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            for (var i = 0; i < FrameCount; i++)
+            {
+                await FrameUtils.AttachFrameAsync(
+                    Page,
+                    $"oopif{i}",
+                    TestConstants.CrossProcessHttpPrefix + "/empty.html");
+            }
+
+            Assert.That(Page.Frames, Has.Length.EqualTo(FrameCount + 1));
+
+            var detachedTask = Page.EvaluateFunctionAsync(@"() => {
+                for (const frame of document.querySelectorAll('iframe')) {
+                    frame.remove();
+                }
+            }");
+            var exposedTask = Page.ExposeFunctionAsync("doubleIt", (int value) => value * 2);
+
+            await exposedTask;
+            await detachedTask;
+
+            var result = await Page.EvaluateFunctionAsync<int>("async () => await window.doubleIt(21)");
+            Assert.That(result, Is.EqualTo(42));
+        }
+
         [Test, PuppeteerTest("oopif.spec", "OOPIF", "should exposeFunction on a page with a PDF viewer")]
         public async Task ShouldExposeFunctionOnAPageWithAPdfViewer()
         {

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -302,7 +302,15 @@ namespace PuppeteerSharp.Cdp
             return slashIndex == -1 ? pathPart : pathPart.Substring(0, slashIndex);
         }
 
-        private static bool IsTargetClosedError(Exception ex)
+        /// <summary>
+        /// Whether an exception means the frame's own CDP session is gone.
+        /// Upstream only has to check for <c>TargetCloseError</c> because the JS session rejects
+        /// pending calls locally. Here the command can still reach the browser before we notice the
+        /// detach, so Chrome answers with a session/frame lookup error instead.
+        /// </summary>
+        /// <param name="ex">The exception raised by the per-frame call.</param>
+        /// <returns>Whether the error is caused by the session going away.</returns>
+        private static bool IsSessionGoneError(Exception ex)
             => ex is TargetClosedException ||
                 ex.Message.Contains("Target closed", StringComparison.Ordinal) ||
                 ex.Message.Contains("Session closed", StringComparison.Ordinal) ||
@@ -648,8 +656,10 @@ namespace PuppeteerSharp.Cdp
                 {
                     await action(cdpFrame).ConfigureAwait(false);
                 }
-                catch (Exception ex) when (cdpFrame.IsOopFrame() && IsTargetClosedError(ex))
+                catch (Exception ex) when (cdpFrame.IsOopFrame() && IsSessionGoneError(ex))
                 {
+                    // Only an out-of-process frame has a session of its own to lose.
+                    // Losing it mid-call must not fail the whole fan-out.
                 }
             })).ConfigureAwait(false);
         }

--- a/lib/PuppeteerSharp/Cdp/FrameManager.cs
+++ b/lib/PuppeteerSharp/Cdp/FrameManager.cs
@@ -103,8 +103,7 @@ namespace PuppeteerSharp.Cdp
             var preloadScript = new CdpPreloadScript(mainFrame, response.Identifier, source);
             _scriptsToEvaluateOnNewDocument.TryAdd(response.Identifier, preloadScript);
 
-            await Task.WhenAll(
-                GetFrames().Select(frame => ((CdpFrame)frame).AddPreloadScriptAsync(preloadScript))).ConfigureAwait(false);
+            await ForEachFrameAsync(frame => frame.AddPreloadScriptAsync(preloadScript)).ConfigureAwait(false);
 
             return new NewDocumentScriptEvaluation(response.Identifier);
         }
@@ -145,15 +144,13 @@ namespace PuppeteerSharp.Cdp
         internal async Task AddExposedFunctionBindingAsync(Binding binding)
         {
             _bindings.Add(binding);
-            await Task.WhenAll(
-                GetFrames().Select(frame => ((CdpFrame)frame).AddExposedFunctionBindingAsync(binding))).ConfigureAwait(false);
+            await ForEachFrameAsync(frame => frame.AddExposedFunctionBindingAsync(binding)).ConfigureAwait(false);
         }
 
         internal async Task RemoveExposedFunctionBindingAsync(Binding binding)
         {
             _bindings.Remove(binding);
-            await Task.WhenAll(
-                GetFrames().Select(frame => ((CdpFrame)frame).RemoveExposedFunctionBindingAsync(binding))).ConfigureAwait(false);
+            await ForEachFrameAsync(frame => frame.RemoveExposedFunctionBindingAsync(binding)).ConfigureAwait(false);
         }
 
         internal void OnAttachedToTarget(CdpTarget target)
@@ -304,6 +301,14 @@ namespace PuppeteerSharp.Cdp
             var slashIndex = pathPart.IndexOf('/');
             return slashIndex == -1 ? pathPart : pathPart.Substring(0, slashIndex);
         }
+
+        private static bool IsTargetClosedError(Exception ex)
+            => ex is TargetClosedException ||
+                ex.Message.Contains("Target closed", StringComparison.Ordinal) ||
+                ex.Message.Contains("Session closed", StringComparison.Ordinal) ||
+                ex.Message.Contains("Session detached", StringComparison.Ordinal) ||
+                ex.Message.Contains("Session with given id not found", StringComparison.Ordinal) ||
+                ex.Message.Contains("No frame with given id", StringComparison.Ordinal);
 
         private CdpFrame GetFrame(string frameId) => FrameTree.GetById(frameId);
 
@@ -632,6 +637,21 @@ namespace PuppeteerSharp.Cdp
                     await HandleFrameTreeAsync(session, child).ConfigureAwait(false);
                 }
             }
+        }
+
+        private async Task ForEachFrameAsync(Func<CdpFrame, Task> action)
+        {
+            await Task.WhenAll(GetFrames().Select(async frame =>
+            {
+                var cdpFrame = (CdpFrame)frame;
+                try
+                {
+                    await action(cdpFrame).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (cdpFrame.IsOopFrame() && IsTargetClosedError(ex))
+                {
+                }
+            })).ConfigureAwait(false);
         }
 
         private async Task CreateIsolatedWorldAsync(CDPSession session, string name)


### PR DESCRIPTION
Ports puppeteer/puppeteer#15300 — a CDP operation that fans out across every frame should not fail just because an out-of-process iframe was destroyed while the call was in flight.

## Problem

`FrameManager` applied preload scripts and exposed-function bindings by running the operation against every frame with `Task.WhenAll`. If an OOPIF was removed mid-flight, its session went away and the whole aggregate operation threw — so `ExposeFunctionAsync` / `EvaluateOnNewDocumentAsync` could fail on the main frame purely because an unrelated iframe disappeared.

## Changes

- Add a `ForEachFrameAsync` helper in `Cdp/FrameManager.cs` and route `EvaluateOnNewDocumentAsync`, `AddExposedFunctionBindingAsync` and `RemoveExposedFunctionBindingAsync` through it.
- The helper swallows the failure only when the frame is an OOP frame **and** the exception is a target/session-gone error (`TargetClosedException`, "Target closed", "Session closed", "Session detached", "Session with given id not found", "No frame with given id"). All other exceptions still propagate.
- Add regression test `should exposeFunction when an OOP iframe goes away mid-call` in `OOPIFTests`, mirroring the upstream `oopif.spec` case.

## Verification

- Build passes
- `OOPIFTests`: 28/28 passing
