### PR TITLE
chore: add newer iPhone KnownDevices (upstream #15400)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,6 +15,10 @@ on:
     - '**.csproj'
     - '**.runsettings'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_VERSION: '10.0.x' # The .NET SDK version to use
 

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptorName.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptorName.cs
@@ -220,6 +220,16 @@ namespace PuppeteerSharp.Mobile
         IPhoneSELandscape,
 
         /// <summary>
+        /// iPhone SE (3rd gen).
+        /// </summary>
+        IPhoneSE3rdGen,
+
+        /// <summary>
+        /// iPhone SE (3rd gen) landscape.
+        /// </summary>
+        IPhoneSE3rdGenLandscape,
+
+        /// <summary>
         /// iPhone X.
         /// </summary>
         IPhoneX,
@@ -268,6 +278,106 @@ namespace PuppeteerSharp.Mobile
         /// iPhone 11 Pro Max landscape.
         /// </summary>
         IPhone11ProMaxLandscape,
+
+        /// <summary>
+        /// iPhone 16.
+        /// </summary>
+        IPhone16,
+
+        /// <summary>
+        /// iPhone 16 landscape.
+        /// </summary>
+        IPhone16Landscape,
+
+        /// <summary>
+        /// iPhone 16 Plus.
+        /// </summary>
+        IPhone16Plus,
+
+        /// <summary>
+        /// iPhone 16 Plus landscape.
+        /// </summary>
+        IPhone16PlusLandscape,
+
+        /// <summary>
+        /// iPhone 16 Pro.
+        /// </summary>
+        IPhone16Pro,
+
+        /// <summary>
+        /// iPhone 16 Pro landscape.
+        /// </summary>
+        IPhone16ProLandscape,
+
+        /// <summary>
+        /// iPhone 16 Pro Max.
+        /// </summary>
+        IPhone16ProMax,
+
+        /// <summary>
+        /// iPhone 16 Pro Max landscape.
+        /// </summary>
+        IPhone16ProMaxLandscape,
+
+        /// <summary>
+        /// iPhone 16e.
+        /// </summary>
+        IPhone16e,
+
+        /// <summary>
+        /// iPhone 16e landscape.
+        /// </summary>
+        IPhone16eLandscape,
+
+        /// <summary>
+        /// iPhone 17.
+        /// </summary>
+        IPhone17,
+
+        /// <summary>
+        /// iPhone 17 landscape.
+        /// </summary>
+        IPhone17Landscape,
+
+        /// <summary>
+        /// iPhone Air.
+        /// </summary>
+        IPhoneAir,
+
+        /// <summary>
+        /// iPhone Air landscape.
+        /// </summary>
+        IPhoneAirLandscape,
+
+        /// <summary>
+        /// iPhone 17 Pro.
+        /// </summary>
+        IPhone17Pro,
+
+        /// <summary>
+        /// iPhone 17 Pro landscape.
+        /// </summary>
+        IPhone17ProLandscape,
+
+        /// <summary>
+        /// iPhone 17 Pro Max.
+        /// </summary>
+        IPhone17ProMax,
+
+        /// <summary>
+        /// iPhone 17 Pro Max landscape.
+        /// </summary>
+        IPhone17ProMaxLandscape,
+
+        /// <summary>
+        /// iPhone 17e.
+        /// </summary>
+        IPhone17e,
+
+        /// <summary>
+        /// iPhone 17e landscape.
+        /// </summary>
+        IPhone17eLandscape,
 
         /// <summary>
         /// JioPhone 2.

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
@@ -599,6 +599,34 @@ namespace PuppeteerSharp.Mobile
                     IsLandscape = true,
                 },
             },
+            [DeviceDescriptorName.IPhoneSE3rdGen] = new DeviceDescriptor
+            {
+                Name = "iPhone SE (3rd gen)",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.5 Mobile/19E241 Safari/602.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 375,
+                    Height = 667,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhoneSE3rdGenLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone SE (3rd gen) landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.5 Mobile/19E241 Safari/602.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 667,
+                    Height = 375,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
             [DeviceDescriptorName.IPhoneX] = new DeviceDescriptor
             {
                 Name = "iPhone X",
@@ -733,6 +761,286 @@ namespace PuppeteerSharp.Mobile
                 {
                     Width = 896,
                     Height = 414,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone16] = new DeviceDescriptor
+            {
+                Name = "iPhone 16",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 393,
+                    Height = 659,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone16Landscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 734,
+                    Height = 343,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone16Plus] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 Plus",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 430,
+                    Height = 739,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone16PlusLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 Plus landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 814,
+                    Height = 380,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone16Pro] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 Pro",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 402,
+                    Height = 681,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone16ProLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 Pro landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 756,
+                    Height = 352,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone16ProMax] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 Pro Max",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 440,
+                    Height = 763,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone16ProMaxLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 16 Pro Max landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 838,
+                    Height = 390,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone16e] = new DeviceDescriptor
+            {
+                Name = "iPhone 16e",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 390,
+                    Height = 651,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone16eLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 16e landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 726,
+                    Height = 340,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone17] = new DeviceDescriptor
+            {
+                Name = "iPhone 17",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 402,
+                    Height = 681,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone17Landscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 17 landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 756,
+                    Height = 352,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhoneAir] = new DeviceDescriptor
+            {
+                Name = "iPhone Air",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 420,
+                    Height = 719,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhoneAirLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone Air landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 794,
+                    Height = 370,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone17Pro] = new DeviceDescriptor
+            {
+                Name = "iPhone 17 Pro",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 402,
+                    Height = 681,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone17ProLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 17 Pro landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 756,
+                    Height = 352,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone17ProMax] = new DeviceDescriptor
+            {
+                Name = "iPhone 17 Pro Max",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 440,
+                    Height = 763,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone17ProMaxLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 17 Pro Max landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 838,
+                    Height = 390,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true,
+                },
+            },
+            [DeviceDescriptorName.IPhone17e] = new DeviceDescriptor
+            {
+                Name = "iPhone 17e",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 390,
+                    Height = 651,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false,
+                },
+            },
+            [DeviceDescriptorName.IPhone17eLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 17e landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 726,
+                    Height = 340,
                     DeviceScaleFactor = 3,
                     IsMobile = true,
                     HasTouch = true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Ports upstream puppeteer [#15400](https://github.com/puppeteer/puppeteer/pull/15400): add newer iPhone models to `KnownDevices` (iPhone 16 / 17 / Air family).

## Test plan
- [x] Library builds; `DeviceDescriptorName` includes iPhone 16/17/Air
- [ ] CI green (re-triggered after 4 jobs sat queued ~6h with empty commit `b9908880`)

## Notes
Do not merge until checks are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06774-6b11-79ce-8ced-b726c32dc423?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06774-6b11-79ce-8ced-b726c32dc423&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

