### PR TITLE
Update WebDriverBiDi dependency with API changes

### DIFF
--- a/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiBrowser.cs
@@ -282,12 +282,12 @@ public class BidiBrowser : Browser
         {
             if (windowBounds.Left.HasValue)
             {
-                parameters.X = (ulong)windowBounds.Left.Value;
+                parameters.X = windowBounds.Left.Value;
             }
 
             if (windowBounds.Top.HasValue)
             {
-                parameters.Y = (ulong)windowBounds.Top.Value;
+                parameters.Y = windowBounds.Top.Value;
             }
 
             if (windowBounds.Width.HasValue)
@@ -338,7 +338,7 @@ public class BidiBrowser : Browser
     {
         var capabilityRequest = new CapabilityRequest()
         {
-            AcceptInsecureCertificates = options.AcceptInsecureCerts,
+            AcceptInsecureCerts = options.AcceptInsecureCerts,
             AdditionalCapabilities = { ["webSocketUrl"] = true, },
 
             // Tell the browser not to auto-handle prompts so we can handle them via the Dialog API.

--- a/lib/PuppeteerSharp/Bidi/BidiElementHandle.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiElementHandle.cs
@@ -96,7 +96,7 @@ internal class BidiElementHandle(RemoteValue value, BidiRealm realm) : ElementHa
 
         if (value?.Type == RemoteValueType.Window && value is WindowProxyRemoteValue windowProxyValue)
         {
-            var contextId = windowProxyValue.Value.Context;
+            var contextId = windowProxyValue.Value.BrowsingContextId;
             return BidiFrame.BidiPage.Frames.FirstOrDefault(frame => frame.Id == contextId);
         }
 

--- a/lib/PuppeteerSharp/Bidi/BidiFrame.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiFrame.cs
@@ -606,7 +606,7 @@ public class BidiFrame : Frame
     internal async Task SetFilesAsync(BidiElementHandle element, string[] files)
     {
         await BrowsingContext.SetFilesAsync(
-            element.Value.ConvertTo<NodeRemoteValue>().ToSharedReference(),
+            element.Value.As<NodeRemoteValue>().ToSharedReference(),
             files).ConfigureAwait(false);
     }
 
@@ -614,7 +614,7 @@ public class BidiFrame : Frame
     {
         return await BrowsingContext.LocateNodesAsync(
             locator,
-            [element.Value.ConvertTo<NodeRemoteValue>().ToSharedReference()]).ConfigureAwait(false);
+            [element.Value.As<NodeRemoteValue>().ToSharedReference()]).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -981,7 +981,7 @@ public class BidiFrame : Frame
 
         BrowsingContext.Log += (sender, args) =>
         {
-            if (Id != args.Source.Context)
+            if (Id != args.Source.BrowsingContextId)
             {
                 return;
             }

--- a/lib/PuppeteerSharp/Bidi/BidiMouse.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiMouse.cs
@@ -123,8 +123,8 @@ internal class BidiMouse(BidiPage page) : Mouse
         {
             _wheelSource.Actions.Add(new WheelScrollAction
             {
-                X = (ulong)_lastMovePoint.X,
-                Y = (ulong)_lastMovePoint.Y,
+                X = (long)_lastMovePoint.X,
+                Y = (long)_lastMovePoint.Y,
                 DeltaX = (long)deltaX,
                 DeltaY = (long)deltaY,
             });
@@ -184,7 +184,7 @@ internal class BidiMouse(BidiPage page) : Mouse
         }
     }
 
-    private long GetBidiButton(MouseButton optionsButton)
+    private ulong GetBidiButton(MouseButton optionsButton)
     {
         return optionsButton switch
         {

--- a/lib/PuppeteerSharp/Bidi/BidiPage.cs
+++ b/lib/PuppeteerSharp/Bidi/BidiPage.cs
@@ -38,6 +38,7 @@ using PuppeteerSharp.Media;
 using WebDriverBiDi.BrowsingContext;
 using WebDriverBiDi.Input;
 using WebDriverBiDi.Network;
+using WebDriverBiDi.Protocol;
 using WebDriverBiDi.Script;
 
 namespace PuppeteerSharp.Bidi;
@@ -215,8 +216,8 @@ public class BidiPage : Page
             var commandParameters = new WebDriverBiDi.Emulation.SetTimeZoneOverrideCommandParameters()
             {
                 TimeZone = timezoneId,
-                Contexts = [BidiMainFrame.BrowsingContext.Id],
             };
+            commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
             await BidiMainFrame.BrowsingContext.Session.Driver.Emulation.SetTimeZoneOverrideAsync(commandParameters).ConfigureAwait(false);
         }
@@ -246,8 +247,8 @@ public class BidiPage : Page
         var commandParameters = new WebDriverBiDi.Emulation.SetLocaleOverrideCommandParameters()
         {
             Locale = locale,
-            Contexts = [BidiMainFrame.BrowsingContext.Id],
         };
+        commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
         await BidiMainFrame.BrowsingContext.Session.Driver.Emulation.SetLocaleOverrideAsync(commandParameters).ConfigureAwait(false);
     }
@@ -309,7 +310,7 @@ public class BidiPage : Page
                 return;
             }
 
-            var element = CreateElementHandleFromSharedReference(e.Element);
+            var element = CreateElementHandleFromSharedReference(e.Element.ToSharedReference());
             var chooser = new FileChooser(element, e.IsMultiple);
             fileChooserTcs.TrySetResult(chooser);
         }
@@ -378,8 +379,8 @@ public class BidiPage : Page
         var commandParameters = new WebDriverBiDi.Emulation.SetGeolocationOverrideCoordinatesCommandParameters
         {
             Coordinates = coordinates,
-            Contexts = [BidiMainFrame.BrowsingContext.Id],
         };
+        commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
         await BidiMainFrame.BrowsingContext.Session.Driver.Emulation.SetGeolocationOverrideAsync(commandParameters).ConfigureAwait(false);
     }
