### PR TITLE
docs: clarify CdpHttpRequest owns its logger (upstream #15338 N/A)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15338.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15338.json
@@ -1,0 +1,1 @@
+{"comment":"ci retrigger 15338","expectations":[]}

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15338.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15338.json
@@ -1,1 +1,0 @@
-{"comment":"ci retrigger 15338","expectations":[]}

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -16,6 +16,9 @@ namespace PuppeteerSharp.Cdp;
 public class CdpHttpRequest : Request<CdpHttpResponse>
 {
     private readonly bool _allowInterception;
+
+    // Owned by the request (not looked up via Frame) so error handlers remain safe after frame detach.
+    // Upstream equivalent: puppeteer/puppeteer#15338.
     private readonly ILogger _logger;
     private readonly List<Func<IRequest, Task>> _interceptHandlers = [];
     private CDPSession _client;

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -15,7 +15,6 @@ namespace PuppeteerSharp.Cdp;
 /// <inheritdoc/>
 public class CdpHttpRequest : Request<CdpHttpResponse>
 {
-    // CI retrigger for upstream #15338
     private readonly bool _allowInterception;
 
     // Owned by the request (not looked up via Frame) so error handlers remain safe after frame detach.

--- a/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpHttpRequest.cs
@@ -15,6 +15,7 @@ namespace PuppeteerSharp.Cdp;
 /// <inheritdoc/>
 public class CdpHttpRequest : Request<CdpHttpResponse>
 {
+    // CI retrigger for upstream #15338
     private readonly bool _allowInterception;
 
     // Owned by the request (not looked up via Frame) so error handlers remain safe after frame detach.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks [puppeteer/puppeteer#15338](https://github.com/puppeteer/puppeteer/pull/15338) from **puppeteer-core-v25.7.0**.

## Verdict
**No behavioral change.** Upstream fixed crashes where request error handlers did `(this.frame() as any).logger` after the frame was detached (`frame()` null).

PuppeteerSharp already avoids that pattern:
- `CdpHttpRequest` takes `ILoggerFactory`, stores `_logger`, and `HandleError` uses that instance
- `NetworkManager` passes the factory when constructing requests
- BiDi request error paths do not look up a logger via `Frame`

## What changed
- Documented on `CdpHttpRequest` that the logger is request-owned so detach-safe error handling is intentional (upstream equivalent already present)

## Test plan
- [ ] Full CI green (path-filtered build triggered by the `.cs` comment change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffccf-2a88-76e3-927e-794f44a5a3ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffccf-2a88-76e3-927e-794f44a5a3ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

