### PR TITLE
New Feature: Roll to Firefox 155.0 (upstream #15408)

### DIFF
--- a/lib/PuppeteerSharp/BrowserData/Firefox.cs
+++ b/lib/PuppeteerSharp/BrowserData/Firefox.cs
@@ -17,7 +17,7 @@ namespace PuppeteerSharp.BrowserData
         /// <summary>
         /// Default firefox build.
         /// </summary>
-        public const string DefaultBuildId = "stable_154.0.1";
+        public const string DefaultBuildId = "stable_155.0";
 
         private static readonly Dictionary<string, string> _cachedBuildIds = [];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Ports [puppeteer/puppeteer#15408](https://github.com/puppeteer/puppeteer/pull/15408): roll Firefox to **155.0** and narrow Firefox `Page.record` FAIL expectation to **linux only**.

## Stacking
- Depends on #3571 (`page.record()`). Rebased onto the post-#3573 #3571 tip.
- Unique commits on this branch: Firefox 155.0 + TestExpectations narrow (dispose fix already in #3571).

Part of the puppeteer-core-v25.10.0 port. After #3571 merges, rebase this onto `master` alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06774-6b11-79ce-8ced-b726c32dc423?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06774-6b11-79ce-8ced-b726c32dc423&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