@@ -390,8 +391,8 @@ public class BidiPage : Page
         var commandParameters = new WebDriverBiDi.Emulation.SetScriptingEnabledCommandParameters
         {
             IsScriptingEnabled = enabled,
-            Contexts = [BidiMainFrame.BrowsingContext.Id],
         };
+        commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
         await BidiMainFrame.BrowsingContext.Session.Driver.Emulation.SetScriptingEnabledAsync(commandParameters).ConfigureAwait(false);
         _isJavaScriptEnabled = enabled;
@@ -409,10 +410,8 @@ public class BidiPage : Page
     /// <inheritdoc />
     public override async Task SetCacheEnabledAsync(bool enabled = true)
     {
-        var commandParameters = new SetCacheBehaviorCommandParameters(enabled ? CacheBehavior.Default : CacheBehavior.Bypass)
-        {
-            Contexts = [BidiMainFrame.BrowsingContext.Id],
-        };
+        var commandParameters = new SetCacheBehaviorCommandParameters(enabled ? CacheBehavior.Default : CacheBehavior.Bypass);
+        commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
         await BidiMainFrame.BrowsingContext.Session.Driver.Network.SetCacheBehaviorAsync(commandParameters).ConfigureAwait(false);
     }
@@ -646,10 +645,8 @@ public class BidiPage : Page
     public override async Task<NewDocumentScriptEvaluation> EvaluateFunctionOnNewDocumentAsync(string pageFunction, params object[] args)
     {
         var expression = EvaluationExpression(pageFunction, args);
-        var commandParameters = new WebDriverBiDi.Script.AddPreloadScriptCommandParameters(expression)
-        {
-            Contexts = [BidiMainFrame.BrowsingContext.Id],
-        };
+        var commandParameters = new WebDriverBiDi.Script.AddPreloadScriptCommandParameters(expression);
+        commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
         var result = await BidiMainFrame.BrowsingContext.Session.Driver.Script.AddPreloadScriptAsync(commandParameters).ConfigureAwait(false);
         return new NewDocumentScriptEvaluation(result.PreloadScriptId);
@@ -682,10 +679,8 @@ public class BidiPage : Page
     {
         // Wrap the expression in a function so it can be used as a preload script
         var functionExpression = $"() => {{{expression}}}";
-        var commandParameters = new WebDriverBiDi.Script.AddPreloadScriptCommandParameters(functionExpression)
-        {
-            Contexts = [BidiMainFrame.BrowsingContext.Id],
-        };
+        var commandParameters = new WebDriverBiDi.Script.AddPreloadScriptCommandParameters(functionExpression);
+        commandParameters.Contexts.Add(BidiMainFrame.BrowsingContext.Id);
 
         var result = await BidiMainFrame.BrowsingContext.Session.Driver.Script.AddPreloadScriptAsync(commandParameters).ConfigureAwait(false);
         return new NewDocumentScriptEvaluation(result.PreloadScriptId);
@@ -906,7 +901,7 @@ public class BidiPage : Page
 
         if (remoteValue is WindowProxyRemoteValue windowProxyRemoteValue)
         {
-            var frame = Frames.OfType<BidiFrame>().FirstOrDefault(f => f.Id == windowProxyRemoteValue.Value.Context);
+            var frame = Frames.OfType<BidiFrame>().FirstOrDefault(f => f.Id == windowProxyRemoteValue.Value.BrowsingContextId);
             if (frame != null)
             {
                 return frame;
@@ -965,7 +960,7 @@ public class BidiPage : Page
                 .WithTimeout(timeout).ConfigureAwait(false);
         }
 
-        var pageRanges = new List<object>();
+        var pageRanges = new List<PageRange>();
         if (!string.IsNullOrEmpty(options.PageRanges))
         {
             foreach (var range in options.PageRanges.Split(','))
@@ -1233,7 +1228,7 @@ public class BidiPage : Page
     {
         if (expected && interception == null)
         {
-            var options = new AddInterceptCommandParameters(phases);
+            var options = new AddInterceptCommandParameters(phases[0]);
 
             return await BidiMainFrame.BrowsingContext.AddInterceptAsync(options).ConfigureAwait(false);
         }

--- a/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/BrowsingContext.cs
@@ -247,8 +247,7 @@ internal class BrowsingContext : IDisposable
 
     internal async Task<string> AddInterceptAsync(WebDriverBiDi.Network.AddInterceptCommandParameters options)
     {
-        options.BrowsingContextIds ??= new List<string>();
-        options.BrowsingContextIds.Add(Id);
+        options.Contexts.Add(Id);
         var result = await Session.Driver.Network.AddInterceptAsync(options).ConfigureAwait(false);
         return result.InterceptId;
     }
@@ -267,8 +266,8 @@ internal class BrowsingContext : IDisposable
         var parameters = new SetUserAgentOverrideCommandParameters
         {
             UserAgent = userAgent,
-            Contexts = [Id],
         };
+        parameters.Contexts.Add(Id);
         await Session.Driver.Emulation.SetUserAgentOverrideAsync(parameters).ConfigureAwait(false);
     }
 
@@ -277,8 +276,8 @@ internal class BrowsingContext : IDisposable
         var parameters = new SetNetworkConditionsCommandParameters
         {
             NetworkConditions = enabled ? new NetworkConditionsOffline() : null,
-            Contexts = [Id],
         };
+        parameters.Contexts.Add(Id);
         await Session.Driver.Emulation.SetNetworkConditionsAsync(parameters).ConfigureAwait(false);
     }
 
@@ -287,8 +286,8 @@ internal class BrowsingContext : IDisposable
         var parameters = new SetScreenOrientationOverrideCommandParameters
         {
             ScreenOrientation = screenOrientation,
-            Contexts = [Id],
         };
+        parameters.Contexts.Add(Id);
         await Session.Driver.Emulation.SetScreenOrientationOverrideAsync(parameters).ConfigureAwait(false);
     }
 
@@ -445,7 +444,7 @@ internal class BrowsingContext : IDisposable
 
         Session.LogEntryAdded += (_, args) =>
         {
-            if (args.Source.Context != Id)
+            if (args.Source.BrowsingContextId != Id)
             {
                 return;
             }

--- a/lib/PuppeteerSharp/Bidi/Core/Request.cs
+++ b/lib/PuppeteerSharp/Bidi/Core/Request.cs
@@ -187,10 +187,7 @@ internal class Request : IDisposable
 
     private async Task<string> FetchPostDataInternalAsync()
     {
-        var commandParams = new GetDataCommandParameters(Id)
-        {
-            DataType = DataType.Request,
-        };
+        var commandParams = new GetDataCommandParameters(Id, DataType.Request);
 
         var result = await Session.Driver.Network.GetDataAsync(commandParams).ConfigureAwait(false);
 
@@ -207,10 +204,7 @@ internal class Request : IDisposable
     {
         try
         {
-            var commandParams = new GetDataCommandParameters(Id)
-            {
-                DataType = DataType.Response,
-            };
+            var commandParams = new GetDataCommandParameters(Id, DataType.Response);
 
             var result = await Session.Driver.Network.GetDataAsync(commandParams).ConfigureAwait(false);
             return result.Bytes.ValueAsByteArray;

--- a/lib/PuppeteerSharp/Bidi/ExposableFunction.cs
+++ b/lib/PuppeteerSharp/Bidi/ExposableFunction.cs
@@ -164,11 +164,9 @@ internal class ExposableFunction : IAsyncDisposable
         // contexts for addPreloadScript (BiDi requires top-level contexts).
         if (!_isolate)
         {
-            var addPreloadParams = new AddPreloadScriptCommandParameters(functionDeclaration)
-            {
-                Arguments = [channelValue],
-                Contexts = [_frame.BrowsingContext.Id],
-            };
+            var addPreloadParams = new AddPreloadScriptCommandParameters(functionDeclaration);
+            addPreloadParams.Arguments.Add(channelValue);
+            addPreloadParams.Contexts.Add(_frame.BrowsingContext.Id);
 
             var scriptResult = await Connection.Script.AddPreloadScriptAsync(addPreloadParams).ConfigureAwait(false);
             _scripts.Add((_frame, scriptResult.PreloadScriptId));
@@ -402,7 +400,7 @@ internal class ExposableFunction : IAsyncDisposable
 
     private BidiRealm GetRealm(Source source)
     {
-        var frame = FindFrame(source.Context);
+        var frame = FindFrame(source.BrowsingContextId);
         if (frame == null)
         {
             return null;

--- a/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
+++ b/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
@@ -68,7 +68,6 @@ internal class PuppeteerConnection : BidiConnection
     /// <inheritdoc/>
     protected override Task StopConnectionAsync(CancellationToken cancellationToken = default)
     {
-        // Signal any in-flight send to stop before the transport goes away.
         _transport.MessageReceived -= OnTransportMessageReceived;
         _transport.Closed -= OnTransportClosed;
         _transport.StopReading();

--- a/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
+++ b/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
@@ -61,8 +61,10 @@ internal class PuppeteerConnection : BidiConnection
     /// <inheritdoc/>
     public override Task StartAsync(string connectionString, CancellationToken cancellationToken = default)
     {
-        // The transport is already connected (it was created by the TransportFactory)
-        // We just need to mark ourselves as active and set the connection string
+        // The transport is already connected (it was created by the TransportFactory), so there is
+        // nothing to open here. StopAsync cancels the connection source unconditionally, so reset it
+        // first; otherwise a reused connection would start with cancellation already requested.
+        ResetConnectionCancellation();
         ConnectionString = connectionString;
         _isActive = true;
         return Task.CompletedTask;
@@ -71,6 +73,8 @@ internal class PuppeteerConnection : BidiConnection
     /// <inheritdoc/>
     public override Task StopAsync(CancellationToken cancellationToken = default)
     {
+        // Signal any in-flight send to stop before the transport goes away.
+        CancelConnection();
         _transport.MessageReceived -= OnTransportMessageReceived;
         _transport.Closed -= OnTransportClosed;
         _transport.StopReading();
@@ -81,12 +85,13 @@ internal class PuppeteerConnection : BidiConnection
     }
 
     /// <inheritdoc/>
-    public override Task SendDataAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
+    protected override Task SendConnectionDataAsync(ReadOnlyMemory<byte> messageBuffer, CancellationToken cancellationToken = default)
     {
-        return _transport.SendAsync(data.ToArray());
+        // IConnectionTransport.SendAsync takes a byte[], so the buffer has to be copied. The base
+        // SendDataAsync has already checked that the connection is active, raised the trace log
+        // message, and taken the send semaphore that makes this call atomic.
+        return _transport.SendAsync(messageBuffer.ToArray());
     }
-
-    protected override Task SendConnectionDataAsync(ReadOnlyMemory<byte> messageBuffer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     /// <inheritdoc/>
     protected override Task ReceiveDataAsync()
@@ -111,7 +116,12 @@ internal class PuppeteerConnection : BidiConnection
     {
         try
         {
-            var owner = MemoryPool<byte>.Shared.Rent(e.Message.Length);
+            // TakeOwnershipOfReceivedData copies the data for the message into a pool-based memory
+            // block. Ownership of that block transfers to the event args: the consumer wraps it in an
+            // IncomingMessage that is queued and parsed after this call returns, and that message
+            // returns the block to the pool when it is disposed. Disposing it here would return the
+            // block while the message still refers to it, so it is deliberately not disposed.
+            var owner = TakeOwnershipOfReceivedData(e.Message, e.Message.Length);
             await InvocableConnectionDataReceivedObservableEvent.InvokeNotifyObserversAsync(new ConnectionDataReceivedEventArgs(owner, e.Message.Length)).ConfigureAwait(false);
         }
         catch

--- a/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
+++ b/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
@@ -59,27 +59,20 @@ internal class PuppeteerConnection : BidiConnection
     public override ConnectionKind ConnectionKind => ConnectionKind.WebSocket;
 
     /// <inheritdoc/>
-    public override Task StartAsync(string connectionString, CancellationToken cancellationToken = default)
+    protected override Task StartConnectionAsync(CancellationToken cancellationToken = default)
     {
-        // The transport is already connected (it was created by the TransportFactory), so there is
-        // nothing to open here. StopAsync cancels the connection source unconditionally, so reset it
-        // first; otherwise a reused connection would start with cancellation already requested.
-        ResetConnectionCancellation();
-        ConnectionString = connectionString;
         _isActive = true;
         return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
-    public override Task StopAsync(CancellationToken cancellationToken = default)
+    protected override Task StopConnectionAsync(CancellationToken cancellationToken = default)
     {
         // Signal any in-flight send to stop before the transport goes away.
-        CancelConnection();
         _transport.MessageReceived -= OnTransportMessageReceived;
         _transport.Closed -= OnTransportClosed;
         _transport.StopReading();
         _transport.Dispose();
-        ConnectionString = string.Empty;
         _isActive = false;
         return Task.CompletedTask;
     }
@@ -116,13 +109,9 @@ internal class PuppeteerConnection : BidiConnection
     {
         try
         {
-            // TakeOwnershipOfReceivedData copies the data for the message into a pool-based memory
-            // block. Ownership of that block transfers to the event args: the consumer wraps it in an
-            // IncomingMessage that is queued and parsed after this call returns, and that message
-            // returns the block to the pool when it is disposed. Disposing it here would return the
-            // block while the message still refers to it, so it is deliberately not disposed.
-            var owner = TakeOwnershipOfReceivedData(e.Message, e.Message.Length);
-            await InvocableConnectionDataReceivedObservableEvent.InvokeNotifyObserversAsync(new ConnectionDataReceivedEventArgs(owner, e.Message.Length)).ConfigureAwait(false);
+            using var messageBuffer = new MessageBuffer();
+            messageBuffer.Append(e.Message);
+            await this.NotifyDataReceivedObserverAsync(messageBuffer).ConfigureAwait(false);
         }
         catch
         {

--- a/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
+++ b/lib/PuppeteerSharp/Bidi/PuppeteerConnection.cs
@@ -23,6 +23,7 @@
 #if !CDP_ONLY
 
 using System;
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using PuppeteerSharp.Transport;
@@ -55,7 +56,7 @@ internal class PuppeteerConnection : BidiConnection
     public override bool IsActive => _isActive;
 
     /// <inheritdoc/>
-    public override ConnectionType ConnectionType => ConnectionType.WebSocket;
+    public override ConnectionKind ConnectionKind => ConnectionKind.WebSocket;
 
     /// <inheritdoc/>
     public override Task StartAsync(string connectionString, CancellationToken cancellationToken = default)
@@ -80,10 +81,12 @@ internal class PuppeteerConnection : BidiConnection
     }
 
     /// <inheritdoc/>
-    public override Task SendDataAsync(byte[] data, CancellationToken cancellationToken = default)
+    public override Task SendDataAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
     {
-        return _transport.SendAsync(data);
+        return _transport.SendAsync(data.ToArray());
     }
+
+    protected override Task SendConnectionDataAsync(ReadOnlyMemory<byte> messageBuffer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     /// <inheritdoc/>
     protected override Task ReceiveDataAsync()
@@ -108,7 +111,8 @@ internal class PuppeteerConnection : BidiConnection
     {
         try
         {
-            await InvocableConnectionDataReceivedObservableEvent.InvokeNotifyObserversAsync(new ConnectionDataReceivedEventArgs(e.Message)).ConfigureAwait(false);
+            var owner = MemoryPool<byte>.Shared.Rent(e.Message.Length);
+            await InvocableConnectionDataReceivedObservableEvent.InvokeNotifyObserversAsync(new ConnectionDataReceivedEventArgs(owner, e.Message.Length)).ConfigureAwait(false);
         }
         catch
         {

--- a/lib/PuppeteerSharp/Bidi/WindowRealm.cs
+++ b/lib/PuppeteerSharp/Bidi/WindowRealm.cs
@@ -95,7 +95,7 @@ internal class WindowRealm(BrowsingContext browsingContext, string sandbox = nul
     private void OnDedicatedRealmCreated(RealmCreatedEventArgs args)
     {
         if (args.Type != RealmType.Window ||
-            args.As<WindowRealmInfo>().BrowsingContext != Context.Id ||
+            args.As<WindowRealmInfo>().BrowsingContextId != Context.Id ||
             args.As<WindowRealmInfo>().Sandbox != _sandbox)
         {
             return;

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -47,12 +47,12 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="ReactiveExtensionsSharp" Version="0.3.0" />
-    <PackageReference Include="WebDriverBiDi" Version="0.0.54" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
+    <PackageReference Include="WebDriverBiDi" Version="0.0.59" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
-    <PackageReference Include="System.Threading.Channels" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageReference Include="System.Text.Json" Version="10.0.11" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -47,7 +47,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="ReactiveExtensionsSharp" Version="0.3.0" />
-    <PackageReference Include="WebDriverBiDi" Version="0.0.59" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
+    <PackageReference Include="WebDriverBiDi" Version="0.0.60" Condition=" !$(DefineConstants.Contains('CDP_ONLY')) " />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />


### PR DESCRIPTION
The latest WebDriverBiDi library has some minor, mostly cosmetic changes to its API (allowed under SemVer, because major version is `0`). This PR updates the dependency, and changes the source to match the current API of the WebDriverBiDi library.