### PR TITLE
fix: roll Firefox to 153.0.4

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15329.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15329.json
@@ -1,1 +1,0 @@
-{"comment":"ci retrigger 15329","expectations":[]}

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15329.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/.ci-retrigger-15329.json
@@ -1,0 +1,1 @@
+{"comment":"ci retrigger 15329","expectations":[]}

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_153.0.3";
+        public const string DefaultBuildId = "stable_153.0.4";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -9,6 +9,7 @@ using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.BrowserData
 {
+    // CI retrigger for upstream #15329
     /// <summary>
     /// Chrome info.
     /// </summary>

--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -9,7 +9,6 @@ using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.BrowserData
 {
-    // CI retrigger for upstream #15329
     /// <summary>
     /// Chrome info.
     /// </summary>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports [puppeteer/puppeteer#15329](https://github.com/puppeteer/puppeteer/pull/15329) from **puppeteer-core-v25.7.0**.

## What changed
- Updated `Firefox.DefaultBuildId` from `stable_153.0.3` → `stable_153.0.4`

## Why
Keeps the pinned Firefox revision aligned with puppeteer-core.

## Test plan
- [x] Firefox-related tests under `BROWSER=FIREFOX PROTOCOL=bidi`
- [ ] Full CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffccf-2a88-76e3-927e-794f44a5a3ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffccf-2a88-76e3-927e-794f44a5a3ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

