### PR TITLE
chore: bump version to 25.8.0

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -12,10 +12,10 @@
     <Description>Headless Browser .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion>25.7.0</PackageVersion>
-    <ReleaseVersion>25.7.0</ReleaseVersion>
-    <AssemblyVersion>25.7.0</AssemblyVersion>
-    <FileVersion>25.7.0</FileVersion>
+    <PackageVersion>25.8.0</PackageVersion>
+    <ReleaseVersion>25.8.0</ReleaseVersion>
+    <AssemblyVersion>25.8.0</AssemblyVersion>
+    <FileVersion>25.8.0</FileVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Align package and assembly versions with [puppeteer-core-v25.8.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v25.8.0).

Updates `PackageVersion`, `ReleaseVersion`, `AssemblyVersion`, and `FileVersion` in `lib/PuppeteerSharp/PuppeteerSharp.csproj` from 25.7.0 to 25.8.0.

Related implementation PRs from this release:
- #3558 — FollowSymlinks (#15335)
- #3557 — computeSystemExecutablePath validatePath (#15340)
- #3559 — Windows launch flakiness (#15339)
- #3560 — ScreenRecorder overwrite/file access (#15352)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2f22072-da72-4e17-bbdd-a2c568564c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2f22072-da72-4e17-bbdd-a2c568564c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

