### PR TITLE
Remove redundant overwrite and file access from ScreenRecorder (#15352)

### DIFF
--- a/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
+++ b/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.FollowSymlinksTests
+{
+    public class FollowSymlinksTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject screencast when overwrite is false and file exists")]
+        public async Task ShouldRejectScreencastWhenOverwriteIsFalseAndFileExists()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var tmpDir = Path.Combine(Path.GetTempPath(), "pptr-screencast-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tmpDir);
+            var targetFile = Path.Combine(tmpDir, "output.webm");
+            File.WriteAllText(targetFile, "placeholder");
+
+            try
+            {
+                var exception = Assert.ThrowsAsync<IOException>(
+                    () => Page.ScreencastAsync(new ScreencastOptions
+                    {
+                        Path = targetFile,
+                        Overwrite = false,
+                    }));
+                Assert.That(exception, Is.Not.Null);
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(tmpDir))
+                    {
+                        Directory.Delete(tmpDir, true);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -508,6 +509,7 @@ namespace PuppeteerSharp
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The caller is responsible for disposing the returned recorder.")]
         public async Task<ScreenRecorder> ScreencastAsync(ScreencastOptions options = null)
         {
             options ??= new ScreencastOptions();

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -558,19 +558,31 @@ namespace PuppeteerSharp
             var width = (int)Math.Round(dimensions.Width);
             var height = (int)Math.Round(dimensions.Height);
 
-            var recorder = new ScreenRecorder(this, width, height, options);
-
+            // Open the output file before starting ffmpeg so overwrite / create
+            // failures do not leave a recorder running. Matches upstream Page.screencast.
+            Stream outputStream = null;
             try
             {
-                await StartScreencastAsync().ConfigureAwait(false);
-            }
-            catch
-            {
-                await recorder.StopAsync().ConfigureAwait(false);
-                throw;
-            }
+                outputStream = CreateScreencastOutputStream(options);
+                var recorder = new ScreenRecorder(this, width, height, options, outputStream);
+                outputStream = null;
 
-            return recorder;
+                try
+                {
+                    await StartScreencastAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    await recorder.StopAsync().ConfigureAwait(false);
+                    throw;
+                }
+
+                return recorder;
+            }
+            finally
+            {
+                outputStream?.Dispose();
+            }
         }
 
         /// <inheritdoc/>
@@ -1297,6 +1309,26 @@ namespace PuppeteerSharp
         /// <param name="puppeteerFunction">Puppeteer function.</param>
         /// <returns>A <see cref="Task"/> that completes when the function has been added.</returns>
         protected abstract Task ExposeFunctionAsync(string name, Delegate puppeteerFunction);
+
+        private static Stream CreateScreencastOutputStream(ScreencastOptions options)
+        {
+            if (string.IsNullOrEmpty(options.Path))
+            {
+                return null;
+            }
+
+            var directory = Path.GetDirectoryName(Path.GetFullPath(options.Path));
+            if (!string.IsNullOrEmpty(directory))
+            {
+                // Upstream mkdir uses {recursive: overwrite ?? true}. .NET's
+                // Directory.CreateDirectory is always recursive and is a no-op
+                // when the directory already exists.
+                Directory.CreateDirectory(directory);
+            }
+
+            var fileMode = (options.Overwrite ?? true) ? FileMode.Create : FileMode.CreateNew;
+            return AsyncFileHelper.CreateStream(options.Path, fileMode);
+        }
 
         private Clip RoundRectangle(Clip clip)
         {

--- a/lib/PuppeteerSharp/ScreenRecorder.cs
+++ b/lib/PuppeteerSharp/ScreenRecorder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -19,6 +20,7 @@ namespace PuppeteerSharp
         private const int DefaultCrf = 30;
         private const int DefaultColors = 256;
 
+        [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", Justification = "Page is owned by the caller.")]
         private readonly Page _page;
         private readonly int _fps;
         private readonly Process _ffmpegProcess;

--- a/lib/PuppeteerSharp/ScreenRecorder.cs
+++ b/lib/PuppeteerSharp/ScreenRecorder.cs
@@ -22,6 +22,8 @@ namespace PuppeteerSharp
         private readonly Page _page;
         private readonly int _fps;
         private readonly Process _ffmpegProcess;
+        private readonly Stream _outputStream;
+        private readonly Task _copyOutputTask;
         private readonly CancellationTokenSource _cts = new();
         private readonly TaskCompletionSource<(byte[] Buffer, double WallTime)> _lastFrameTcs =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -30,9 +32,10 @@ namespace PuppeteerSharp
 
         private bool _stopped;
 
-        internal ScreenRecorder(Page page, int width, int height, ScreencastOptions options)
+        internal ScreenRecorder(Page page, int width, int height, ScreencastOptions options, Stream outputStream = null)
         {
             _page = page;
+            _outputStream = outputStream;
 
             var ffmpegPath = options.FfmpegPath ?? "ffmpeg";
             var fps = options.Fps ?? DefaultFps;
@@ -61,7 +64,6 @@ namespace PuppeteerSharp
             var delay = options.Delay ?? -1;
             var quality = options.Quality ?? DefaultCrf;
             var colors = options.Colors ?? DefaultColors;
-            var overwrite = options.Overwrite ?? true;
 
             var filters = new List<string>
             {
@@ -86,16 +88,6 @@ namespace PuppeteerSharp
             }
 
             var formatArgs = GetFormatArgs(format, fps, loop, delay, quality, colors, filters);
-
-            // Ensure the output directory exists.
-            if (options.Path != null)
-            {
-                var dir = Path.GetDirectoryName(Path.GetFullPath(options.Path));
-                if (!string.IsNullOrEmpty(dir))
-                {
-                    Directory.CreateDirectory(dir);
-                }
-            }
 
             // Build ffmpeg argument list as a single string for compatibility with netstandard2.0.
             var argParts = new List<string>
@@ -133,10 +125,7 @@ namespace PuppeteerSharp
             argParts.AddRange(formatArgs);
             argParts.AddRange(new[] { "-vf", string.Join(",", filters) });
 
-            // Overwrite output, or exit immediately if file already exists.
-            argParts.Add(overwrite ? "-y" : "-n");
-
-            // Output to stdout.
+            // Output to stdout. File overwrite is applied when Page opens the stream.
             argParts.Add("pipe:1");
 
             var startInfo = new ProcessStartInfo(ffmpegPath, string.Join(" ", argParts.Select(QuoteArgument)))
@@ -151,18 +140,9 @@ namespace PuppeteerSharp
             _ffmpegProcess = Process.Start(startInfo)
                 ?? throw new PuppeteerException("Failed to start ffmpeg process.");
 
-            // If a path is specified, pipe output to file.
-            if (options.Path != null)
-            {
-                var outputPath = options.Path;
-                _ = Task.Run(async () =>
-                {
-                    using var fileStream = File.OpenWrite(outputPath);
-                    await _ffmpegProcess.StandardOutput.BaseStream
-                        .CopyToAsync(fileStream)
-                        .ConfigureAwait(false);
-                });
-            }
+            _copyOutputTask = _outputStream != null
+                ? _ffmpegProcess.StandardOutput.BaseStream.CopyToAsync(_outputStream)
+                : Task.CompletedTask;
 
             _ffmpegProcess.ErrorDataReceived += (_, e) =>
             {
@@ -189,42 +169,58 @@ namespace PuppeteerSharp
 
             _stopped = true;
 
-            // Stop sending more frames.
-            await _page.StopScreencastAsync().ConfigureAwait(false);
-
-            // Signal frame processing to stop accepting new frames.
-            _cts.Cancel();
-
-            // Wait for frame processing task to finish.
             try
             {
-                await _frameProcessingTask.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected.
-            }
+                // Stop sending more frames.
+                await _page.StopScreencastAsync().ConfigureAwait(false);
 
-            // Pad the end with the last frame to fill any remaining time.
-            if (_lastFrameTcs.Task.Status == TaskStatus.RanToCompletion)
-            {
-                var (buffer, lastWallTime) = await _lastFrameTcs.Task.ConfigureAwait(false);
-                if (buffer.Length > 0)
+                // Signal frame processing to stop accepting new frames.
+                _cts.Cancel();
+
+                // Wait for frame processing task to finish.
+                try
                 {
-                    var elapsed = (Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency) - lastWallTime;
-                    var padFrames = Math.Max(1, (int)Math.Round(_fps * elapsed));
-                    for (var i = 0; i < padFrames; i++)
+                    await _frameProcessingTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected.
+                }
+
+                // Pad the end with the last frame to fill any remaining time.
+                if (_lastFrameTcs.Task.Status == TaskStatus.RanToCompletion)
+                {
+                    var (buffer, lastWallTime) = await _lastFrameTcs.Task.ConfigureAwait(false);
+                    if (buffer.Length > 0)
                     {
-                        await WriteFrameAsync(buffer).ConfigureAwait(false);
+                        var elapsed = (Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency) - lastWallTime;
+                        var padFrames = Math.Max(1, (int)Math.Round(_fps * elapsed));
+                        for (var i = 0; i < padFrames; i++)
+                        {
+                            await WriteFrameAsync(buffer).ConfigureAwait(false);
+                        }
                     }
                 }
+
+                // Close stdin to signal ffmpeg we are done.
+                _ffmpegProcess.StandardInput.Close();
+
+                // Wait for ffmpeg to finish.
+                await Task.Run(() => _ffmpegProcess.WaitForExit()).ConfigureAwait(false);
+
+                try
+                {
+                    await _copyOutputTask.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[ffmpeg] Failed to copy output: {ex.Message}");
+                }
             }
-
-            // Close stdin to signal ffmpeg we are done.
-            _ffmpegProcess.StandardInput.Close();
-
-            // Wait for ffmpeg to finish.
-            await Task.Run(() => _ffmpegProcess.WaitForExit()).ConfigureAwait(false);
+            finally
+            {
+                _outputStream?.Dispose();
+            }
         }
 
         /// <inheritdoc/>

--- a/lib/PuppeteerSharp/ScreencastOptions.cs
+++ b/lib/PuppeteerSharp/ScreencastOptions.cs
@@ -11,7 +11,8 @@ namespace PuppeteerSharp
         public string Path { get; set; }
 
         /// <summary>
-        /// Specifies whether to overwrite the output file, or exit immediately if it already exists.
+        /// Specifies whether to overwrite the output file if it already exists.
+        /// Defaults to <c>true</c>. When <c>false</c>, an existing file causes an <see cref="System.IO.IOException"/>.
         /// </summary>
         public bool? Overwrite { get; set; }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15352 (puppeteer-core v25.8.0).

## Upstream

File creation and overwrite policy move out of `ScreenRecorder`. The output stream is opened before ffmpeg starts. Redundant ffmpeg `-y`/`-n` flags and in-recorder `mkdir`/`path` handling are removed.

## PuppeteerSharp

- `Page.ScreencastAsync` creates the parent directory and opens the output file before constructing `ScreenRecorder`
- `overwrite: false` uses `FileMode.CreateNew` (fails if the file exists)
- `ScreenRecorder` only writes ffmpeg stdout (`pipe:1`) to the provided stream and disposes it on stop
- Ported `"should reject screencast when overwrite is false and file exists"`

The symlink screencast test from this upstream PR needs `SetFollowSymlinks` from #15335 and is not included here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f22072-da72-4e17-bbdd-a2c568564c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f22072-da72-4e17-bbdd-a2c568564c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

