### PR TITLE
Fix: launch browsers in detached mode on Windows to fix flakiness (#15339)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -4038,6 +4038,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.touchMove should work with three touches",
+    "platforms": [
+      "darwin"
+    ],
+    "parameters": [
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL",
+      "PASS"
+    ],
+    "comment": "Started to flake on MacOS"
+  },
+  {
     "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.touchMove should work with two touches",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerLaunchTests.cs
@@ -45,7 +45,10 @@ namespace PuppeteerSharp.Tests.LauncherTests
             var options = TestConstants.DefaultBrowserOptions();
             options.ExecutablePath = "random-invalid-path";
 
-            Assert.ThrowsAsync<ProcessException>(() => Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory));
+            var exception = Assert.ThrowsAsync<ProcessException>(() => Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory));
+            Assert.That(
+                exception!.Message,
+                Is.EqualTo("Browser was not found at the configured executablePath (random-invalid-path)"));
         }
 
         [Test, PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "throws an error if executable path is not valid with pipe=true")]
@@ -55,7 +58,10 @@ namespace PuppeteerSharp.Tests.LauncherTests
             options.ExecutablePath = "/tmp/does-not-exist";
             options.Pipe = true;
 
-            Assert.ThrowsAsync<ProcessException>(() => Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory));
+            var exception = Assert.ThrowsAsync<ProcessException>(() => Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory));
+            Assert.That(
+                exception!.Message,
+                Does.Contain("Browser was not found at the configured executablePath (/tmp/does-not-exist)"));
         }
 
         [Test, PuppeteerTest("launcher.spec", "Launcher specs Puppeteer Puppeteer.launch", "userDataDir option")]

--- a/lib/PuppeteerSharp/FirefoxLauncher.cs
+++ b/lib/PuppeteerSharp/FirefoxLauncher.cs
@@ -85,23 +85,30 @@ namespace PuppeteerSharp
             // If TempUserDataDir is null it means that the user provided their own userDataDir
             if (TempUserDataDir is null)
             {
-                var backupSuffix = ".puppeteer";
-                string[] backupFiles = ["prefs.js", "user.js"];
-                var basePath = _userDataDir.Unquote();
-                foreach (var backupFile in backupFiles)
+                try
                 {
-                    var backupPath = Path.Combine(basePath, backupFile + backupSuffix);
-                    var originalPath = Path.Combine(basePath, backupFile);
-                    if (File.Exists(backupPath))
+                    var backupSuffix = ".puppeteer";
+                    string[] backupFiles = ["prefs.js", "user.js"];
+                    var basePath = _userDataDir.Unquote();
+                    foreach (var backupFile in backupFiles)
                     {
-                        // We don't have the overwrite parameter in netstandard
-                        if (File.Exists(originalPath))
+                        var backupPath = Path.Combine(basePath, backupFile + backupSuffix);
+                        var originalPath = Path.Combine(basePath, backupFile);
+                        if (File.Exists(backupPath))
                         {
-                            File.Delete(originalPath);
-                        }
+                            // We don't have the overwrite parameter in netstandard
+                            if (File.Exists(originalPath))
+                            {
+                                File.Delete(originalPath);
+                            }
 
-                        File.Move(backupPath, Path.Combine(basePath, backupFile));
+                            File.Move(backupPath, Path.Combine(basePath, backupFile));
+                        }
                     }
+                }
+                catch
+                {
+                    // Cleanup errors must not become uncaught exceptions.
                 }
             }
 

