### PR TITLE
feat: roll to Firefox 154.0 (#15361)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_153.0.4";
+        public const string DefaultBuildId = "stable_154.0";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15361

### Changes
- Updated `Firefox.DefaultBuildId` from `stable_153.0.4` to `stable_154.0`

Part of puppeteer-core-v25.9.0 release port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03863-7297-7864-9cbc-65e25f67ed57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03863-7297-7864-9cbc-65e25f67ed57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

