### PR TITLE
Fix: Detect a websocket connection that died without a close (upstream #15406)

### DIFF
--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -103,7 +103,7 @@ namespace PuppeteerSharp.Tests.LauncherTests
                 },
                 WebSocketFactory = async (uri, socketOptions, cancellationToken) =>
                 {
-                    webSocketAuthorizationHeader = socketOptions.Headers["Authorization"];
+                    webSocketAuthorizationHeader = ConnectionOptionsHelper.GetEffectiveHeaders(socketOptions)?["Authorization"];
                     return await WebSocketTransport.DefaultWebSocketFactory(uri, socketOptions, cancellationToken).ConfigureAwait(false);
                 },
                 Protocol = ((Browser)Browser).Protocol,

--- a/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/LauncherTests/PuppeteerConnectTests.cs
@@ -94,9 +94,12 @@ namespace PuppeteerSharp.Tests.LauncherTests
             await using var connectedBrowser = await Puppeteer.ConnectAsync(new ConnectOptions
             {
                 BrowserURL = TestConstants.ServerUrl,
-                Headers = new Dictionary<string, string>
+                WsOptions = new WsOptions
                 {
-                    ["Authorization"] = authorizationHeader,
+                    Headers = new Dictionary<string, string>
+                    {
+                        ["Authorization"] = authorizationHeader,
+                    },
                 },
                 WebSocketFactory = async (uri, socketOptions, cancellationToken) =>
                 {

--- a/lib/PuppeteerSharp.Tests/TransportTests/WebSocketTransportKeepAliveTests.cs
+++ b/lib/PuppeteerSharp.Tests/TransportTests/WebSocketTransportKeepAliveTests.cs
@@ -15,9 +15,9 @@ namespace PuppeteerSharp.Tests.TransportTests
     public class WebSocketTransportKeepAliveTests
     {
         [Test]
-        [Obsolete]
         public void GetEffectiveHeaders_PrefersWsOptionsHeaders()
         {
+#pragma warning disable CS0618 // Intentionally testing legacy Headers vs WsOptions.Headers precedence
             var options = new ConnectOptions
             {
                 Headers = new Dictionary<string, string> { ["X-Legacy"] = "legacy" },
@@ -26,6 +26,7 @@ namespace PuppeteerSharp.Tests.TransportTests
                     Headers = new Dictionary<string, string> { ["X-Modern"] = "modern" },
                 },
             };
+#pragma warning restore CS0618
 
             var headers = ConnectionOptionsHelper.GetEffectiveHeaders(options);
 

--- a/lib/PuppeteerSharp.Tests/TransportTests/WebSocketTransportKeepAliveTests.cs
+++ b/lib/PuppeteerSharp.Tests/TransportTests/WebSocketTransportKeepAliveTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Transport;
+
+namespace PuppeteerSharp.Tests.TransportTests
+{
+    [TestFixture]
+    public class WebSocketTransportKeepAliveTests
+    {
+        [Test]
+        [Obsolete]
+        public void GetEffectiveHeaders_PrefersWsOptionsHeaders()
+        {
+            var options = new ConnectOptions
+            {
+                Headers = new Dictionary<string, string> { ["X-Legacy"] = "legacy" },
+                WsOptions = new WsOptions
+                {
+                    Headers = new Dictionary<string, string> { ["X-Modern"] = "modern" },
+                },
+            };
+
+            var headers = ConnectionOptionsHelper.GetEffectiveHeaders(options);
+
+            Assert.That(headers, Is.Not.Null);
+            Assert.That(headers["X-Modern"], Is.EqualTo("modern"));
+            Assert.That(headers.ContainsKey("X-Legacy"), Is.False);
+        }
+
+        [Test]
+        public void ConfigureWebSocketKeepAlive_DisablesKeepAliveByDefault()
+        {
+            using var client = new ClientWebSocket();
+            ConnectionOptionsHelper.ConfigureWebSocketKeepAlive(client, null);
+
+            Assert.That(client.Options.KeepAliveInterval, Is.EqualTo(TimeSpan.Zero));
+        }
+
+#if NET9_0_OR_GREATER
+        [Test]
+        public void ConfigureWebSocketKeepAlive_EnablesPingPongWhenRequested()
+        {
+            using var client = new ClientWebSocket();
+            ConnectionOptionsHelper.ConfigureWebSocketKeepAlive(
+                client,
+                new WsOptions { KeepAlive = true, KeepAliveIntervalMs = 1234 });
+
+            Assert.That(client.Options.KeepAliveInterval, Is.EqualTo(TimeSpan.FromMilliseconds(1234)));
+            Assert.That(client.Options.KeepAliveTimeout, Is.EqualTo(TimeSpan.FromMilliseconds(1234)));
+        }
+
+        [Test]
+        public async Task KeepAlive_StaysOpenWhilePeerAnswersPings()
+        {
+            using var listener = new HttpListener();
+            var prefix = $"http://127.0.0.1:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+
+            var serverAccepted = new TaskCompletionSource<WebSocket>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _ = Task.Run(async () =>
+            {
+                var context = await listener.GetContextAsync().ConfigureAwait(false);
+                var webSocketContext = await context.AcceptWebSocketAsync(null).ConfigureAwait(false);
+                serverAccepted.TrySetResult(webSocketContext.WebSocket);
+                var buffer = new byte[128];
+                while (webSocketContext.WebSocket.State == WebSocketState.Open)
+                {
+                    await webSocketContext.WebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None).ConfigureAwait(false);
+                }
+            });
+
+            var connectOptions = new ConnectOptions
+            {
+                WsOptions = new WsOptions
+                {
+                    KeepAlive = true,
+                    KeepAliveIntervalMs = 50,
+                },
+            };
+
+            var transport = await WebSocketTransport.DefaultTransportFactory(
+                new Uri(prefix.Replace("http://", "ws://")),
+                connectOptions,
+                CancellationToken.None).ConfigureAwait(false);
+
+            var closed = false;
+            transport.Closed += (_, _) => closed = true;
+
+            await serverAccepted.Task.WithTimeout(5000).ConfigureAwait(false);
+            await Task.Delay(300).ConfigureAwait(false);
+
+            Assert.That(closed, Is.False);
+            transport.Dispose();
+        }
+#endif
+
+        private static int GetFreePort()
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+    }
+}

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -39,8 +39,14 @@ namespace PuppeteerSharp
         public WebSocketFactory WebSocketFactory { get; set; }
 
         /// <summary>
+        /// Options for the WebSocket connection to the browser.
+        /// </summary>
+        public WsOptions WsOptions { get; set; }
+
+        /// <summary>
         /// Headers that should be sent with connection-related HTTP and WebSocket requests.
         /// </summary>
+        [Obsolete("Use WsOptions.Headers via ConnectOptions.WsOptions instead. When both are set, WsOptions.Headers wins.")]
         public Dictionary<string, string> Headers { get; set; }
 
         /// <summary>

--- a/lib/PuppeteerSharp/Helpers/ConnectionOptionsHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/ConnectionOptionsHelper.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace PuppeteerSharp.Helpers
+{
+    internal static class ConnectionOptionsHelper
+    {
+        internal static Dictionary<string, string> GetEffectiveHeaders(IConnectionOptions options)
+        {
+#pragma warning disable CS0618
+            return options.WsOptions?.Headers ?? options.Headers;
+#pragma warning restore CS0618
+        }
+
+        internal static void ConfigureWebSocketKeepAlive(System.Net.WebSockets.ClientWebSocket client, WsOptions wsOptions)
+        {
+            if (wsOptions?.KeepAlive != true)
+            {
+                client.Options.KeepAliveInterval = System.TimeSpan.Zero;
+                return;
+            }
+
+            var intervalMs = wsOptions.KeepAliveIntervalMs ?? WsOptions.DefaultKeepAliveIntervalMs;
+            var interval = System.TimeSpan.FromMilliseconds(intervalMs);
+            client.Options.KeepAliveInterval = interval;
+#if NET9_0_OR_GREATER
+            client.Options.KeepAliveTimeout = interval;
+#endif
+        }
+    }
+}

--- a/lib/PuppeteerSharp/IConnectionOptions.cs
+++ b/lib/PuppeteerSharp/IConnectionOptions.cs
@@ -49,8 +49,14 @@ namespace PuppeteerSharp
         public int ProtocolTimeout { get; set; }
 
         /// <summary>
+        /// Options for the WebSocket connection to the browser.
+        /// </summary>
+        WsOptions WsOptions { get; set; }
+
+        /// <summary>
         /// Headers that should be sent with connection-related HTTP and WebSocket requests.
         /// </summary>
-        public Dictionary<string, string> Headers { get; set; }
+        [Obsolete("Use WsOptions.Headers via IConnectionOptions.WsOptions instead. When both are set, WsOptions.Headers wins.")]
+        Dictionary<string, string> Headers { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -150,8 +150,14 @@ namespace PuppeteerSharp
         public WebSocketFactory WebSocketFactory { get; set; }
 
         /// <summary>
+        /// Options for the WebSocket connection to the browser.
+        /// </summary>
+        public WsOptions WsOptions { get; set; }
+
+        /// <summary>
         /// Headers that should be sent with connection-related HTTP and WebSocket requests.
         /// </summary>
+        [Obsolete("Use WsOptions.Headers via LaunchOptions.WsOptions instead. When both are set, WsOptions.Headers wins.")]
         public Dictionary<string, string> Headers { get; set; }
 
         /// <summary>

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -277,7 +277,7 @@ namespace PuppeteerSharp
 
             var browserWSEndpoint = string.IsNullOrEmpty(options.BrowserURL)
                 ? options.BrowserWSEndpoint
-                : await GetWSEndpointAsync(options.BrowserURL, options.Headers).ConfigureAwait(false);
+                : await GetWSEndpointAsync(options.BrowserURL, ConnectionOptionsHelper.GetEffectiveHeaders(options)).ConfigureAwait(false);
 
             if (options.Protocol == ProtocolType.WebdriverBiDi)
             {

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -117,10 +117,11 @@ namespace PuppeteerSharp.Transport
         private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
         {
             var result = new ClientWebSocket();
-            result.Options.KeepAliveInterval = TimeSpan.Zero;
-            if (options.Headers != null)
+            ConnectionOptionsHelper.ConfigureWebSocketKeepAlive(result, options.WsOptions);
+            var headers = ConnectionOptionsHelper.GetEffectiveHeaders(options);
+            if (headers != null)
             {
-                foreach (var header in options.Headers)
+                foreach (var header in headers)
                 {
                     result.Options.SetRequestHeader(header.Key, header.Value);
                 }

--- a/lib/PuppeteerSharp/WsOptions.cs
+++ b/lib/PuppeteerSharp/WsOptions.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Options for the WebSocket connection to the browser.
+    /// </summary>
+    public class WsOptions
+    {
+        /// <summary>
+        /// Default ping period in milliseconds when <see cref="KeepAlive"/> is enabled.
+        /// </summary>
+        public const int DefaultKeepAliveIntervalMs = 30_000;
+
+        /// <summary>
+        /// Headers to use for the web socket connection.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; }
+
+        /// <summary>
+        /// Whether to send WebSocket pings and drop the connection when a pong does
+        /// not come back within the same interval. Detects a connection that died
+        /// without a close frame, which otherwise leaves calls hanging until
+        /// <see cref="IConnectionOptions.ProtocolTimeout"/>.
+        /// </summary>
+        /// <remarks>
+        /// Dead-connection detection requires .NET 9 or later. On earlier runtimes,
+        /// enabling keep-alive only configures the WebSocket keep-alive interval.
+        /// </remarks>
+        public bool KeepAlive { get; set; }
+
+        /// <summary>
+        /// Ping period in milliseconds. Only used when <see cref="KeepAlive"/> is set.
+        /// Defaults to <see cref="DefaultKeepAliveIntervalMs"/>.
+        /// </summary>
+        public int? KeepAliveIntervalMs { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements changes from https://github.com/puppeteer/puppeteer/pull/15406 as part of puppeteer-core-v25.10.0.

### Changes
- Add `WsOptions` with keep-alive ping/pong for dead WebSocket detection
- Wire `WsOptions` through `ConnectOptions`, `LaunchOptions`, and `IConnectionOptions`
- Configure `ClientWebSocket` keep-alive on .NET 9+
- Add `WebSocketTransportKeepAliveTests`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06774-6b11-79ce-8ced-b726c32dc423?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06774-6b11-79ce-8ced-b726c32dc423&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

