### PR TITLE
New Feature: Implement page.record() video-stream screen recording (upstream #15387)

### DIFF
--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -544,6 +544,34 @@
     "comment": "Bidi does not have equivalent field"
   },
   {
+    "testIdPattern": "[page.test] Page Page.record *",
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ],
+    "parameters": [
+      "chrome"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "Screen recording is not supported until Chrome 153"
+  },
+  {
+    "testIdPattern": "[page.test] Page Page.record *",
+    "platforms": [
+      "linux"
+    ],
+    "parameters": [
+      "firefox"
+    ],
+    "expectations": [
+      "FAIL"
+    ],
+    "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=2066782"
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.metrics *",
     "platforms": [
       "darwin",

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -561,7 +561,9 @@
   {
     "testIdPattern": "[page.test] Page Page.record *",
     "platforms": [
-      "linux"
+      "darwin",
+      "linux",
+      "win32"
     ],
     "parameters": [
       "firefox"

--- a/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
+++ b/lib/PuppeteerSharp.Nunit/TestExpectations/TestExpectations.upstream.json
@@ -561,9 +561,7 @@
   {
     "testIdPattern": "[page.test] Page Page.record *",
     "platforms": [
-      "darwin",
-      "linux",
-      "win32"
+      "linux"
     ],
     "parameters": [
       "firefox"

--- a/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
+++ b/lib/PuppeteerSharp.Tests/FollowSymlinksTests/FollowSymlinksTests.cs
@@ -145,6 +145,7 @@ namespace PuppeteerSharp.Tests.FollowSymlinksTests
         }
 
         [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject screencast when overwrite is false and file exists")]
+        [Obsolete]
         public async Task ShouldRejectScreencastWhenOverwriteIsFalseAndFileExists()
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
@@ -181,6 +182,7 @@ namespace PuppeteerSharp.Tests.FollowSymlinksTests
         }
 
         [Test, PuppeteerTest("followSymlinks.test", "followSymlinks when followSymlinks is false", "should reject screencast to an existing symlink path")]
+        [Obsolete]
         public async Task ShouldRejectScreencastToAnExistingSymlinkPath()
         {
             IgnoreIfWindowsOrSymlinksUnsupported();

--- a/lib/PuppeteerSharp.Tests/PageTests/PageRecordTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/PageRecordTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PuppeteerSharp.Input;
+using PuppeteerSharp.Nunit;
+
+namespace PuppeteerSharp.Tests.PageTests
+{
+    public class PageRecordTests : PuppeteerPageBaseTest
+    {
+        [Test, PuppeteerTest("page.test", "Page Page.record", "should record page")]
+        public async Task ShouldRecordPage()
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), $"test-video-{Guid.NewGuid()}.mp4");
+
+            try
+            {
+                var recording = await Page.RecordAsync(new RecordOptions
+                {
+                    Path = filePath,
+                });
+
+                await Page.GoToAsync("data:text/html,<input>");
+                var input = await Page.WaitForSelectorAsync("input");
+                await input.TypeAsync("ab", new TypeOptions { Delay = 100 });
+
+                await recording.StopAsync();
+
+                Assert.That(new FileInfo(filePath).Length, Is.GreaterThan(0));
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Test, PuppeteerTest("ScreenRecording.test", "ScreenRecording", "should validate options")]
+        public async Task ShouldValidateOptions()
+        {
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { MaxWidth = 0 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { MaxWidth = -10 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { MaxHeight = 0 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { MaxHeight = -10 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { FrameRate = 0 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { FrameRate = -5 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { Fps = 0 }));
+            Assert.ThrowsAsync<PuppeteerException>(() => Page.RecordAsync(new RecordOptions { Fps = -5 }));
+        }
+    }
+}

--- a/lib/PuppeteerSharp.Tests/ScreencastTests/ScreencastsTests.cs
+++ b/lib/PuppeteerSharp.Tests/ScreencastTests/ScreencastsTests.cs
@@ -10,6 +10,7 @@ namespace PuppeteerSharp.Tests.ScreencastTests
     public class ScreencastsTests : PuppeteerPageBaseTest
     {
         [Test, PuppeteerTest("screencast.spec", "Screencasts Page.screencast", "should work")]
+        [Obsolete]
         public async Task ShouldWork()
         {
             var filePath = Path.Combine(Path.GetTempPath(), $"test-video-{Guid.NewGuid()}.webm");
@@ -42,6 +43,7 @@ namespace PuppeteerSharp.Tests.ScreencastTests
         }
 
         [Test, PuppeteerTest("screencast.spec", "Screencasts Page.screencast", "should work concurrently")]
+        [Obsolete]
         public async Task ShouldWorkConcurrently()
         {
             var filePath1 = Path.Combine(Path.GetTempPath(), $"test-video-{Guid.NewGuid()}.webm");
@@ -85,6 +87,7 @@ namespace PuppeteerSharp.Tests.ScreencastTests
         }
 
         [Test, PuppeteerTest("screencast.spec", "Screencasts Page.screencast", "should validate options")]
+        [Obsolete]
         public async Task ShouldValidateOptions()
         {
             Assert.ThrowsAsync<PuppeteerException>(() => Page.ScreencastAsync(new ScreencastOptions { Scale = 0 }));

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -30,6 +30,8 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using PuppeteerSharp.Bidi.Core;
 using PuppeteerSharp.Helpers;
 using PuppeteerSharp.Media;
@@ -1102,6 +1104,13 @@ public class BidiPage : Page
     /// <inheritdoc />
     protected override Task ExposeFunctionAsync(string name, Delegate puppeteerFunction)
         => BidiMainFrame.ExposeFunctionAsync(name, puppeteerFunction);
+
+    /// <inheritdoc/>
+    protected override ScreenRecording CreateScreenRecording(RecordOptions options)
+    {
+        var logger = BidiBrowser.LoggerFactory?.CreateLogger<ScreenRecording>() ?? NullLogger<ScreenRecording>.Instance;
+        return new BidiScreenRecording(this, options, logger);
+    }
 
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)

--- a/lib/PuppeteerSharp/Bidi/BidiScreenRecording.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiScreenRecording.cs
@@ -1,0 +1,109 @@
+#if !CDP_ONLY
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using PuppeteerSharp.Bidi.Core;
+
+namespace PuppeteerSharp.Bidi;
+
+internal sealed class BidiScreenRecording : ScreenRecording
+{
+    private readonly BidiPage _page;
+    private string _screencastId;
+    private string _path;
+
+    internal BidiScreenRecording(BidiPage page, RecordOptions options, ILogger logger)
+        : base(page, options, logger)
+    {
+        _page = page;
+        _page.BidiMainFrame.BrowsingContext.Closed += OnBrowsingContextClosed;
+    }
+
+    /// <inheritdoc/>
+    public override async Task StopAsync()
+    {
+        if (Stopped)
+        {
+            return;
+        }
+
+        Stopped = true;
+        _page.BidiMainFrame.BrowsingContext.Closed -= OnBrowsingContextClosed;
+
+        try
+        {
+            if (string.IsNullOrEmpty(_screencastId))
+            {
+                return;
+            }
+
+            StopScreencastCommandResult result = null;
+
+            try
+            {
+                result = await _page.BidiMainFrame.BrowsingContext.StopScreencastAsync(_screencastId).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to stop screencast.");
+            }
+
+            if (!string.IsNullOrEmpty(result?.Error))
+            {
+                Logger.LogError("Failed to stop screencast: {Error}", result.Error);
+            }
+
+            var filePath = result?.Path ?? _path;
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                try
+                {
+                    var buffer = await File.ReadAllBytesAsync(filePath).ConfigureAwait(false);
+                    EnqueueChunk(buffer);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Failed to read screencast file.");
+                }
+            }
+        }
+        finally
+        {
+            await CloseDestinationsAsync().ConfigureAwait(false);
+        }
+    }
+
+    internal override async Task StartAsync()
+    {
+        var frameRate = Options.FrameRate ?? Options.Fps;
+        StartScreencastVideoParameters video = null;
+
+        if (Options.MaxWidth != null || Options.MaxHeight != null || frameRate != null)
+        {
+            video = new StartScreencastVideoParameters
+            {
+                Width = Options.MaxWidth,
+                Height = Options.MaxHeight,
+                FrameRate = frameRate,
+            };
+        }
+
+        var result = await _page.BidiMainFrame.BrowsingContext.StartScreencastAsync(new StartScreencastCommandParameters(_page.BidiMainFrame.BrowsingContext.Id)
+        {
+            Audio = Options.Audio,
+            Video = video,
+        }).ConfigureAwait(false);
+
+        _screencastId = result.Screencast;
+        _path = result.Path;
+    }
+
+    private void OnBrowsingContextClosed(object sender, Core.ClosedEventArgs e)
+    {
+        _ = StopAsync();
+    }
+}
+
+#endif

--- a/lib/PuppeteerSharp/Bidi/BidiScreenRecording.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiScreenRecording.cs
@@ -60,7 +60,11 @@ internal sealed class BidiScreenRecording : ScreenRecording
             {
                 try
                 {
+#if NETSTANDARD2_0
+                    var buffer = File.ReadAllBytes(filePath);
+#else
                     var buffer = await File.ReadAllBytesAsync(filePath).ConfigureAwait(false);
+#endif
                     EnqueueChunk(buffer);
                 }
                 catch (Exception ex)

--- a/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
@@ -253,6 +253,15 @@ internal class BrowsingContext : IDisposable
         return result.InterceptId;
     }
 
+    internal async Task<StartScreencastCommandResult> StartScreencastAsync(StartScreencastCommandParameters options)
+    {
+        options.Context = Id;
+        return await Session.Driver.ExecuteCommandAsync(options).ConfigureAwait(false);
+    }
+
+    internal async Task<StopScreencastCommandResult> StopScreencastAsync(string screencast)
+        => await Session.Driver.ExecuteCommandAsync(new StopScreencastCommandParameters(screencast)).ConfigureAwait(false);
+
     internal async Task SetUserAgentAsync(string userAgent)
     {
         var parameters = new SetUserAgentOverrideCommandParameters

--- a/lib/PuppeteerSharp/Bidi/Core/StartScreencastCommandParameters.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/StartScreencastCommandParameters.cs
@@ -1,0 +1,27 @@
+#if !CDP_ONLY
+
+using System.Text.Json.Serialization;
+using WebDriverBiDi;
+
+namespace PuppeteerSharp.Bidi.Core;
+
+internal sealed class StartScreencastCommandParameters : CommandParameters<StartScreencastCommandResult>
+{
+    public StartScreencastCommandParameters(string contextId)
+    {
+        Context = contextId;
+    }
+
+    public override string MethodName => "browsingContext.startScreencast";
+
+    [JsonPropertyName("context")]
+    public string Context { get; set; }
+
+    [JsonPropertyName("audio")]
+    public bool? Audio { get; set; }
+
+    [JsonPropertyName("video")]
+    public StartScreencastVideoParameters Video { get; set; }
+}
+
+#endif

--- a/lib/PuppeteerSharp/Bidi/Core/StartScreencastCommandResult.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/StartScreencastCommandResult.cs
@@ -1,0 +1,17 @@
+#if !CDP_ONLY
+
+using System.Text.Json.Serialization;
+using WebDriverBiDi;
+
+namespace PuppeteerSharp.Bidi.Core;
+
+internal sealed record StartScreencastCommandResult : CommandResult
+{
+    [JsonPropertyName("screencast")]
+    public string Screencast { get; init; }
+
+    [JsonPropertyName("path")]
+    public string Path { get; init; }
+}
+
+#endif

--- a/lib/PuppeteerSharp/Bidi/Core/StartScreencastVideoParameters.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/StartScreencastVideoParameters.cs
@@ -1,0 +1,19 @@
+#if !CDP_ONLY
+
+using System.Text.Json.Serialization;
+
+namespace PuppeteerSharp.Bidi.Core;
+
+internal sealed class StartScreencastVideoParameters
+{
+    [JsonPropertyName("width")]
+    public int? Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public int? Height { get; set; }
+
+    [JsonPropertyName("frameRate")]
+    public int? FrameRate { get; set; }
+}
+
+#endif

--- a/lib/PuppeteerSharp/Bidi/Core/StopScreencastCommandParameters.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/StopScreencastCommandParameters.cs
@@ -1,0 +1,21 @@
+#if !CDP_ONLY
+
+using System.Text.Json.Serialization;
+using WebDriverBiDi;
+
+namespace PuppeteerSharp.Bidi.Core;
+
+internal sealed class StopScreencastCommandParameters : CommandParameters<StopScreencastCommandResult>
+{
+    public StopScreencastCommandParameters(string screencast)
+    {
+        Screencast = screencast;
+    }
+
+    public override string MethodName => "browsingContext.stopScreencast";
+
+    [JsonPropertyName("screencast")]
+    public string Screencast { get; set; }
+}
+
+#endif

--- a/lib/PuppeteerSharp/Bidi/Core/StopScreencastCommandResult.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/StopScreencastCommandResult.cs
@@ -1,0 +1,17 @@
+#if !CDP_ONLY
+
+using System.Text.Json.Serialization;
+using WebDriverBiDi;
+
+namespace PuppeteerSharp.Bidi.Core;
+
+internal sealed record StopScreencastCommandResult : CommandResult
+{
+    [JsonPropertyName("path")]
+    public string Path { get; init; }
+
+    [JsonPropertyName("error")]
+    public string Error { get; init; }
+}
+
+#endif

--- a/lib/PuppeteerSharp/Cdp/CdpPage.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpPage.cs
@@ -886,6 +886,10 @@ public class CdpPage : Page
         }
     }
 
+    /// <inheritdoc/>
+    protected override ScreenRecording CreateScreenRecording(RecordOptions options)
+        => new CdpScreenRecording(this, options, _logger);
+
     private static decimal? GetPixels(string unit) => unit switch
     {
         "px" => 1,

--- a/lib/PuppeteerSharp/Cdp/CdpScreenRecording.cs
+++ b/lib/PuppeteerSharp/Cdp/CdpScreenRecording.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using PuppeteerSharp.Cdp.Messaging;
+using PuppeteerSharp.Helpers;
+
+namespace PuppeteerSharp.Cdp
+{
+    internal sealed class CdpScreenRecording : ScreenRecording
+    {
+        private readonly CdpPage _page;
+        private string _streamHandle;
+
+        internal CdpScreenRecording(CdpPage page, RecordOptions options, ILogger logger)
+            : base(page, options, logger)
+        {
+            _page = page;
+            _page.Client.Disconnected += OnClientDisconnected;
+        }
+
+        /// <inheritdoc/>
+        public override async Task StopAsync()
+        {
+            if (Stopped)
+            {
+                return;
+            }
+
+            Stopped = true;
+            var client = _page.Client;
+            client.Disconnected -= OnClientDisconnected;
+
+            try
+            {
+                try
+                {
+                    await client.SendAsync("Page.stopScreenRecording").ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Failed to stop screen recording.");
+                }
+
+                if (string.IsNullOrEmpty(_streamHandle))
+                {
+                    throw new PuppeteerException("Screen recording stream handle is missing.");
+                }
+
+                await ProtocolStreamReader.ReadProtocolStreamBytesAsync(
+                    client,
+                    _streamHandle,
+                    EnqueueChunk).ConfigureAwait(false);
+            }
+            finally
+            {
+                await CloseDestinationsAsync().ConfigureAwait(false);
+            }
+        }
+
+        internal override async Task StartAsync()
+        {
+            var frameRate = Options.FrameRate ?? Options.Fps;
+            var response = await _page.Client.SendAsync<PageStartScreenRecordingResponse>(
+                "Page.startScreenRecording",
+                new PageStartScreenRecordingRequest
+                {
+                    Audio = Options.Audio,
+                    MaxWidth = Options.MaxWidth,
+                    MaxHeight = Options.MaxHeight,
+                    FrameRate = frameRate,
+                }).ConfigureAwait(false);
+
+            _streamHandle = response.Stream;
+        }
+
+        private void OnClientDisconnected(object sender, EventArgs e)
+        {
+            _ = StopAsync();
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/PageStartScreenRecordingRequest.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/PageStartScreenRecordingRequest.cs
@@ -1,0 +1,13 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class PageStartScreenRecordingRequest
+    {
+        public bool? Audio { get; set; }
+
+        public int? MaxWidth { get; set; }
+
+        public int? MaxHeight { get; set; }
+
+        public int? FrameRate { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Cdp/Messaging/PageStartScreenRecordingResponse.cs
+++ b/lib/PuppeteerSharp/Cdp/Messaging/PageStartScreenRecordingResponse.cs
@@ -1,0 +1,7 @@
+namespace PuppeteerSharp.Cdp.Messaging
+{
+    internal class PageStartScreenRecordingResponse
+    {
+        public string Stream { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/SystemTextJsonSerializationContext.cs
@@ -179,6 +179,8 @@ namespace PuppeteerSharp.Helpers.Json;
 [JsonSerializable(typeof(PagePrintToPDFResponse))]
 [JsonSerializable(typeof(PageReloadRequest))]
 [JsonSerializable(typeof(PageRemoveScriptToEvaluateOnNewDocumentRequest))]
+[JsonSerializable(typeof(PageStartScreenRecordingRequest))]
+[JsonSerializable(typeof(PageStartScreenRecordingResponse))]
 [JsonSerializable(typeof(PageSetBypassCSPRequest))]
 [JsonSerializable(typeof(PageSetDocumentContentRequest))]
 [JsonSerializable(typeof(PageSetInterceptFileChooserDialog))]

--- a/lib/PuppeteerSharp/Helpers/ProtocolStreamReader.cs
+++ b/lib/PuppeteerSharp/Helpers/ProtocolStreamReader.cs
@@ -49,6 +49,20 @@ namespace PuppeteerSharp.Helpers
 
         internal static async Task ReadProtocolBase64StreamByteAsync(CDPSession client, string handle, Stream outputStream)
         {
+            await ReadProtocolStreamBytesAsync(
+                client,
+                handle,
+                buffer =>
+                {
+                    outputStream.Write(buffer, 0, buffer.Length);
+                }).ConfigureAwait(false);
+        }
+
+        internal static async Task ReadProtocolStreamBytesAsync(
+            CDPSession client,
+            string handle,
+            Action<byte[]> onChunk)
+        {
             var eof = false;
 
             while (!eof)
@@ -59,7 +73,14 @@ namespace PuppeteerSharp.Helpers
                 }).ConfigureAwait(false);
 
                 eof = response.Eof;
-                await DecodeStringInChunksAsync(response.Data, outputStream).ConfigureAwait(false);
+
+                if (!string.IsNullOrEmpty(response.Data))
+                {
+                    var buffer = response.Base64Encoded
+                        ? Convert.FromBase64String(response.Data)
+                        : Encoding.UTF8.GetBytes(response.Data);
+                    onChunk(buffer);
+                }
             }
 
             await client.SendAsync("IO.close", new IOCloseRequest

--- a/lib/PuppeteerSharp/IPage.cs
+++ b/lib/PuppeteerSharp/IPage.cs
@@ -1024,7 +1024,19 @@ namespace PuppeteerSharp
         /// By default, all recordings will be WebM format using the VP9 video codec, with a frame rate of 30 FPS.
         /// You must have ffmpeg installed on your system.
         /// </remarks>
+        [Obsolete("Use RecordAsync instead.")]
         Task<ScreenRecorder> ScreencastAsync(ScreencastOptions options = null);
+
+        /// <summary>
+        /// Records this <see cref="IPage"/> using the Chrome DevTools Protocol
+        /// <see href="https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreenRecording">Page.startScreenRecording</see> API.
+        /// </summary>
+        /// <remarks>
+        /// Outputs mp4 video stream.
+        /// </remarks>
+        /// <param name="options">Recording options.</param>
+        /// <returns>A task which resolves to a <see cref="ScreenRecording"/> that can be used to stop the recording.</returns>
+        Task<ScreenRecording> RecordAsync(RecordOptions options = null);
 
         /// <summary>
         /// Captures a screenshot of this <see cref="IPage"/>.

--- a/lib/PuppeteerSharp/IWritableDestination.cs
+++ b/lib/PuppeteerSharp/IWritableDestination.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Represents a writable destination for a <see cref="ScreenRecording"/>.
+    /// </summary>
+    public interface IWritableDestination
+    {
+        /// <summary>
+        /// Writes a chunk of data to the destination.
+        /// </summary>
+        /// <param name="chunk">The chunk to write.</param>
+        /// <returns><c>true</c> if the chunk was written.</returns>
+        bool Write(ReadOnlySpan<byte> chunk);
+
+        /// <summary>
+        /// Ends the destination stream.
+        /// </summary>
+        void End();
+    }
+}

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -508,7 +508,72 @@ namespace PuppeteerSharp
                 SetUserAgentAsync(options.UserAgent));
         }
 
+        /// <summary>
+        /// Records this <see cref="IPage"/> using the Chrome DevTools Protocol
+        /// <see href="https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreenRecording">Page.startScreenRecording</see> API.
+        /// </summary>
+        /// <remarks>
+        /// Outputs mp4 video stream.
+        /// </remarks>
+        /// <param name="options">Recording options.</param>
+        /// <returns>A task which resolves to a <see cref="ScreenRecording"/> that can be used to stop the recording.</returns>
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The caller is responsible for disposing the returned recording.")]
+        public async Task<ScreenRecording> RecordAsync(RecordOptions options = null)
+        {
+            options ??= new RecordOptions();
+
+            if (options.MaxWidth is <= 0)
+            {
+                throw new PuppeteerException("`maxWidth` must be greater than 0.");
+            }
+
+            if (options.MaxHeight is <= 0)
+            {
+                throw new PuppeteerException("`maxHeight` must be greater than 0.");
+            }
+
+            if (options.FrameRate is <= 0)
+            {
+                throw new PuppeteerException("`frameRate` must be greater than 0.");
+            }
+
+            if (options.Fps is <= 0)
+            {
+                throw new PuppeteerException("`fps` must be greater than 0.");
+            }
+
+            Stream outputStream = null;
+            try
+            {
+                outputStream = CreateRecordingOutputStream(options);
+                var recording = CreateScreenRecording(options);
+
+                try
+                {
+                    await recording.StartAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    await recording.StopAsync().ConfigureAwait(false);
+                    throw;
+                }
+
+                if (outputStream != null)
+                {
+                    await recording.PipeAsync(outputStream).ConfigureAwait(false);
+                    outputStream = null;
+                }
+
+                return recording;
+            }
+            finally
+            {
+                outputStream?.Dispose();
+            }
+        }
+
         /// <inheritdoc/>
+        [Obsolete("Use RecordAsync instead.")]
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The caller is responsible for disposing the returned recorder.")]
         public async Task<ScreenRecorder> ScreencastAsync(ScreencastOptions options = null)
         {
@@ -1316,14 +1381,27 @@ namespace PuppeteerSharp
         /// <returns>A <see cref="Task"/> that completes when the function has been added.</returns>
         protected abstract Task ExposeFunctionAsync(string name, Delegate puppeteerFunction);
 
+        /// <summary>
+        /// Creates a protocol-specific screen recording instance.
+        /// </summary>
+        /// <param name="options">Recording options.</param>
+        /// <returns>A screen recording instance.</returns>
+        protected abstract ScreenRecording CreateScreenRecording(RecordOptions options);
+
         private static Stream CreateScreencastOutputStream(ScreencastOptions options)
+            => CreateRecordingOutputStream(options.Path, options.Overwrite);
+
+        private static Stream CreateRecordingOutputStream(RecordOptions options)
+            => CreateRecordingOutputStream(options.Path, options.Overwrite);
+
+        private static Stream CreateRecordingOutputStream(string path, bool? overwrite)
         {
-            if (string.IsNullOrEmpty(options.Path))
+            if (string.IsNullOrEmpty(path))
             {
                 return null;
             }
 
-            var directory = Path.GetDirectoryName(Path.GetFullPath(options.Path));
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path));
             if (!string.IsNullOrEmpty(directory))
             {
                 // Upstream mkdir uses {recursive: overwrite ?? true}. .NET's
@@ -1332,8 +1410,8 @@ namespace PuppeteerSharp
                 Directory.CreateDirectory(directory);
             }
 
-            var fileMode = (options.Overwrite ?? true) ? FileMode.Create : FileMode.CreateNew;
-            return AsyncFileHelper.CreateStream(options.Path, fileMode);
+            var fileMode = (overwrite ?? true) ? FileMode.Create : FileMode.CreateNew;
+            return AsyncFileHelper.CreateStream(path, fileMode);
         }
 
         private Clip RoundRectangle(Clip clip)

--- a/lib/PuppeteerSharp/RecordOptions.cs
+++ b/lib/PuppeteerSharp/RecordOptions.cs
@@ -1,0 +1,45 @@
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Options for <see cref="IPage.RecordAsync(RecordOptions)"/>.
+    /// </summary>
+    public class RecordOptions
+    {
+        /// <summary>
+        /// File path to save the recording to.
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Specifies whether to overwrite the output file if it already exists.
+        /// Defaults to <c>true</c>. When <c>false</c>, an existing file causes an <see cref="System.IO.IOException"/>.
+        /// </summary>
+        public bool? Overwrite { get; set; }
+
+        /// <summary>
+        /// Whether to record audio.
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        public bool? Audio { get; set; }
+
+        /// <summary>
+        /// Maximum frame width in pixels.
+        /// </summary>
+        public int? MaxWidth { get; set; }
+
+        /// <summary>
+        /// Maximum frame height in pixels.
+        /// </summary>
+        public int? MaxHeight { get; set; }
+
+        /// <summary>
+        /// Maximum frame rate in frames per second.
+        /// </summary>
+        public int? FrameRate { get; set; }
+
+        /// <summary>
+        /// Frame rate in frames per second (alias for <see cref="FrameRate"/>).
+        /// </summary>
+        public int? Fps { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp/ScreenRecording.cs
+++ b/lib/PuppeteerSharp/ScreenRecording.cs
@@ -172,7 +172,16 @@ namespace PuppeteerSharp
 
             public void End()
             {
-                _stream.Flush();
+                // Match upstream WritableDestination.end(): finish and close the
+                // write stream so Path-backed FileStreams release the file handle.
+                try
+                {
+                    _stream.Flush();
+                }
+                finally
+                {
+                    _stream.Dispose();
+                }
             }
         }
     }

--- a/lib/PuppeteerSharp/ScreenRecording.cs
+++ b/lib/PuppeteerSharp/ScreenRecording.cs
@@ -162,7 +162,11 @@ namespace PuppeteerSharp
 
             public bool Write(ReadOnlySpan<byte> chunk)
             {
+#if NETSTANDARD2_0
+                _stream.Write(chunk.ToArray(), 0, chunk.Length);
+#else
                 _stream.Write(chunk);
+#endif
                 return true;
             }
 

--- a/lib/PuppeteerSharp/ScreenRecording.cs
+++ b/lib/PuppeteerSharp/ScreenRecording.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Represents a video stream-based screen recording session.
+    /// </summary>
+    public abstract class ScreenRecording : IAsyncEnumerable<byte[]>, IAsyncDisposable
+    {
+        private readonly Channel<byte[]> _channel = Channel.CreateUnbounded<byte[]>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = false,
+                SingleWriter = true,
+            });
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScreenRecording"/> class.
+        /// </summary>
+        /// <param name="page">The page being recorded.</param>
+        /// <param name="options">Recording options.</param>
+        /// <param name="logger">Logger instance.</param>
+        protected ScreenRecording(Page page, RecordOptions options, ILogger logger)
+        {
+            Page = page;
+            Options = options ?? new RecordOptions();
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets the page being recorded.
+        /// </summary>
+        protected Page Page { get; }
+
+        /// <summary>
+        /// Gets the recording options.
+        /// </summary>
+        protected RecordOptions Options { get; }
+
+        /// <summary>
+        /// Gets the logger instance.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the destinations the recording is piped to.
+        /// </summary>
+        protected HashSet<IWritableDestination> Destinations { get; } = new();
+
+        /// <summary>
+        /// Gets a value indicating whether the recording has been stopped.
+        /// </summary>
+        protected bool Stopped { get; set; }
+
+        /// <summary>
+        /// Stops the screen recording.
+        /// </summary>
+        /// <returns>A task that completes when recording has stopped.</returns>
+        public abstract Task StopAsync();
+
+        /// <summary>
+        /// Pipes the recorded stream to a destination stream.
+        /// </summary>
+        /// <param name="destination">The destination stream.</param>
+        /// <returns>A task that completes when piping finishes.</returns>
+        public Task PipeAsync(Stream destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            return PipeAsync(new StreamWritableDestination(destination));
+        }
+
+        /// <summary>
+        /// Pipes the recorded stream to a writable destination and returns it for chaining.
+        /// </summary>
+        /// <param name="destination">Writable target for MP4 chunks.</param>
+        /// <returns>The same destination instance.</returns>
+        public IWritableDestination Pipe(IWritableDestination destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            Destinations.Add(destination);
+            return destination;
+        }
+
+        /// <summary>
+        /// Registers a writable destination to receive recording chunks asynchronously.
+        /// </summary>
+        /// <param name="destination">The destination that will receive chunks.</param>
+        /// <returns>A task that completes when the destination has been registered.</returns>
+        public Task PipeAsync(IWritableDestination destination)
+        {
+            Pipe(destination);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public IAsyncEnumerator<byte[]> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => _channel.Reader.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            await StopAsync().ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Starts the screen recording.
+        /// </summary>
+        /// <returns>A task that completes when recording has started.</returns>
+        internal abstract Task StartAsync();
+
+        /// <summary>
+        /// Enqueues a chunk to stream consumers and destinations.
+        /// </summary>
+        /// <param name="buffer">The chunk to enqueue.</param>
+        protected void EnqueueChunk(byte[] buffer)
+        {
+            _channel.Writer.TryWrite(buffer);
+
+            foreach (var destination in Destinations)
+            {
+                destination.Write(buffer);
+            }
+        }
+
+        /// <summary>
+        /// Closes all destinations and completes the readable stream.
+        /// </summary>
+        /// <returns>A task that completes when destinations are closed.</returns>
+        protected Task CloseDestinationsAsync()
+        {
+            _channel.Writer.TryComplete();
+
+            foreach (var destination in Destinations)
+            {
+                destination.End();
+            }
+
+            Destinations.Clear();
+            return Task.CompletedTask;
+        }
+
+        private sealed class StreamWritableDestination : IWritableDestination
+        {
+            private readonly Stream _stream;
+
+            internal StreamWritableDestination(Stream stream) => _stream = stream;
+
+            public bool Write(ReadOnlySpan<byte> chunk)
+            {
+                _stream.Write(chunk);
+                return true;
+            }
+
+            public void End()
+            {
+                _stream.Flush();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Ports [puppeteer/puppeteer#15387](https://github.com/puppeteer/puppeteer/pull/15387): `page.record()` video-stream screen recording (CDP + BiDi), writable destinations, and matching tests/expectations.

## Notes
- Rebased onto `master` after #3573 (Firefox 154.0.1) and #3578 (screencast docs) merged — conflict was only whitespace in workflow concurrency.
- Path-backed recordings dispose the underlying stream on `End()` to match upstream `WritableDestination.end()`.
- Firefox Page.record remains expected FAIL on all platforms per upstream expectations (narrowed to linux-only in follow-up #3577 / upstream #15408).

Part of the puppeteer-core-v25.10.0 port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06774-6b11-79ce-8ced-b726c32dc423?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06774-6b11-79ce-8ced-b726c32dc423&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

