### PR TITLE
Fix: computeSystemExecutablePath support validatePath (#15340)

### DIFF
--- a/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
+++ b/lib/PuppeteerSharp.Tests/Browsers/Chrome/ChromeDataTests.cs
@@ -138,6 +138,34 @@ namespace PuppeteerSharp.Tests.Browsers.Chrome
         }
 
         [Test]
+        public void ComputeSystemExecutablePathShouldHonorValidatePath()
+        {
+            const string macOsBetaPath = "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta";
+
+            Assert.That(
+                BrowserData.Chrome.ResolveSystemExecutablePaths(Platform.MacOS, ChromeReleaseChannel.Beta),
+                Is.EqualTo(new[] { macOsBetaPath }));
+
+            var unresolvedPath = Launcher.ComputeSystemExecutablePath(
+                SupportedBrowser.Chrome,
+                ChromeReleaseChannel.Beta,
+                validatePath: false,
+                platform: Platform.MacOS);
+
+            Assert.That(unresolvedPath, Is.EqualTo(macOsBetaPath));
+            Assert.That(File.Exists(unresolvedPath), Is.False);
+
+            var exception = Assert.Throws<PuppeteerException>(() =>
+                Launcher.ComputeSystemExecutablePath(
+                    SupportedBrowser.Chrome,
+                    ChromeReleaseChannel.Beta,
+                    validatePath: true,
+                    platform: Platform.MacOS));
+
+            Assert.That(exception!.Message, Does.Contain(macOsBetaPath));
+        }
+
+        [Test]
         [Retry(2)]
         public async Task ShouldReturnLatestVersion()
             => await BrowserData.Chrome.ResolveBuildIdAsync(ChromeReleaseChannel.Stable);

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -290,6 +290,50 @@ namespace PuppeteerSharp
             return await ConnectCdpAsync(browserWSEndpoint, options).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Returns a path to a system-wide Chrome installation for the given release channel.
+        /// </summary>
+        /// <param name="browser">Browser to resolve. Only <see cref="SupportedBrowser.Chrome"/> is supported.</param>
+        /// <param name="channel">Release channel to look for on the system.</param>
+        /// <param name="validatePath">
+        /// If <c>true</c> (default), throws when no candidate exists.
+        /// If <c>false</c>, returns the first resolved candidate even when the file is missing.
+        /// </param>
+        /// <param name="platform">
+        /// Platform whose known install locations should be used.
+        /// Defaults to the current platform.
+        /// </param>
+        /// <returns>The first existing candidate, or the first resolved path when <paramref name="validatePath"/> is <c>false</c>.</returns>
+        internal static string ComputeSystemExecutablePath(
+            SupportedBrowser browser,
+            ChromeReleaseChannel channel,
+            bool validatePath = true,
+            Platform? platform = null)
+        {
+            if (browser != SupportedBrowser.Chrome)
+            {
+                throw new PuppeteerException($"System browser detection is not supported for {browser} yet.");
+            }
+
+            var paths = Chrome.ResolveSystemExecutablePaths(platform ?? BrowserFetcher.GetCurrentPlatform(), channel);
+
+            foreach (var path in paths)
+            {
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            if (!validatePath)
+            {
+                return paths[0];
+            }
+
+            throw new PuppeteerException(
+                $"Could not find Google Chrome executable for channel '{channel}' at:\n - {string.Join("\n - ", paths)}");
+        }
+
         private static bool IsBrowserAlreadyRunning(Exception ex, string userDataDir)
         {
             var message = ex.ToString();
@@ -531,27 +575,6 @@ namespace PuppeteerSharp
             }
 
             return ResolveExecutablePath(options.HeadlessMode, buildId);
-        }
-
-        private string ComputeSystemExecutablePath(SupportedBrowser browser, ChromeReleaseChannel channel)
-        {
-            if (browser != SupportedBrowser.Chrome)
-            {
-                throw new PuppeteerException($"System browser detection is not supported for {browser} yet.");
-            }
-
-            var paths = Chrome.ResolveSystemExecutablePaths(BrowserFetcher.GetCurrentPlatform(), channel);
-
-            foreach (var path in paths)
-            {
-                if (File.Exists(path))
-                {
-                    return path;
-                }
-            }
-
-            throw new PuppeteerException(
-                $"Could not find Google Chrome executable for channel '{channel}' at:\n - {string.Join("\n - ", paths)}");
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15340 (puppeteer-core v25.8.0).

## Upstream

`computeSystemExecutablePath` now accepts `validatePath` (default `true`). When `validatePath` is `false` and no candidate exists, the first resolved path is returned instead of throwing.

## PuppeteerSharp

- `Launcher.ComputeSystemExecutablePath` is internal and accepts `validatePath` (default `true`)
- Launch still validates the path when a channel is set
- Unit test covers both `validatePath: true` (throws) and `validatePath: false` (returns the first candidate)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f22072-da72-4e17-bbdd-a2c568564c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f22072-da72-4e17-bbdd-a2c568564c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

