### PR TITLE
feat(tracing): support BufferSize option in Tracing.StartAsync

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15328.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15328.json
@@ -1,0 +1,1 @@
+{"comment":"ci retrigger 15328","expectations":[]}

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15328.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15328.json
@@ -1,1 +1,0 @@
-{"comment":"ci retrigger 15328","expectations":[]}

--- a/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
+++ b/lib/PuppeteerSharp.Tests/TracingTests/TracingTests.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
 using NUnit.Framework;
+using PuppeteerSharp.Cdp.Messaging;
 using PuppeteerSharp.Nunit;
 
 namespace PuppeteerSharp.Tests.TracingTests
@@ -143,6 +146,31 @@ namespace PuppeteerSharp.Tests.TracingTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/grid.html");
             var trace = await Page.Tracing.StopAsync();
             Assert.That(trace, Is.Not.Null);
+        }
+
+        [Test, PuppeteerTest("tracing.spec", "Tracing", "should support bufferSize option")]
+        public async Task ShouldSupportBufferSizeOption()
+        {
+            using var loggerFactory = new LoggerFactory();
+            var client = Substitute.For<CDPSession>();
+            client.LoggerFactory.Returns(loggerFactory);
+            client.SendAsync(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<bool>(), Arg.Any<CommandOptions>())
+                .Returns(Task.FromResult<JsonElement?>(null));
+
+            var tracing = new Tracing(client);
+            await tracing.StartAsync(new TracingOptions
+            {
+                Path = _file,
+                BufferSize = 10,
+            });
+
+            await client.Received().SendAsync(
+                "Tracing.start",
+                Arg.Is<TracingStartRequest>(request =>
+                    request.TraceConfig != null &&
+                    request.TraceConfig.TraceBufferSizeInKb == 10),
+                Arg.Any<bool>(),
+                Arg.Any<CommandOptions>());
         }
 
         [Test, PuppeteerTest("tracing.spec", "Tracing", "should support a typedArray without a path")]

