### PR TITLE
fix: set frame content without document.write (#15358)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ await using var page = await browser.NewPageAsync();
 await page.SetContentAsync("<div>My Receipt</div>");
 var result = await page.GetContentAsync();
 ```
-<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L14-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs#L16-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-setcontentasync_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Evaluate Javascript

--- a/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/SetContentTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using PuppeteerSharp.Nunit;
@@ -143,6 +145,27 @@ namespace PuppeteerSharp.Tests.PageTests
             var result = await Page.GetContentAsync();
 
             Assert.That(result, Is.EqualTo($"{comment}{ExpectedOutput}"));
+        }
+
+        [Test, PuppeteerTest("page.spec", "Page Page.setContent", "should not run a cross-origin script through document.write")]
+        public async Task ShouldNotRunACrossOriginScriptThroughDocumentWrite()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            var warnings = new List<string>();
+            Page.Console += (_, e) =>
+            {
+                if (e.Message.Type == ConsoleType.Warning)
+                {
+                    warnings.Add(e.Message.Text);
+                }
+            };
+
+            await Page.SetContentAsync(
+                $"<script src=\"{TestConstants.CrossProcessHttpPrefix}/injectedfile.js\"></script>",
+                new SetContentOptions { WaitUntil = new[] { WaitUntilNavigation.Load } });
+
+            Assert.That(await Page.EvaluateExpressionAsync<int>("window.__injected"), Is.EqualTo(42));
+            Assert.That(warnings.Where(warning => warning.Contains("document.write")), Is.Empty);
         }
     }
 }

--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -407,11 +407,6 @@ public class CdpFrame : Frame
             Regex.Replace(referrerPolicy, "-(.)", match => match.Groups[1].Value.ToUpperInvariant());
     }
 
-    /// <summary>
-    /// Sets the frame HTML content without going through <c>document.write</c>.
-    /// </summary>
-    /// <param name="content">HTML content to set.</param>
-    /// <returns>A task that resolves when the content has been set.</returns>
     private async Task SetFrameContentAsync(string content)
     {
         // Writing the content from the page would go through document.write, which

--- a/lib/PuppeteerSharp/Cdp/CdpFrame.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpFrame.cs
@@ -183,15 +183,10 @@ public class CdpFrame : Frame
         var waitUntil = options?.WaitUntil ?? new[] { WaitUntilNavigation.Load };
         var timeout = options?.Timeout ?? FrameManager.TimeoutSettings.NavigationTimeout;
 
-        // We rely upon the fact that document.open() will reset frame lifecycle with "init"
-        // lifecycle event. @see https://crrev.com/608658
-        await IsolatedRealm.EvaluateFunctionAsync(
-            @"html => {
-                    document.open();
-                    document.write(html);
-                    document.close();
-                }",
-            html).ConfigureAwait(false);
+        // We rely upon the fact that the document is reopened, which resets the
+        // frame lifecycle with an "init" lifecycle event.
+        // @see https://crrev.com/608658
+        await SetFrameContentAsync(html).ConfigureAwait(false);
 
         using var watcher = new LifecycleWatcher(FrameManager.NetworkManager, this, waitUntil, timeout);
         var watcherTask = await Task.WhenAny(
@@ -410,5 +405,22 @@ public class CdpFrame : Frame
         // Transform kebab-case to camelCase
         return string.IsNullOrEmpty(referrerPolicy) ? null :
             Regex.Replace(referrerPolicy, "-(.)", match => match.Groups[1].Value.ToUpperInvariant());
+    }
+
+    /// <summary>
+    /// Sets the frame HTML content without going through <c>document.write</c>.
+    /// </summary>
+    /// <param name="content">HTML content to set.</param>
+    /// <returns>A task that resolves when the content has been set.</returns>
+    private async Task SetFrameContentAsync(string content)
+    {
+        // Writing the content from the page would go through document.write, which
+        // makes Chrome treat parser-blocking cross-site scripts in it as an
+        // intervention candidate and may block them outright.
+        await Client.SendAsync("Page.setDocumentContent", new PageSetDocumentContentRequest
+        {
+            FrameId = Id,
+            Html = content,
+        }).ConfigureAwait(false);
     }
 }

--- a/lib/PuppeteerSharp/Cdp/Messaging/PageSetDocumentContentRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/PageSetDocumentContentRequest.cs
@@ -1,0 +1,9 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class PageSetDocumentContentRequest
+    {
+        public string FrameId { get; set; }
+
+        public string Html { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
@@ -180,6 +180,7 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(PageReloadRequest))]
 [JsonSerializable(typeof(PageRemoveScriptToEvaluateOnNewDocumentRequest))]
 [JsonSerializable(typeof(PageSetBypassCSPRequest))]
+[JsonSerializable(typeof(PageSetDocumentContentRequest))]
 [JsonSerializable(typeof(PageSetInterceptFileChooserDialog))]
 [JsonSerializable(typeof(PageSetLifecycleEventsEnabledRequest))]
 [JsonSerializable(typeof(PerformanceGetMetricsResponse))]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15358

### Changes
- `CdpFrame.SetContentAsync` now uses CDP `Page.setDocumentContent` instead of `document.write`
- Added `PageSetDocumentContentRequest`
- Ported test: should not run a cross-origin script through document.write
- BiDi still uses `document.write` (same as upstream)

Part of puppeteer-core-v25.9.0 release port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03863-7297-7864-9cbc-65e25f67ed57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03863-7297-7864-9cbc-65e25f67ed57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