--- a/lib/PuppeteerSharp/Helpers/TempDirectory.cs
+++ b/lib/PuppeteerSharp/Helpers/TempDirectory.cs
@@ -46,10 +46,12 @@ namespace PuppeteerSharp.Helpers
 
         public async Task DeleteAsync()
         {
-            const int minDelayInMillis = 200;
+            const int maxRetries = 10;
+            const int retryDelayInMillis = 100;
             const int maxDelayInMillis = 8000;
 
-            var retryDelay = minDelayInMillis;
+            var retryDelay = retryDelayInMillis;
+            var attempt = 0;
             while (Directory.Exists(Path))
             {
                 try
@@ -60,7 +62,8 @@ namespace PuppeteerSharp.Helpers
                 catch
                 {
                     await Task.Delay(retryDelay).ConfigureAwait(false);
-                    if (retryDelay < maxDelayInMillis)
+                    attempt++;
+                    if (attempt >= maxRetries && retryDelay < maxDelayInMillis)
                     {
                         retryDelay = Math.Min(2 * retryDelay, maxDelayInMillis);
                     }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -233,6 +233,7 @@ namespace PuppeteerSharp
             catch (Exception ex)
             {
                 await Process.KillAsync().ConfigureAwait(false);
+                await Process.CleanTempUserDataDirAsync().ConfigureAwait(false);
 
                 var userDataDir = options.UserDataDir ?? Process.TempUserDataDir?.Path;
                 if (userDataDir != null && IsBrowserAlreadyRunning(ex, userDataDir))

--- a/lib/PuppeteerSharp/LauncherBase.cs
+++ b/lib/PuppeteerSharp/LauncherBase.cs
@@ -32,8 +32,10 @@ namespace PuppeteerSharp
                 EnableRaisingEvents = true,
             };
             Process.StartInfo.UseShellExecute = false;
+            Process.StartInfo.CreateNoWindow = true;
             Process.StartInfo.FileName = executable;
             Process.StartInfo.RedirectStandardError = true;
+            ExecutablePath = executable;
 
             SetEnvVariables(Process.StartInfo.Environment, options.Env, Environment.GetEnvironmentVariables());
 
@@ -72,6 +74,11 @@ namespace PuppeteerSharp
         /// Indicates whether Base process has exited.
         /// </summary>
         public bool HasExited => StateManager.CurrentState.IsExited;
+
+        /// <summary>
+        /// Gets the browser executable path used to launch the process.
+        /// </summary>
+        internal string ExecutablePath { get; }
 
         internal StateManager StateManager { get; }
 
@@ -145,6 +152,16 @@ namespace PuppeteerSharp
             await ExitCompletionSource.Task.ConfigureAwait(false);
             return true;
         }
+
+        /// <summary>
+        /// Deletes the temporary user data directory if one was created for this launch.
+        /// Cleanup errors are swallowed so they cannot become uncaught exceptions.
+        /// </summary>
+        /// <returns>A task that completes when cleanup finishes.</returns>
+        internal Task CleanTempUserDataDirAsync()
+            => TempUserDataDir is { } tempUserDataDir
+                ? tempUserDataDir.DeleteAsync()
+                : Task.CompletedTask;
 
         /// <summary>
         /// Cleans up temporary user data directory.

--- a/lib/PuppeteerSharp/States/ProcessStartingState.cs
+++ b/lib/PuppeteerSharp/States/ProcessStartingState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -37,6 +38,13 @@ namespace PuppeteerSharp.States
 
         protected virtual async Task StartCoreAsync(LauncherBase p)
         {
+            if (p.ExecutablePath == null || !File.Exists(p.ExecutablePath))
+            {
+                await p.CleanTempUserDataDirAsync().ConfigureAwait(false);
+                throw new ProcessException(
+                    $"Browser was not found at the configured executablePath ({p.ExecutablePath})");
+            }
+
             var output = new StringBuilder();
             var usePipe = p.Options.Pipe;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15339 (puppeteer-core v25.8.0).

## Upstream

- Launch browsers with `detached: true` on all platforms and `windowsHide: true`
- Clean a temp user-data dir if the executable is missing
- Do not rethrow cleanup errors
- Increase temp-dir removal retries
- Mark a MacOS Chrome touchscreen test as flaky

## PuppeteerSharp

- Set `Process.StartInfo.CreateNoWindow = true` (Windows `windowsHide` equivalent; .NET has no `detached` flag)
- Delete the temp user-data directory before throwing when the executable is missing
- Swallow Firefox prefs-restore errors on exit
- Temp directory deletion: 10 retries with a 100ms delay, then existing backoff
- Synced the upstream darwin+chrome flake expectation for `touchscreen.spec` / three touches

Skipped the Node `mocha-runner` changes (no PuppeteerSharp equivalent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f22072-da72-4e17-bbdd-a2c568564c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f22072-da72-4e17-bbdd-a2c568564c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

