### PR TITLE
New Feature: Support FollowSymlinks option (#15335)

### DIFF
--- a/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
+++ b/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
@@ -180,6 +180,24 @@ namespace PuppeteerSharp.Tests.FollowSymlinksTests
             }
         }
 
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject screencast to an existing symlink path")]
+        public async Task ShouldRejectScreencastToAnExistingSymlinkPath()
+        {
+            IgnoreIfWindowsOrSymlinksUnsupported();
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var targetFile = Path.Combine(_tmpDir, "output.webm");
+            var linkFile = Path.Combine(_tmpDir, "output-link.webm");
+            File.WriteAllText(targetFile, "placeholder");
+            File.CreateSymbolicLink(linkFile, targetFile);
+
+            var exception = Assert.ThrowsAsync<IOException>(
+                () => Page.ScreencastAsync(new ScreencastOptions { Path = linkFile }));
+            Assert.That(exception, Is.Not.Null);
+        }
+
         [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is true (default)", "should allow addScriptTag with a symlinked path")]
         public async Task ShouldAllowAddScriptTagWithASymlinkedPath()
         {

--- a/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
+++ b/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Nunit;
@@ -8,6 +9,141 @@ namespace PuppeteerSharp.Tests.FollowSymlinksTests
 {
     public class FollowSymlinksTests : PuppeteerPageBaseTest
     {
+        private string _tmpDir;
+        private string _scriptFile;
+        private string _scriptSymlink;
+        private string _styleFile;
+        private string _styleSymlink;
+        private bool _symlinksSupported = true;
+
+        [SetUp]
+        public void CreateTempFiles()
+        {
+            _tmpDir = Path.Combine(Path.GetTempPath(), "pptr-symlink-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tmpDir);
+
+            _scriptFile = Path.Combine(_tmpDir, "script.js");
+            _scriptSymlink = Path.Combine(_tmpDir, "script-link.js");
+            File.WriteAllText(_scriptFile, "window.__injected = 123;");
+
+            try
+            {
+                File.CreateSymbolicLink(_scriptSymlink, _scriptFile);
+                _symlinksSupported = true;
+            }
+            catch
+            {
+                _symlinksSupported = false;
+                return;
+            }
+
+            _styleFile = Path.Combine(_tmpDir, "style.css");
+            _styleSymlink = Path.Combine(_tmpDir, "style-link.css");
+            File.WriteAllText(_styleFile, "body { background-color: rgb(0, 255, 0); }");
+            File.CreateSymbolicLink(_styleSymlink, _styleFile);
+        }
+
+        [TearDown]
+        public void CleanupTempFiles()
+        {
+            Puppeteer.SetFollowSymlinks(true);
+
+            try
+            {
+                if (!string.IsNullOrEmpty(_tmpDir) && Directory.Exists(_tmpDir))
+                {
+                    Directory.Delete(_tmpDir, true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject addScriptTag with a symlinked path")]
+        public async Task ShouldRejectAddScriptTagWithASymlinkedPath()
+        {
+            IgnoreIfWindowsOrSymlinksUnsupported();
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var exception = Assert.ThrowsAsync<IOException>(
+                () => Page.AddScriptTagAsync(new AddTagOptions { Path = _scriptSymlink }));
+            Assert.That(exception, Is.Not.Null);
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should allow addScriptTag with a regular file path")]
+        public async Task ShouldAllowAddScriptTagWithARegularFilePath()
+        {
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            await Page.AddScriptTagAsync(new AddTagOptions { Path = _scriptFile });
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(123));
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject addStyleTag with a symlinked path")]
+        public async Task ShouldRejectAddStyleTagWithASymlinkedPath()
+        {
+            IgnoreIfWindowsOrSymlinksUnsupported();
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var exception = Assert.ThrowsAsync<IOException>(
+                () => Page.AddStyleTagAsync(new AddTagOptions { Path = _styleSymlink }));
+            Assert.That(exception, Is.Not.Null);
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should allow addStyleTag with a regular file path")]
+        public async Task ShouldAllowAddStyleTagWithARegularFilePath()
+        {
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            await Page.AddStyleTagAsync(new AddTagOptions { Path = _styleFile });
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string>(
+                    "window.getComputedStyle(document.body).getPropertyValue('background-color')"),
+                Is.EqualTo("rgb(0, 255, 0)"));
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject screenshot to an existing symlink path")]
+        public async Task ShouldRejectScreenshotToAnExistingSymlinkPath()
+        {
+            IgnoreIfWindowsOrSymlinksUnsupported();
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var targetFile = Path.Combine(_tmpDir, "screenshot.png");
+            var linkFile = Path.Combine(_tmpDir, "screenshot-link.png");
+            File.WriteAllText(targetFile, "placeholder");
+            File.CreateSymbolicLink(linkFile, targetFile);
+
+            var exception = Assert.ThrowsAsync<IOException>(() => Page.ScreenshotAsync(linkFile));
+            Assert.That(exception, Is.Not.Null);
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject pdf to an existing symlink path")]
+        public async Task ShouldRejectPdfToAnExistingSymlinkPath()
+        {
+            IgnoreIfWindowsOrSymlinksUnsupported();
+            Puppeteer.SetFollowSymlinks(false);
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var targetFile = Path.Combine(_tmpDir, "output.pdf");
+            var linkFile = Path.Combine(_tmpDir, "output-link.pdf");
+            File.WriteAllText(targetFile, "placeholder");
+            File.CreateSymbolicLink(linkFile, targetFile);
+
+            var exception = Assert.ThrowsAsync<IOException>(() => Page.PdfAsync(linkFile));
+            Assert.That(exception, Is.Not.Null);
+        }
+
         [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject screencast when overwrite is false and file exists")]
         public async Task ShouldRejectScreencastWhenOverwriteIsFalseAndFileExists()
         {
@@ -41,6 +177,63 @@ namespace PuppeteerSharp.Tests.FollowSymlinksTests
                 {
                     // Ignore cleanup errors
                 }
+            }
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is true (default)", "should allow addScriptTag with a symlinked path")]
+        public async Task ShouldAllowAddScriptTagWithASymlinkedPath()
+        {
+            IgnoreIfSymlinksUnsupported();
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            await Page.AddScriptTagAsync(new AddTagOptions { Path = _scriptSymlink });
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(123));
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is true (default)", "should allow addStyleTag with a symlinked path")]
+        public async Task ShouldAllowAddStyleTagWithASymlinkedPath()
+        {
+            IgnoreIfSymlinksUnsupported();
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            await Page.AddStyleTagAsync(new AddTagOptions { Path = _styleSymlink });
+            Assert.That(
+                await Page.EvaluateExpressionAsync<string>(
+                    "window.getComputedStyle(document.body).getPropertyValue('background-color')"),
+                Is.EqualTo("rgb(0, 255, 0)"));
+        }
+
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is true (default)", "should allow screenshot to a symlink path")]
+        public async Task ShouldAllowScreenshotToASymlinkPath()
+        {
+            IgnoreIfSymlinksUnsupported();
+
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var targetFile = Path.Combine(_tmpDir, "screenshot-target.png");
+            var linkFile = Path.Combine(_tmpDir, "screenshot-default-link.png");
+            File.WriteAllText(targetFile, "placeholder");
+            File.CreateSymbolicLink(linkFile, targetFile);
+
+            await Page.ScreenshotAsync(linkFile);
+            Assert.That(new FileInfo(targetFile).Length, Is.GreaterThan(0));
+        }
+
+        private void IgnoreIfWindowsOrSymlinksUnsupported()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Ignore("Symlink rejection is not enforced on Windows");
+            }
+
+            IgnoreIfSymlinksUnsupported();
+        }
+
+        private void IgnoreIfSymlinksUnsupported()
+        {
+            if (!_symlinksSupported)
+            {
+                Assert.Ignore("Creating symbolic links is not supported on this system");
             }
         }
     }

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -318,7 +318,7 @@ public class CdpPage : Page
         await client.SendAsync("HeapProfiler.enable").ConfigureAwait(false);
         await client.SendAsync("HeapProfiler.collectGarbage").ConfigureAwait(false);
 
-        using var fileStream = new StreamWriter(options.Path);
+        using var fileStream = new StreamWriter(AsyncFileHelper.CreateStream(options.Path, FileMode.Create));
 
         void Handler(object sender, MessageEventArgs e)
         {

--- a/lib/PuppeteerSharp/Helpers/AsyncFileHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/AsyncFileHelper.cs
@@ -1,4 +1,7 @@
 using System.IO;
+#if !NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 using System.Text;
 using System.Threading.Tasks;
 
@@ -64,16 +67,17 @@ namespace PuppeteerSharp.Helpers
         {
             try
             {
-                var attributes = File.GetAttributes(path);
-                if ((attributes & FileAttributes.ReparsePoint) == 0)
-                {
-                    return false;
-                }
-
 #if NET8_0_OR_GREATER
+                // File.GetAttributes follows symlinks on Unix and will not report
+                // ReparsePoint, so ResolveLinkTarget must be the primary check.
                 return File.ResolveLinkTarget(path, returnFinalTarget: false) != null;
 #else
-                return true;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+                }
+
+                return UnixIsSymbolicLink(path);
 #endif
             }
             catch (FileNotFoundException)
@@ -85,5 +89,16 @@ namespace PuppeteerSharp.Helpers
                 return false;
             }
         }
+
+#if !NET8_0_OR_GREATER
+        [DllImport("libc", SetLastError = true, EntryPoint = "readlink")]
+        private static extern int ReadLink(string path, byte[] buf, ulong bufsiz);
+
+        private static bool UnixIsSymbolicLink(string path)
+        {
+            var buffer = new byte[1];
+            return ReadLink(path, buffer, (ulong)buffer.Length) >= 0;
+        }
+#endif
     }
 }

--- a/lib/PuppeteerSharp/Helpers/AsyncFileHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/AsyncFileHelper.cs
@@ -19,7 +19,10 @@ namespace PuppeteerSharp.Helpers
 
         /// <inheritdoc cref="System.IO.FileStream(string, FileMode, FileAccess, FileShare)" />
         public static FileStream CreateStream(string path, FileMode mode, FileAccess access, FileShare share)
-            => new FileStream(path, mode, access, share, 4096, true);
+        {
+            ThrowIfSymlinkNotAllowed(path);
+            return new FileStream(path, mode, access, share, 4096, true);
+        }
 
         /// <inheritdoc cref="System.IO.File.ReadAllText(string)" />
         public static Task<string> ReadAllText(string path)
@@ -43,5 +46,44 @@ namespace PuppeteerSharp.Helpers
         /// <param name="encoding">The encoding applied to the contents of the file.</param>
         public static StreamReader OpenText(string path, Encoding encoding)
             => new StreamReader(OpenRead(path), encoding);
+
+        private static void ThrowIfSymlinkNotAllowed(string path)
+        {
+            if (Puppeteer.FollowSymlinks || string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            if (IsSymbolicLink(path))
+            {
+                throw new IOException($"The path '{path}' is a symbolic link and following symlinks is disabled.");
+            }
+        }
+
+        private static bool IsSymbolicLink(string path)
+        {
+            try
+            {
+                var attributes = File.GetAttributes(path);
+                if ((attributes & FileAttributes.ReparsePoint) == 0)
+                {
+                    return false;
+                }
+
+#if NET8_0_OR_GREATER
+                return File.ResolveLinkTarget(path, returnFinalTarget: false) != null;
+#else
+                return true;
+#endif
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/lib/PuppeteerSharp/Puppeteer.cs
+++ b/lib/PuppeteerSharp/Puppeteer.cs
@@ -67,6 +67,11 @@ namespace PuppeteerSharp
         public static IJsonTypeInfoResolver ExtraJsonSerializerContext { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether Puppeteer should follow symlinks for file operations.
+        /// </summary>
+        internal static bool FollowSymlinks { get; private set; } = true;
+
+        /// <summary>
         /// Returns an array of argument based on the options provided and the platform where the library is running.
         /// </summary>
         /// <returns>Chromium arguments.</returns>
@@ -112,5 +117,12 @@ namespace PuppeteerSharp
         /// <returns>The browser fetcher.</returns>
         /// <param name="options">Options.</param>
         public static IBrowserFetcher CreateBrowserFetcher(BrowserFetcherOptions options) => new BrowserFetcher(options);
+
+        /// <summary>
+        /// Defines whether Puppeteer should follow symlinks for file operations.
+        /// </summary>
+        /// <param name="followSymlinks">Whether Puppeteer should follow symlinks.</param>
+        public static void SetFollowSymlinks(bool followSymlinks)
+            => FollowSymlinks = followSymlinks;
     }
 }

--- a/lib/PuppeteerSharp/ScreenRecorder.cs
+++ b/lib/PuppeteerSharp/ScreenRecorder.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp
 {

--- a/lib/PuppeteerSharp/ScreenRecorder.cs
+++ b/lib/PuppeteerSharp/ScreenRecorder.cs
@@ -44,6 +44,19 @@ namespace PuppeteerSharp
             var fps = options.Fps ?? DefaultFps;
             _fps = fps;
 
+            // Open the output file first so followSymlinks / overwrite errors
+            // surface from construction even when ffmpeg is unavailable.
+            if (options.Path != null)
+            {
+                var dir = Path.GetDirectoryName(Path.GetFullPath(options.Path));
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                _outputStream = AsyncFileHelper.CreateStream(options.Path, FileMode.Create);
+            }
+
             // Validate ffmpeg exists.
             try
             {
@@ -59,6 +72,7 @@ namespace PuppeteerSharp
             }
             catch (Exception ex)
             {
+                _outputStream?.Dispose();
                 throw new PuppeteerException($"Failed to launch ffmpeg: {ex.Message}", ex);
             }
 

--- a/lib/PuppeteerSharp/ScreenRecorder.cs
+++ b/lib/PuppeteerSharp/ScreenRecorder.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp
 {
@@ -44,19 +43,6 @@ namespace PuppeteerSharp
             var fps = options.Fps ?? DefaultFps;
             _fps = fps;
 
-            // Open the output file first so followSymlinks / overwrite errors
-            // surface from construction even when ffmpeg is unavailable.
-            if (options.Path != null)
-            {
-                var dir = Path.GetDirectoryName(Path.GetFullPath(options.Path));
-                if (!string.IsNullOrEmpty(dir))
-                {
-                    Directory.CreateDirectory(dir);
-                }
-
-                _outputStream = AsyncFileHelper.CreateStream(options.Path, FileMode.Create);
-            }
-
             // Validate ffmpeg exists.
             try
             {
@@ -72,7 +58,6 @@ namespace PuppeteerSharp
             }
             catch (Exception ex)
             {
-                _outputStream?.Dispose();
                 throw new PuppeteerException($"Failed to launch ffmpeg: {ex.Message}", ex);
             }
 
@@ -244,7 +229,6 @@ namespace PuppeteerSharp
         public async ValueTask DisposeAsync()
         {
             await StopAsync().ConfigureAwait(false);
-            _outputStream?.Dispose();
             _cts.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/lib/PuppeteerSharp/ScreenRecorder.cs
+++ b/lib/PuppeteerSharp/ScreenRecorder.cs
@@ -230,6 +230,7 @@ namespace PuppeteerSharp
         public async ValueTask DisposeAsync()
         {
             await StopAsync().ConfigureAwait(false);
+            _outputStream?.Dispose();
             _cts.Dispose();
             GC.SuppressFinalize(this);
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports [puppeteer#15335](https://github.com/puppeteer/puppeteer/pull/15335) (`followSymlinks` option) onto current `master`.

## Changes
- `Puppeteer.SetFollowSymlinks(bool)` (default `true`)
- `AsyncFileHelper` refuses symlink paths when follow-symlinks is disabled
- Linux detection uses `File.ResolveLinkTarget` (net8+/net10) or `readlink` (netstandard2.0), because `File.GetAttributes` follows links on Unix
- Heap profiler dumps go through `AsyncFileHelper`
- Tests for script/style/screenshot/pdf/screencast symlink rejection, plus the existing overwrite screencast test from #3560

Rebased onto `master` after #3557, #3559, #3560, and #3561 merged. ScreenRecorder no longer re-opens the output file; `Page.ScreencastAsync` already opens the stream via `AsyncFileHelper` before ffmpeg starts.

## Test plan
- [x] Rebase onto current master
- [x] FollowSymlinks tests pass locally (Chrome/CDP) — 11/11
- [x] Required CI (`CHROME-headless-ubuntu-latest-cdp`) is green
- [x] Full `build` matrix is green (all 11 jobs)

Ready to merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f22072-da72-4e17-bbdd-a2c568564c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f22072-da72-4e17-bbdd-a2c568564c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

