### PR TITLE
New Feature: Support shadow roots in MutationPoller (#15292)

### DIFF
--- a/UPSTREAM-15292.md
+++ b/UPSTREAM-15292.md
@@ -1,0 +1,39 @@
+# Upstream PR #15292 — Shadow roots in MutationPoller
+
+## Upstream
+
+- PR: https://github.com/puppeteer/puppeteer/pull/15292
+- Title: feat: support shadow roots in MutationPoller
+- Fix intent: `MutationPoller` did not observe shadow roots, so piercing
+  selectors (`div >>> h1`) and other mutation-polled handlers timed out when
+  matching nodes were added inside open shadow DOM.
+
+## Mapping to PuppeteerSharp
+
+| Upstream | PuppeteerSharp |
+| --- | --- |
+| `packages/puppeteer-core/src/injected/Poller.ts` | `lib/PuppeteerSharp/Injected/injected.js` (bundled MutationPoller) |
+| `test/src/waittask.test.ts` | `lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs` |
+| `test/TestExpectations.json` | `lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json` |
+
+## Implementation notes
+
+- Kept PuppeteerSharp’s existing `createDeferredPromise` / `#promise` style in
+  `injected.js` rather than switching the whole poller stack to upstream’s
+  `Deferred` helper.
+- Ported helper logic: `MUTATION_OBSERVER_OPTIONS`, `canHostShadowRoots`,
+  `parentOf`, `hasAncestorIn`, plus `#observe` / `#observeAddedShadowRoots` /
+  `#observeShadowRoots`.
+- Attaching a shadow root to a node already in the DOM still produces no
+  mutation (WHATWG DOM #1287); that test remains SKIP’d, matching upstream.
+
+## Verification
+
+```bash
+BROWSER=CHROME PROTOCOL=cdp dotnet build lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+BROWSER=CHROME PROTOCOL=cdp dotnet test lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj \
+  --filter "FullyQualifiedName~FrameWaitForSelectorTests" --no-build \
+  -- NUnit.TestOutputXml=TestResults
+```
+
+Result: 38 passed, 1 skipped (`ShouldWorkWhenAShadowRootIsAttachedToAnExistingNode`).

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -694,7 +694,7 @@
     "comment": "we currently do not detect this siutation for Firefox"
   },
   {
-    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should work when node is added in a shadow root",
+    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should work when a shadow root is attached to an existing node",
     "platforms": [
       "darwin",
       "linux",
@@ -704,7 +704,7 @@
     "expectations": [
       "SKIP"
     ],
-    "comment": "See https://github.com/puppeteer/puppeteer/issues/13163"
+    "comment": "Shadow root attachment does not produce a mutation, see https://github.com/whatwg/dom/issues/1287"
   },
   {
     "testIdPattern": "[worker.spec] *",

--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
@@ -12,6 +12,19 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
     public sealed class FrameWaitForSelectorTests : PuppeteerPageBaseTest, IDisposable
     {
         private const string AddElement = "tag => document.body.appendChild(document.createElement(tag))";
+
+        private const string AddShadowHost = @"tag => {
+            document.body
+                .appendChild(document.createElement(tag))
+                .attachShadow({mode: 'open'});
+        }";
+
+        private const string AddElementToShadowRoot = @"(selector, tag) => {
+            const element = document.createElement(tag);
+            element.textContent = 'inside';
+            document.querySelector(selector).shadowRoot.appendChild(element);
+        }";
+
         private PollerInterceptor _pollerInterceptor;
 
         public FrameWaitForSelectorTests()
@@ -112,8 +125,63 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             var watcher = Page.WaitForSelectorAsync("div >>> h1");
+            await Page.EvaluateFunctionAsync(AddShadowHost, "div");
+            var completed = await Task.WhenAny(watcher, Task.Delay(40));
+            Assert.That(completed, Is.Not.EqualTo(watcher));
+            await Page.EvaluateFunctionAsync(AddElementToShadowRoot, "div", "h1");
+            var element = await watcher;
+            Assert.That(await element.EvaluateFunctionAsync<string>("el => el.textContent"), Is.EqualTo("inside"));
+        }
+
+        [Test, PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should work when node is added in a shadow root that predates the wait")]
+        public async Task ShouldWorkWhenNodeIsAddedInAShadowRootThatPredatesTheWait()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            await Page.EvaluateFunctionAsync(AddShadowHost, "div");
+            var watcher = Page.WaitForSelectorAsync("div >>> h1");
+            var completed = await Task.WhenAny(watcher, Task.Delay(40));
+            Assert.That(completed, Is.Not.EqualTo(watcher));
+            await Page.EvaluateFunctionAsync(AddElementToShadowRoot, "div", "h1");
+            var element = await watcher;
+            Assert.That(await element.EvaluateFunctionAsync<string>("el => el.textContent"), Is.EqualTo("inside"));
+        }
+
+        [Test, PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should work when node is added in a nested shadow root")]
+        public async Task ShouldWorkWhenNodeIsAddedInANestedShadowRoot()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var watcher = Page.WaitForSelectorAsync("div >>> h1");
+            await Page.EvaluateFunctionAsync(@"() => {
+                const host = document.body.appendChild(document.createElement('div'));
+                const inner = document.createElement('section');
+                inner.attachShadow({mode: 'open'});
+                host.attachShadow({mode: 'open'}).appendChild(inner);
+            }");
+            var completed = await Task.WhenAny(watcher, Task.Delay(40));
+            Assert.That(completed, Is.Not.EqualTo(watcher));
+            await Page.EvaluateFunctionAsync(@"() => {
+                const h1 = document.createElement('h1');
+                h1.textContent = 'inside';
+                document
+                    .querySelector('div')
+                    .shadowRoot.querySelector('section')
+                    .shadowRoot.appendChild(h1);
+            }");
+            var element = await watcher;
+            Assert.That(await element.EvaluateFunctionAsync<string>("el => el.textContent"), Is.EqualTo("inside"));
+        }
+
+        // Attaching a shadow root to a node that is already in the DOM does not
+        // produce a mutation, so MutationPoller has nothing to react to.
+        // See https://github.com/whatwg/dom/issues/1287.
+        [Test, PuppeteerTest("waittask.spec", "waittask specs Frame.waitForSelector", "should work when a shadow root is attached to an existing node")]
+        public async Task ShouldWorkWhenAShadowRootIsAttachedToAnExistingNode()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var watcher = Page.WaitForSelectorAsync("div >>> h1");
             await Page.EvaluateFunctionAsync(AddElement, "div");
-            await Task.Delay(100);
+            var completed = await Task.WhenAny(watcher, Task.Delay(40));
+            Assert.That(completed, Is.Not.EqualTo(watcher));
             await Page.EvaluateFunctionAsync(@"() => {
                 const host = document.querySelector('div');
                 const shadow = host.attachShadow({mode: 'open'});

--- a/lib/PuppeteerSharp/Injected/injected.js
+++ b/lib/PuppeteerSharp/Injected/injected.js
@@ -231,10 +231,40 @@ var assert = (value, message) => {
 };
 
 // src/injected/Poller.ts
+var MUTATION_OBSERVER_OPTIONS = {
+    childList: true,
+    subtree: true,
+    attributes: true,
+};
+var canHostShadowRoots = (node) => {
+    return (
+        node.nodeType === Node.ELEMENT_NODE ||
+        node.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+    );
+};
+/**
+ * A shadow root has no parent, so the walk up continues through its host to
+ * stay inside the tree the node was added to.
+ */
+var parentOf = (node) => {
+    return node.parentNode ?? node.host ?? null;
+};
+var hasAncestorIn = (node, nodes) => {
+    let current = node;
+    let parent;
+    while ((parent = parentOf(current))) {
+        if (nodes.has(parent)) {
+            return true;
+        }
+        current = parent;
+    }
+    return false;
+};
 var MutationPoller = class {
     #fn;
     #root;
     #observer;
+    #observedRoots = new WeakSet();
     #promise;
     constructor(fn, root) {
         this.#fn = fn;
@@ -247,7 +277,9 @@ var MutationPoller = class {
             promise.resolve(result);
             return;
         }
-        this.#observer = new MutationObserver(async () => {
+        this.#observedRoots = new WeakSet();
+        this.#observer = new MutationObserver(async (mutations) => {
+            this.#observeAddedShadowRoots(mutations);
             const result2 = await this.#fn();
             if (!result2) {
                 return;
@@ -255,11 +287,52 @@ var MutationPoller = class {
             promise.resolve(result2);
             await this.stop();
         });
-        this.#observer.observe(this.#root, {
-            childList: true,
-            subtree: true,
-            attributes: true,
-        });
+        this.#observe(this.#root);
+    }
+    /**
+     * A `subtree` observation does not cross shadow boundaries, so every shadow
+     * root needs to be observed on its own.
+     */
+    #observe(root) {
+        if (!this.#observer || this.#observedRoots.has(root)) {
+            return;
+        }
+        this.#observedRoots.add(root);
+        this.#observer.observe(root, MUTATION_OBSERVER_OPTIONS);
+        this.#observeShadowRoots(root);
+    }
+    /**
+     * A batch can report a subtree and nodes inside it, so the added nodes are
+     * pruned to the top-most ones and each tree is walked once.
+     */
+    #observeAddedShadowRoots(mutations) {
+        const addedNodes = new Set();
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (!canHostShadowRoots(node)) {
+                    continue;
+                }
+                addedNodes.add(node);
+            }
+        }
+        for (const node of addedNodes) {
+            if (!hasAncestorIn(node, addedNodes)) {
+                this.#observeShadowRoots(node);
+            }
+        }
+    }
+    /**
+     * Attaching a shadow root does not emit a mutation, so shadow roots are
+     * instead picked up from the trees they arrive in.
+     */
+    #observeShadowRoots(root) {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+        do {
+            const { shadowRoot } = walker.currentNode;
+            if (shadowRoot) {
+                this.#observe(shadowRoot);
+            }
+        } while (walker.nextNode());
     }
     async stop() {
         assert(this.#promise, "Polling never started.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15292

### Changes
- `MutationPoller` now observes open shadow roots so piercing/`waitForSelector` works when nodes appear inside shadow DOM
- Updated injected.js and related wait-for-selector tests
- Synced upstream test expectations for the unobservable attachShadow case

Part of puppeteer-core-v25.9.0 release port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03863-7297-7864-9cbc-65e25f67ed57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03863-7297-7864-9cbc-65e25f67ed57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

