### PR TITLE
Fix: Do not miss the first screencast frame while startScreencast is in flight (upstream #15389)

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1169,6 +1169,10 @@ namespace PuppeteerSharp
         /// <summary>
         /// Starts a CDP screencast session.
         /// </summary>
+        /// <remarks>
+        /// Registers the screencast frame listener before starting screencast so the first frame is not missed
+        /// while <c>Page.startScreencast</c> is in flight (upstream puppeteer/puppeteer#15389).
+        /// </remarks>
         /// <returns>A <see cref="Task"/> that completes when the screencast has started.</returns>
         internal async Task StartScreencastAsync()
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements tracking for https://github.com/puppeteer/puppeteer/pull/15389 as part of puppeteer-core-v25.10.0.

**There are no behavioral code changes** because the upstream fix was already present in PuppeteerSharp.

Upstream #15389 moved the `Page.screencastFrame` listener **before** `Page.startScreencast` so the first frame is not missed while `startScreencast` is in flight.

Our `StartScreencastAsync` already registers the frame listener before sending `Page.startScreencast`. This PR only adds a doc remark pointing at that upstream issue for 25.10.0 release tracking.

## Test plan
- [x] Confirm listener is registered before `Page.startScreencast` in `StartScreencastAsync`
- [x] CI green (no behavioral delta)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06774-6b11-79ce-8ced-b726c32dc423?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06774-6b11-79ce-8ced-b726c32dc423&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