--- a/lib/PuppeteerSharp/Cdp/Messaging/TracingStartRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/TracingStartRequest.cs
@@ -2,8 +2,8 @@ namespace PuppeteerSharp.Cdp.Messaging
 {
     internal class TracingStartRequest
     {
-        public string Categories { get; set; }
-
         public string TransferMode { get; set; }
+
+        public TracingTraceConfig TraceConfig { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/Messaging/TracingTraceConfig.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/TracingTraceConfig.cs
@@ -1,0 +1,11 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class TracingTraceConfig
+    {
+        public string[] IncludedCategories { get; set; }
+
+        public string[] ExcludedCategories { get; set; }
+
+        public int? TraceBufferSizeInKb { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
@@ -256,6 +256,7 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(TargetType))]
 [JsonSerializable(typeof(TracingCompleteResponse))]
 [JsonSerializable(typeof(TracingStartRequest))]
+[JsonSerializable(typeof(TracingTraceConfig))]
 [JsonSerializable(typeof(WSEndpointResponse))]
 [JsonSerializable(typeof(TargetInfo))]
 [JsonSerializable(typeof(WaitForFunctionPollingOption))]

--- a/lib/PuppeteerSharp/Tracing.cs
+++ b/lib/PuppeteerSharp/Tracing.cs
@@ -66,12 +66,18 @@ namespace PuppeteerSharp
                 throw new InvalidOperationException("Cannot start recording trace while already recording trace.");
             }
 
-            var categories = options?.Categories ?? _defaultCategories;
+            var categories = new List<string>(options?.Categories ?? _defaultCategories);
 
             if (options?.Screenshots == true)
             {
                 categories.Add("disabled-by-default-devtools.screenshot");
             }
+
+            var excludedCategories = categories
+                .FindAll(category => category.StartsWith("-", StringComparison.Ordinal))
+                .ConvertAll(category => category.Substring(1));
+            var includedCategories = categories
+                .FindAll(category => !category.StartsWith("-", StringComparison.Ordinal));
 
             _path = options?.Path;
             _recording = true;
@@ -79,7 +85,12 @@ namespace PuppeteerSharp
             return _client.SendAsync("Tracing.start", new TracingStartRequest
             {
                 TransferMode = "ReturnAsStream",
-                Categories = string.Join(", ", categories),
+                TraceConfig = new TracingTraceConfig
+                {
+                    ExcludedCategories = excludedCategories.ToArray(),
+                    IncludedCategories = includedCategories.ToArray(),
+                    TraceBufferSizeInKb = options?.BufferSize,
+                },
             });
         }
 

--- a/lib/PuppeteerSharp/Tracing.cs
+++ b/lib/PuppeteerSharp/Tracing.cs
@@ -9,7 +9,6 @@ using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp
 {
-    // CI retrigger for upstream #15328
     /// <summary>
     /// You can use <see cref="ITracing.StartAsync(TracingOptions)"/> and <see cref="ITracing.StopAsync"/> to create a trace file which can be opened in Chrome DevTools or timeline viewer.
     /// </summary>

--- a/lib/PuppeteerSharp/Tracing.cs
+++ b/lib/PuppeteerSharp/Tracing.cs
@@ -9,6 +9,7 @@ using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp
 {
+    // CI retrigger for upstream #15328
     /// <summary>
     /// You can use <see cref="ITracing.StartAsync(TracingOptions)"/> and <see cref="ITracing.StopAsync"/> to create a trace file which can be opened in Chrome DevTools or timeline viewer.
     /// </summary>

--- a/lib/PuppeteerSharp/TracingOptions.cs
+++ b/lib/PuppeteerSharp/TracingOptions.cs
@@ -8,21 +8,32 @@ namespace PuppeteerSharp
     public class TracingOptions
     {
         /// <summary>
+        /// Gets or sets a path to write the trace file to.
+        /// If no path is specified, the trace will not be written to disk, but can
+        /// still be retrieved as a string from <see cref="ITracing.StopAsync"/>.
+        /// </summary>
+        /// <value>The path.</value>
+        public string Path { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether Tracing should capture screenshots in the trace.
         /// </summary>
         /// <value>Screenshots option.</value>
         public bool Screenshots { get; set; }
 
         /// <summary>
-        /// A path to write the trace file to.
-        /// </summary>
-        /// <value>The path.</value>
-        public string Path { get; set; }
-
-        /// <summary>
-        /// Specify custom categories to use instead of default.
+        /// Gets or sets custom categories to use instead of default.
+        /// To exclude a category, prefix it with <c>-</c> (e.g., <c>-toplevel</c>).
         /// </summary>
         /// <value>The categories.</value>
         public List<string> Categories { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the trace buffer in kilobytes.
+        /// If not specified or zero is passed, the default value of 200 MB
+        /// (200,000 KB) is used by Chromium.
+        /// </summary>
+        /// <value>The buffer size in kilobytes.</value>
+        public int? BufferSize { get; set; }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports [puppeteer/puppeteer#15328](https://github.com/puppeteer/puppeteer/pull/15328) from **puppeteer-core-v25.7.0**.

## What changed
- Added `TracingOptions.BufferSize` (`int?`), forwarded to CDP as `traceConfig.traceBufferSizeInKb`
- Switched `Tracing.StartAsync` to send a `TraceConfig` with included/excluded categories (required to set buffer size; matches upstream)
- Added `TracingTraceConfig` messaging type + JSON source-gen registration
- Added `should support bufferSize option` test

## Why
Upstream tracing now allows callers to size the in-memory trace buffer. Without this, PuppeteerSharp cannot pass `bufferSize` through to Chrome.

## Test plan
- [x] `BROWSER=CHROME PROTOCOL=cdp` Tracing tests
- [ ] Full CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffccf-2a88-76e3-927e-794f44a5a3ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffccf-2a88-76e3-927e-794f44a5a3ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

