### PR TITLE
Bump version to 25.6.0

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.5.1</PackageVersion>
-    <ReleaseVersion>25.5.1</ReleaseVersion>
-    <AssemblyVersion>25.5.1</AssemblyVersion>
-    <FileVersion>25.5.1</FileVersion>
+    <PackageVersion>25.6.0</PackageVersion>
+    <ReleaseVersion>25.6.0</ReleaseVersion>
+    <AssemblyVersion>25.6.0</AssemblyVersion>
+    <FileVersion>25.6.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Bumps `PuppeteerSharp.csproj` from 25.5.1 to **25.6.0**, aligning with the upstream [puppeteer-core v25.6.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v25.6.0) release.

## Included in this release

- #3546 — Roll browsers: Chrome 151.0.7922.77, Firefox 153.0.3 (upstream #15295, #15308, #15294)
- #3547 — Propagate `ILoggerFactory` through BiDi sessions, frames and realms (upstream #15324, #15297, #15302)
- #3548 — Do not fail per-frame CDP fan-out when an OOP iframe goes away (upstream #15300)

> Merge this after the three PRs above.
