### PR TITLE
Bump version to 25.7.0

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.6.0</PackageVersion>
-    <ReleaseVersion>25.6.0</ReleaseVersion>
-    <AssemblyVersion>25.6.0</AssemblyVersion>
-    <FileVersion>25.6.0</FileVersion>
+    <PackageVersion>25.7.0</PackageVersion>
+    <ReleaseVersion>25.7.0</ReleaseVersion>
+    <AssemblyVersion>25.7.0</AssemblyVersion>
+    <FileVersion>25.7.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Bumps `PuppeteerSharp.csproj` from 25.6.0 to **25.7.0**, aligning with the upstream [puppeteer-core v25.7.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v25.7.0) release.

## Included in this release

- #3553 — feat: roll Chrome to 152.0.7977.42 (upstream #15330)
- #3554 — fix: roll Firefox to 153.0.4 (upstream #15329)
- #3551 — feat(tracing): support BufferSize option in Tracing.StartAsync (upstream #15328)
- #3555 — refactor: track CDP listeners with DisposableActionsStack (upstream #15332)
- #3552 — docs: clarify CdpHttpRequest owns its logger (upstream #15338 N/A)